### PR TITLE
feat: allow to `:write` the prompt

### DIFF
--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -460,6 +460,14 @@ function ChatWidget:_create_buf_nrs()
         string.format("AgenticInput-%d", self.tab_page_id)
     )
 
+    vim.api.nvim_create_autocmd("QuitPre", {
+        buffer = input,
+        callback = function()
+            -- Prevent "unsaved changes" prompt when deleting/exiting input buffer
+            vim.bo.modified = false
+        end,
+    })
+
     vim.api.nvim_create_autocmd("BufWriteCmd", {
         buffer = input,
         callback = function()


### PR DESCRIPTION
fixes #68 

TODO:

- [x] autocmd cleanup? - I expect it should be auto cleaned up when the buffer is removed
- [x] any better buffer name than `AgenticInput`?
  - [x] decide on a way to have unique buffer names
  - [ ] ~~include agent mode?~~ This is rendered already
- [ ] test coverage