### PR TITLE
feat: allow on request/response callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,22 +418,20 @@ the the acknowledgments 😊.
 [opencode]: https://github.com/sst/opencode
 [cursor-agent]: https://github.com/blowmage/cursor-agent-acp-npm
 
-### Callbacks
+### Event Hooks
 
-Agentic.nvim provides callbacks that let you hook into key events during the
+Agentic.nvim provides hooks that let you respond to key events during the
 chat lifecycle. These are useful for logging, notifications, analytics, or
 integrating with other plugins.
 
 ```lua
 {
-  callbacks = {
+  hooks = {
     -- Called when the user submits a prompt
     on_prompt_submit = function(data)
       -- data.prompt: string - The user's prompt text
       -- data.session_id: string - The ACP session ID
       -- data.tab_page_id: number - The Neovim tabpage ID
-      -- data.has_code_selection: boolean - Whether code was included
-      -- data.has_file_references: boolean - Whether files were referenced
       vim.notify("Prompt submitted: " .. data.prompt:sub(1, 50))
     end,
 

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -5,8 +5,6 @@
 --- @field prompt string The user's prompt text
 --- @field session_id string The ACP session ID
 --- @field tab_page_id number The tabpage ID
---- @field has_code_selection boolean Whether code was included in the prompt
---- @field has_file_references boolean Whether files were referenced in the prompt
 
 --- Data passed to the on_response_complete hook
 --- @class agentic.UserConfig.ResponseCompleteData

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -18,10 +18,14 @@ function P.invoke_hook(hook_name, data)
     local hook = Config.hooks and Config.hooks[hook_name]
 
     if hook and type(hook) == "function" then
-        local ok, err = pcall(hook, data)
-        if not ok then
-            Logger.debug(string.format("Hook '%s' error: %s", hook_name, err))
-        end
+        vim.schedule(function()
+            local ok, err = pcall(hook, data)
+            if not ok then
+                Logger.debug(
+                    string.format("Hook '%s' error: %s", hook_name, err)
+                )
+            end
+        end)
     end
 end
 
@@ -202,10 +206,6 @@ function SessionManager:_handle_input_submit(input_text)
         return
     end
 
-    -- Capture these before they get cleared during prompt building
-    local has_code_selection = not self.code_selection:is_empty()
-    local has_file_references = not self.file_list:is_empty()
-
     --- @type agentic.acp.Content[]
     local prompt = {}
 
@@ -331,8 +331,6 @@ function SessionManager:_handle_input_submit(input_text)
         prompt = input_text,
         session_id = self.session_id,
         tab_page_id = self.tab_page_id,
-        has_code_selection = has_code_selection,
-        has_file_references = has_file_references,
     })
 
     local session_id = self.session_id


### PR DESCRIPTION
Another feature I'm missing that might also be interesting for others is to have callbacks when things happen. 

This does allow me for example to save a history of commands I sent and get a notification when the agent is finished with a task.

This PR implements this in a simple way allowing function callbacks.

Let me know what you think.