### PR TITLE
feat: add focus_prompt option to allow disabling auto focus the sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,23 @@ see available modes for your provider.
 | `:lua require("agentic").new_session()`                      | Start new chat session, destroying and cleaning the current one  |
 | `:lua require("agentic").stop_generation()`                  | Stop current generation or tool execution (session stays active) |
 
+### Optional Parameters
+
+Content-adding methods accept an optional `opts` table:
+
+- **`focus_prompt`** (boolean, default: `true`) - Whether to move cursor to
+  prompt input after opening the chat
+
+Available on: `add_selection(opts)`, `add_file(opts)`,
+`add_selection_or_file_to_context(opts)`
+
+**Example:**
+
+```lua
+-- Add selection without focusing the prompt
+require("agentic").add_selection({ focus_prompt = false })
+```
+
 ### Built-in Keybindings
 
 These keybindings are automatically set in Agentic buffers:

--- a/lua/agentic/init.lua
+++ b/lua/agentic/init.lua
@@ -50,26 +50,29 @@ function Agentic.toggle()
 end
 
 --- Add the current visual selection to the Chat context
-function Agentic.add_selection()
+--- @param opts? agentic.ui.ChatWidget.ShowOpts Options for adding selection
+function Agentic.add_selection(opts)
     SessionRegistry.get_session_for_tab_page(nil, function(session)
         session:add_selection_to_session()
-        session.widget:show()
+        session.widget:show(opts)
     end)
 end
 
 --- Add the current file to the Chat context
-function Agentic.add_file()
+--- @param opts? agentic.ui.ChatWidget.ShowOpts Options for adding file
+function Agentic.add_file(opts)
     SessionRegistry.get_session_for_tab_page(nil, function(session)
         session:add_file_to_session()
-        session.widget:show()
+        session.widget:show(opts)
     end)
 end
 
 --- Add either the current visual selection or the current file to the Chat context
-function Agentic.add_selection_or_file_to_context()
+--- @param opts? agentic.ui.ChatWidget.ShowOpts Options for adding content
+function Agentic.add_selection_or_file_to_context(opts)
     SessionRegistry.get_session_for_tab_page(nil, function(session)
         session:add_selection_or_file_to_session()
-        session.widget:show()
+        session.widget:show(opts)
     end)
 end
 

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -12,6 +12,9 @@ local WindowDecoration = require("agentic.ui.window_decoration")
 ---   suffix?: string,
 ---   persistent?: string|nil }>
 
+--- Options for controlling widget display behavior
+--- @alias agentic.ui.ChatWidget.ShowOpts { focus_prompt?: boolean }
+
 --- @type agentic.ui.ChatWidget.Headers
 local WINDOW_HEADERS = {
     chat = {
@@ -62,7 +65,12 @@ function ChatWidget:is_open()
     return win_id and vim.api.nvim_win_is_valid(win_id)
 end
 
-function ChatWidget:show()
+--- @param opts? agentic.ui.ChatWidget.ShowOpts Options for showing the widget
+function ChatWidget:show(opts)
+    local options = opts or {}
+    local should_focus = options.focus_prompt == nil and true
+        or options.focus_prompt
+
     if
         not self.win_nrs.chat
         or not vim.api.nvim_win_is_valid(self.win_nrs.chat)
@@ -122,10 +130,12 @@ function ChatWidget:show()
         self:render_header("files")
     end
 
-    self:move_cursor_to(
-        self.win_nrs.input,
-        BufHelpers.start_insert_on_last_char
-    )
+    if should_focus then
+        self:move_cursor_to(
+            self.win_nrs.input,
+            BufHelpers.start_insert_on_last_char
+        )
+    end
 end
 
 --- Closes all windows but keeps buffers in memory


### PR DESCRIPTION
Add optional `focus_prompt` parameter to `add_selection()`, `add_file()`, 
and `add_selection_or_file_to_context()` methods, allowing users to add multiple items to the chat context without automatically focusing the prompt input after each addition.

closes #41 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lua API methods for adding content now support optional parameters, enabling users to control whether the cursor automatically focuses on the prompt input field after opening the chat interface

* **Documentation**
  * Added comprehensive Optional Parameters section to the API documentation, detailing all affected methods, configuration options, and providing clear usage examples

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->