### PR TITLE
add client info into agentic for allow ACP whitelist

### DIFF
--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -390,6 +390,7 @@ function ACPClient:_connect()
 
     self:_send_request("initialize", {
         protocolVersion = self.protocol_version,
+        clientInfo = self.capabilities.clientInfo,
         clientCapabilities = self.capabilities,
     }, function(result, err)
         if not result or err then


### PR DESCRIPTION
## Summary
Add client identification (clientInfo) to the ACP (Agent Communication Protocol) initialize request to enable proper client whitelisting by ACP agents.

## Problem
When Agentic.nvim connects to ACP agents like auggie, the agent needs to identify and whitelist the connecting client. Currently, Agentic.nvim only sends `protocolVersion` and `clientCapabilities` during the ACP initialization handshake, but is missing the `clientInfo` field that contains the client's name and version.

This causes issues with ACP agents that require client identification for whitelisting purposes. For example, auggie logs show it expects a user-agent string:
```
'ACPSessionManager': Using session user-agent: augment.cli/0.15.0-prerelease.4 (commit 7a31a643)/acp
```

Without clientInfo, ACP agents cannot properly identify Agentic.nvim clients, potentially blocking or limiting functionality.

## Solution
This PR adds `clientInfo` support to the ACP client implementation with sensible defaults.

## Changes Made
- Updated `ACPClient:_connect()` to include `clientInfo` in the initialize request parameters
- The `clientInfo` field (already defined in capabilities) is now explicitly sent as a separate parameter
- Client identifies as:
  - **Name**: "Agentic.nvim"
  - **Version**: "0.0.1"

## ACP Initialize Request (Before)
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "initialize",
  "params": {
    "protocolVersion": 1,
    "clientCapabilities": {
      "fs": {
        "readTextFile": true,
        "writeTextFile": true
      },
      "terminal": false,
      "clientInfo": {
        "name": "Agentic.nvim",
        "version": "0.0.1"
      }
    }
  }
}
```

## ACP Initialize Request (After)
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "initialize",
  "params": {
    "protocolVersion": 1,
    "clientInfo": {
      "name": "Agentic.nvim",
      "version": "0.0.1"
    },
    "clientCapabilities": {
      "fs": {
        "readTextFile": true,
        "writeTextFile": true
      },
      "terminal": false,
      "clientInfo": {
        "name": "Agentic.nvim",
        "version": "0.0.1"
      }
    }
  }
}
```

## Testing
Tested with auggie ACP client to verify:
- ✅ `clientInfo` is properly sent in the initialize request
- ✅ ACP agents can identify and whitelist Agentic.nvim clients
- ✅ Default values work correctly

Use this config
```
  {
    dir = "/Users/justinxu/acp/agentic.nvim",
    opts = {
      provider = "claude-acp",
      acp_providers = {
        -- Override claude-acp to use auggie instead
        ["claude-acp"] = {
          name = "Auggie ACP",
          command = "auggie",
          args = {
            "--acp",
            "--log-file", "/tmp/agentic-acp-log.txt",
            "--permission", "*:allow",
          },
          env = {
            NODE_NO_WARNINGS = "1",
            IS_AI_TERMINAL = "1",
          },
        },
      },
    },
    keys = {
      {
        "<leader>ag",
        function() require("agentic").toggle() end,
        mode = { "n", "v", "i" },
        desc = "Toggle Agentic Chat"
      },
      {
        "<leader>as",
        function() require("agentic").add_selection_or_file_to_context() end,
        mode = { "n", "v" },
        desc = "Add file or selection to Agentic Context"
      },
      {
        "<leader>an",
        function() require("agentic").new_session() end,
        mode = { "n", "v", "i" },
        desc = "New Agentic Session"
      },
    },
  },
```

Before:
<img width="1368" height="591" alt="image" src="https://github.com/user-attachments/assets/f3d86ace-918d-4401-9a7f-812f136b3b20" />

After:
<img width="1372" height="634" alt="image" src="https://github.com/user-attachments/assets/c211fee4-d276-417e-88e1-53d12bb499e9" />


## Impact
This change enables Agentic.nvim to work properly with ACP agents that require client identification for whitelisting, such as auggie and other ACP-compliant agents. It follows the ACP protocol specification (similar to LSP) which requires clients to identify themselves during initialization.