### PR TITLE
feat(acp): add usage_update message type and handler

### DIFF
--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -760,6 +760,12 @@ return ACPClient
 --- @field sessionUpdate "current_mode_update"
 --- @field currentModeId string
 
+--- @class agentic.acp.UsageUpdate
+--- @field sessionUpdate "usage_update"
+--- @field used number Tokens currently in context
+--- @field size number Total context window size in tokens
+--- @field cost? { amount: number, currency: string } Cumulative session cost
+
 --- @alias agentic.acp.SessionUpdateMessage
 --- | agentic.acp.UserMessageChunk
 --- | agentic.acp.AgentMessageChunk
@@ -769,6 +775,7 @@ return ACPClient
 --- | agentic.acp.PlanUpdate
 --- | agentic.acp.AvailableCommandsUpdate
 --- | agentic.acp.CurrentModeUpdate
+--- | agentic.acp.UsageUpdate
 
 --- @class agentic.acp.PermissionOption
 --- @field optionId string

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -185,6 +185,10 @@ function SessionManager:_on_session_update(update)
         if self.agent_modes:update_mode(update.currentModeId) then
             self:_set_mode_to_chat_header(update.currentModeId)
         end
+    elseif update.sessionUpdate == "usage_update" then
+        -- Usage updates contain token/cost information - currently informational only
+        -- Fields: used (tokens), size (context window), cost (optional: amount, currency)
+        -- Keeping silent for now to avoid "press any key" prompts on large JSON output
     else
         -- TODO: Move this to Logger from notify to debug when confidence is high
         Logger.notify(


### PR DESCRIPTION
Add support for ACP usage_update session messages containing token usage and cost information.

While testing the plugin with `opencode-acp`, I noticed after every prompt there is an error getting logged.
<img width="2560" height="1039" alt="image" src="https://github.com/user-attachments/assets/b09aa59f-53c6-4d04-bde5-1736ca403b9d" />

This appears to be an issue with opencode returning a payload agentic's ACP client doesn't know how to handle.  The error encountered is 
```
Unknown session update type: usage_update
```

For now the handler is empty (debug log) but I could see this being actually useful to incorporate into the UI (tokens used, cost, etc. are all commonly shown to the user)

```
❯ opencode --version
1.1.53
```
