### PR TITLE
fix: resume animation after permission approval (#16)

### DIFF
--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -416,13 +416,13 @@ function SessionManager:new_session()
                 self.permission_manager:remove_request_by_tool_call_id(
                     tool_call_update.tool_call_id
                 )
+            end
 
-                if
-                    not self.permission_manager.current_request
-                    and #self.permission_manager.queue == 0
-                then
-                    self.status_animation:start("generating")
-                end
+            if
+                not self.permission_manager.current_request
+                and #self.permission_manager.queue == 0
+            then
+                self.status_animation:start("generating")
             end
         end,
 
@@ -440,8 +440,6 @@ function SessionManager:new_session()
                 end
             end
 
-            -- FIXIT: I might have to generate a tool call block
-            -- Codex ask for permission before sending the `edit` tool call
             self.permission_manager:add_request(request, wrapped_callback)
         end,
     }

--- a/lua/agentic/ui/file_list.lua
+++ b/lua/agentic/ui/file_list.lua
@@ -74,7 +74,6 @@ function FileList:_render()
     local lines = {}
 
     for _, file in ipairs(self._files) do
-        -- FIXIT: ADD Icon to the file list
         table.insert(lines, "-   " .. FileSystem.to_smart_path(file))
     end
 


### PR DESCRIPTION
## Summary
Fixes #16 - Animation indicator disappearing after permission approval

## Changes
- Move animation restart logic outside the failed tool call condition in `on_tool_call_update` handler
- Ensure animation resumes after any permission approval when no requests are pending
- Remove obsolete FIXIT comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control flow logic in session management to properly handle conditional blocks and prevent incorrect code execution sequencing.
  * Improved code structure clarity by correcting nesting and logical flow in request queue handling.
  * Removed unnecessary internal comments for code cleanliness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->