### PR TITLE
fix: prevent chat window from resizing horizontally

### DIFF
--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -92,6 +92,7 @@ function ChatWidget:show(opts)
             "chat",
             {
                 winfixheight = false,
+                winfixwidth = true,
                 scrolloff = 4, -- Keep 4 lines visible above/below cursor (keeps animation visible)
             }
         )


### PR DESCRIPTION
## Summary
- Add `winfixwidth = true` to the chat window options to prevent horizontal resizing when the Neovim window is resized

Closes #17