### PR TITLE
fix: prevent execution halt from newlines in permission request display

### DIFF
--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -487,14 +487,19 @@ function MessageWriter:display_permission_buttons(tool_call_id, options)
         local sanitized_argument = tracker.argument:gsub("\n", "\\n")
 
         -- Get buffer width and limit the display line
-        local buf_width =
-            vim.api.nvim_win_get_width(vim.fn.bufwinid(self.bufnr))
+        local winid = vim.fn.bufwinid(self.bufnr)
+
+        local buf_width = 80 -- default fallback width, in case buf is not visible
+        if winid ~= -1 then
+            buf_width = vim.api.nvim_win_get_width(winid)
+        end
+
         local tool_line =
             string.format(" %s(%s)", tracker.kind, sanitized_argument)
 
-        -- Truncate if longer than buffer width, leaving space for "..."
+        -- Truncate if longer than buffer width, leaving space for "...)"
         if #tool_line > buf_width then
-            tool_line = tool_line:sub(1, buf_width - 3) .. "..."
+            tool_line = tool_line:sub(1, buf_width - 4) .. "...)"
         end
 
         vim.list_extend(lines_to_append, {


### PR DESCRIPTION
- Sanitise newlines in tool call arguments before displaying in permission requests
- Add width limiting to truncate long tool call displays with "..." suffix
- Wrap nvim_buf_set_text and nvim_buf_set_lines in pcall to prevent crashes

Fixes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added defensive error handling and logging for UI buffer updates to improve stability and prevent failures when updating displayed text; preserves auto-scroll behavior on update failures.
  * Improved permission button display by sanitizing newlines, measuring available width, and truncating long text with an ellipsis to avoid overflow and preserve layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->