### PR TITLE
fix: infinite loop with blink.cmp and make accept key configurable

### DIFF
--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -163,11 +163,18 @@ local ConfigDefault = {
 
             paste_image = {
                 {
-                    "<localleader>p",
+                    "<localLeader>p",
                     mode = { "n" },
                 },
                 {
                     "<C-v>", -- Same as Claude-code in insert mode
+                    mode = { "i" },
+                },
+            },
+
+            accept_completion = {
+                {
+                    "<Tab>",
                     mode = { "i" },
                 },
             },

--- a/lua/agentic/ui/file_picker.lua
+++ b/lua/agentic/ui/file_picker.lua
@@ -1,7 +1,7 @@
 local FileSystem = require("agentic.utils.file_system")
 local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
-local KeymapFallback = require("agentic.utils.keymap_fallback")
+local BufHelpers = require("agentic.utils.buf_helpers")
 
 --- @class agentic.ui.FilePicker
 --- @field _files table[]
@@ -60,42 +60,22 @@ function FilePicker:_setup_completion(bufnr)
     vim.bo[bufnr].iskeyword = vim.bo[bufnr].iskeyword .. ",@"
     instances_by_buffer[bufnr] = self
 
-    local prev_tab_map = KeymapFallback.get_existing_mapping("i", "<Tab>")
+    BufHelpers.multi_keymap_set(
+        Config.keymaps.prompt.accept_completion,
+        bufnr,
+        function()
+            if vim.fn.pumvisible() == 1 then
+                return COMPLETION_ACCEPT
+            end
 
-    vim.keymap.set("i", "<Tab>", function()
-        if vim.fn.pumvisible() == 1 then
-            return COMPLETION_ACCEPT
-        end
-
-        -- Always check for existing mapping to handle lazy-loaded plugins
-        -- the check is very fast and Tab isn't pressed frequently to cause noticeable lag
-        prev_tab_map = KeymapFallback.get_existing_mapping("i", "<Tab>")
-            or prev_tab_map
-        return KeymapFallback.execute_fallback(prev_tab_map, "<Tab>")
-    end, {
-        buffer = bufnr,
-        expr = true,
-        replace_keycodes = false, -- Needed to avoid double-escaping, as it's true by default when expr=true
-        desc = KeymapFallback.MARKER .. " Tab completion fallback",
-    })
-
-    local prev_cr_map = KeymapFallback.get_existing_mapping("i", "<CR>")
-
-    vim.keymap.set("i", "<CR>", function()
-        if vim.fn.pumvisible() == 1 then
-            return COMPLETION_ACCEPT
-        end
-
-        -- Always check for existing mapping to handle lazy-loaded plugins
-        prev_cr_map = KeymapFallback.get_existing_mapping("i", "<CR>")
-            or prev_cr_map
-        return KeymapFallback.execute_fallback(prev_cr_map, "<CR>")
-    end, {
-        buffer = bufnr,
-        expr = true,
-        replace_keycodes = false,
-        desc = KeymapFallback.MARKER .. " CR completion fallback",
-    })
+            return ""
+        end,
+        {
+            desc = "Agentic accept completion",
+            expr = true,
+            replace_keycodes = false,
+        }
+    )
 
     local last_at_pos = nil
 

--- a/lua/agentic/ui/file_picker.test.lua
+++ b/lua/agentic/ui/file_picker.test.lua
@@ -200,12 +200,6 @@ describe("FilePicker keymap fallback", function()
         child.lua([[require("agentic.ui.file_picker"):new(0)]])
     end
 
-    --- Execute insert mode key via normal command
-    --- @param key string
-    local function execute_insert_key(key)
-        child.cmd(([[silent execute "normal i\%s"]]):format(key))
-    end
-
     before_each(function()
         child.setup()
     end)
@@ -214,31 +208,7 @@ describe("FilePicker keymap fallback", function()
         child.stop()
     end)
 
-    it(
-        "should call fallback Tab mapping when completion menu not visible",
-        function()
-            local prop_name = "tab_called"
-            setup_tracking_keymap("<Tab>", prop_name)
-            load_file_picker()
-            execute_insert_key("<Tab>")
-
-            assert.is_true(child.g[prop_name])
-        end
-    )
-
-    it(
-        "should call fallback CR mapping when completion menu not visible",
-        function()
-            local prop_name = "cr_called"
-            setup_tracking_keymap("<CR>", prop_name)
-            load_file_picker()
-            execute_insert_key("<CR>")
-
-            assert.is_true(child.g[prop_name])
-        end
-    )
-
-    it("should NOT call fallback when completion menu is visible", function()
+    it("should accept completion when completion menu is visible", function()
         local prop_name = "tab_called"
         setup_tracking_keymap("<Tab>", prop_name)
         load_file_picker()
@@ -264,36 +234,4 @@ describe("FilePicker keymap fallback", function()
 
         assert.is_false(child.g[prop_name])
     end)
-
-    it("should call fallback for lazy-loaded global mapping", function()
-        local prop_name = "tab_called"
-        child.g[prop_name] = false
-        -- Initialize FilePicker BEFORE setting up any global mapping
-        -- This simulates a plugin that loads after Agentic
-        load_file_picker()
-
-        -- Now register a global Tab mapping (simulates lazy-loaded plugin)
-        setup_tracking_keymap("<Tab>", prop_name)
-        execute_insert_key("<Tab>")
-
-        assert.is_true(child.g[prop_name])
-    end)
-
-    it(
-        "should handle vimscript expr mappings with proper keycode conversion",
-        function()
-            child.cmd([[
-                function! TestVimscriptExpr()
-                    return "\t\t\<C-R>\<C-R>=123\<CR>\<CR>\<CR>"
-                endfunction
-                inoremap <expr> <Tab> TestVimscriptExpr()
-            ]])
-
-            load_file_picker()
-            execute_insert_key("<Tab>")
-
-            local lines = child.api.nvim_buf_get_lines(0, 0, -1, false)
-            assert.equal("\t\t123\n\n", table.concat(lines, "\n"))
-        end
-    )
 end)

--- a/lua/agentic/utils/buf_helpers.lua
+++ b/lua/agentic/utils/buf_helpers.lua
@@ -59,12 +59,41 @@ end
 --- @param bufnr integer
 --- @param mode string|string[]
 --- @param lhs string
---- @param rhs string|fun()
+--- @param rhs string|fun():any
 --- @param opts vim.keymap.set.Opts|nil
 function BufHelpers.keymap_set(bufnr, mode, lhs, rhs, opts)
     opts = opts or {}
     opts.buffer = bufnr
     vim.keymap.set(mode, lhs, rhs, opts)
+end
+
+--- Sets multiple keymaps from a KeymapValue config entry for a specific buffer.
+--- Normalizes the config value (string, string[], or array of string/KeymapEntry)
+--- and calls keymap_set for each binding.
+--- @param keymaps agentic.UserConfig.KeymapValue
+--- @param bufnr integer
+--- @param callback fun():any
+--- @param opts vim.keymap.set.Opts|nil
+function BufHelpers.multi_keymap_set(keymaps, bufnr, callback, opts)
+    if type(keymaps) == "string" then
+        keymaps = { keymaps }
+    end
+
+    for _, key in ipairs(keymaps) do
+        --- @type string|string[]
+        local modes = "n"
+        --- @type string
+        local keymap
+
+        if type(key) == "table" and key.mode then
+            modes = key.mode
+            keymap = key[1]
+        else
+            keymap = key --[[@as string]]
+        end
+
+        BufHelpers.keymap_set(bufnr, modes, keymap, callback, opts)
+    end
 end
 
 --- @param bufnr integer


### PR DESCRIPTION
- fix #106
- Both Agentic and Blink were trying to apply fallbacks for Tab and Enter, creating an infinite loop. 
- removed fallback from Agentic, as it's a buffer keymap, leave fallback for plugins that try to hijack buffers, like Blink.cmp
