### PR TITLE
feat: Add diagnostics context support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,22 @@ tools like `nvm`, `fnm`, etc...
       silent = true,
       mode = { "n", "v", "i" },
     },
+    {
+      "<leader>ad", -- ai Diagnostics
+      function()
+          require("agentic").add_current_line_diagnostics()
+      end,
+      desc = "Add current line diagnostic to Agentic",
+      mode = { "n" },
+    },
+    {
+      "<leader>aD", -- ai all Diagnostics
+      function()
+          require("agentic").add_buffer_diagnostics()
+      end,
+      desc = "Add all buffer diagnostics to Agentic",
+      mode = { "n" },
+    },
   },
 }
 ```
@@ -372,6 +388,8 @@ header parts:
 | `:lua require("agentic").add_selection()`                    | Add visual selection to context                                   |
 | `:lua require("agentic").add_file()`                         | Add current file to context                                       |
 | `:lua require("agentic").add_selection_or_file_to_context()` | Add selection (if any) or file to the context                     |
+| `:lua require("agentic").add_current_line_diagnostics()`     | Add diagnostics at cursor line to context                         |
+| `:lua require("agentic").add_buffer_diagnostics()`           | Add all diagnostics from current buffer to context                |
 | `:lua require("agentic").new_session()`                      | Start new chat session, destroying and cleaning the current one   |
 | `:lua require("agentic").stop_generation()`                  | Stop current generation or tool execution (session stays active)  |
 | `:lua require("agentic").restore_session()`                  | Show session picker to restore a previous session and continue    |
@@ -397,7 +415,8 @@ focus the prompt input after opening the chat:
   input after opening the chat
 
 Available on: `add_selection(opts)`, `add_file(opts)`,
-`add_selection_or_file_to_context(opts)`
+`add_selection_or_file_to_context(opts)`, `add_current_line_diagnostics(opts)`,
+`add_buffer_diagnostics(opts)`
 
 ```lua
 -- Add selection without focusing the prompt
@@ -408,19 +427,19 @@ require("agentic").add_selection({ focus_prompt = false })
 
 These keybindings are automatically set in Agentic buffers:
 
-| Keybinding       | Mode  | Description                                                   |
-| ---------------- | ----- | ------------------------------------------------------------- |
-| `<S-Tab>`        | n/v/i | Switch agent mode (only available if provider supports modes) |
-| `<CR>`           | n     | Submit prompt                                                 |
-| `<C-s>`          | n/v/i | Submit prompt                                                 |
-| `<localLeader>p` | n     | Paste image from clipboard in the Prompt buffer               |
-| `<C-v>`          | i     | Paste image from clipboard (same as Claude-code)              |
-| `<localLeader>s` | n     | Switch ACP provider (preserves chat history)                  |
-| `q`              | n     | Close chat widget                                             |
-| `d`              | n     | Remove file or code selection at cursor                       |
-| `d`              | v     | Remove multiple selected files or code selections             |
-| `]c`             | n     | Navigate to next diff hunk (when diff preview is active)      |
-| `[c`             | n     | Navigate to previous diff hunk (when diff preview is active)  |
+| Keybinding       | Mode  | Description                                                     |
+| ---------------- | ----- | --------------------------------------------------------------- |
+| `<S-Tab>`        | n/v/i | Switch agent mode (only available if provider supports modes)   |
+| `<CR>`           | n     | Submit prompt                                                   |
+| `<C-s>`          | n/v/i | Submit prompt                                                   |
+| `<localLeader>p` | n     | Paste image from clipboard in the Prompt buffer                 |
+| `<C-v>`          | i     | Paste image from clipboard (same as Claude-code)                |
+| `<localLeader>s` | n     | Switch ACP provider (preserves chat history)                    |
+| `q`              | n     | Close chat widget                                               |
+| `d`              | n     | Remove file, code selection, or diagnostic at cursor            |
+| `d`              | v     | Remove multiple selected files, code selections, or diagnostics |
+| `]c`             | n     | Navigate to next diff hunk (when diff preview is active)        |
+| `[c`             | n     | Navigate to previous diff hunk (when diff preview is active)    |
 
 #### Customizing Keybindings
 
@@ -705,6 +724,24 @@ colorscheme.
 If any of these highlight exists, Agentic will use it instead of creating new
 ones.
 
+### Customizing Diagnostic Icons
+
+You can customize the icons used for diagnostics in the context panel:
+
+```lua
+require("agentic").setup({
+    diagnostic_icons = {
+        error = "❌",
+        warn = "⚠️",
+        info = "ℹ️",
+        hint = "✨",
+    },
+})
+```
+
+Default icons use emoji characters (❌, ⚠️, ℹ️, ✨) but you can use any string,
+including Nerd Font icons or plain text.
+
 ## Integration with other Plugins
 
 ### Prompt suggestions with Copilot
@@ -761,8 +798,8 @@ conflicts with custom window decorations:
 require('lualine').setup({
   options = {
     disabled_filetypes = {
-      statusline = { 'AgenticChat', 'AgenticInput', 'AgenticCode', 'AgenticFiles' },
-      winbar = { 'AgenticChat', 'AgenticInput', 'AgenticCode', 'AgenticFiles' },
+      statusline = { 'AgenticChat', 'AgenticInput', 'AgenticCode', 'AgenticFiles', 'AgenticDiagnostics' },
+      winbar = { 'AgenticChat', 'AgenticInput', 'AgenticCode', 'AgenticFiles', 'AgenticDiagnostics' },
     }
   }
 })

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -125,6 +125,10 @@ local ConfigDefault = {
     --- @field max_height number
     --- @field win_opts? agentic.UserConfig.WinOpts
 
+    --- @class agentic.UserConfig.Windows.Diagnostics
+    --- @field max_height number
+    --- @field win_opts? agentic.UserConfig.WinOpts
+
     --- @class agentic.UserConfig.Windows.Todos
     --- @field display boolean
     --- @field max_height number
@@ -141,6 +145,7 @@ local ConfigDefault = {
     --- @field input agentic.UserConfig.Windows.Input
     --- @field code agentic.UserConfig.Windows.Code
     --- @field files agentic.UserConfig.Windows.Files
+    --- @field diagnostics agentic.UserConfig.Windows.Diagnostics
     --- @field todos agentic.UserConfig.Windows.Todos
     windows = {
         position = "right",
@@ -151,6 +156,7 @@ local ConfigDefault = {
         input = { height = 10, win_opts = {} },
         code = { max_height = 15, win_opts = {} },
         files = { max_height = 10, win_opts = {} },
+        diagnostics = { max_height = 10, win_opts = {} },
         todos = { display = true, max_height = 10, win_opts = {} },
     },
 
@@ -224,6 +230,19 @@ local ConfigDefault = {
         pending = "󰔛",
         completed = "✔",
         failed = "",
+    },
+
+    --- Icons used for diagnostics in the context panel
+    --- @class agentic.UserConfig.DiagnosticIcons
+    --- @field error string Icon for error severity
+    --- @field warn string Icon for warning severity
+    --- @field info string Icon for info severity
+    --- @field hint string Icon for hint severity
+    diagnostic_icons = {
+        error = "❌",
+        warn = "⚠️",
+        info = "ℹ️",
+        hint = "✨",
     },
 
     --- @class agentic.UserConfig.PermissionIcons

--- a/lua/agentic/init.lua
+++ b/lua/agentic/init.lua
@@ -85,6 +85,38 @@ end
 --- @class agentic.ui.NewSessionOpts : agentic.ui.ChatWidget.ShowOpts
 --- @field provider? agentic.UserConfig.ProviderName
 
+--- Add diagnostics at the current cursor line to the Chat context
+--- @param opts agentic.ui.ChatWidget.AddToContextOpts|nil
+function Agentic.add_current_line_diagnostics(opts)
+    SessionRegistry.get_session_for_tab_page(nil, function(session)
+        local count = session:add_current_line_diagnostics_to_context()
+        if count > 0 then
+            session.widget:show(opts)
+        else
+            Logger.notify(
+                "No diagnostics found on the current line",
+                vim.log.levels.INFO
+            )
+        end
+    end)
+end
+
+--- Add all diagnostics from the current buffer to the Chat context
+--- @param opts agentic.ui.ChatWidget.AddToContextOpts|nil
+function Agentic.add_buffer_diagnostics(opts)
+    SessionRegistry.get_session_for_tab_page(nil, function(session)
+        local count = session:add_buffer_diagnostics_to_context()
+        if count > 0 then
+            session.widget:show(opts)
+        else
+            Logger.notify(
+                "No diagnostics found in the current buffer",
+                vim.log.levels.INFO
+            )
+        end
+    end)
+end
+
 --- Destroys the current Chat session and starts a new one
 --- @param opts agentic.ui.NewSessionOpts|nil
 function Agentic.new_session(opts)

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -7,12 +7,15 @@
 local ACPPayloads = require("agentic.acp.acp_payloads")
 local ChatHistory = require("agentic.ui.chat_history")
 local Config = require("agentic.config")
+local DiagnosticsContext = require("agentic.ui.diagnostics_context")
 local DiffPreview = require("agentic.ui.diff_preview")
+local DiagnosticsList = require("agentic.ui.diagnostics_list")
 local FileSystem = require("agentic.utils.file_system")
 local Logger = require("agentic.utils.logger")
 local SessionRestore = require("agentic.session_restore")
 local SlashCommands = require("agentic.acp.slash_commands")
 local TodoList = require("agentic.ui.todo_list")
+local WidgetLayout = require("agentic.ui.widget_layout")
 
 --- @class agentic._SessionManagerPrivate
 local P = {}
@@ -47,6 +50,7 @@ end
 --- @field status_animation agentic.ui.StatusAnimation
 --- @field file_list agentic.ui.FileList
 --- @field code_selection agentic.ui.CodeSelection
+--- @field diagnostics_list agentic.ui.DiagnosticsList
 --- @field agent_modes agentic.acp.AgentModes
 --- @field todo_list agentic.ui.TodoList
 --- @field chat_history agentic.ui.ChatHistory
@@ -142,6 +146,23 @@ function SessionManager:new(tab_page_id)
                 self.widget:render_header(
                     "code",
                     tostring(#code_selection:get_selections())
+                )
+                self.widget:show({ focus_prompt = false })
+            end
+        end
+    )
+
+    self.diagnostics_list = DiagnosticsList:new(
+        self.widget.buf_nrs.diagnostics,
+        function(diagnostics_list)
+            if diagnostics_list:is_empty() then
+                self.widget:close_optional_window("diagnostics")
+                self.widget:move_cursor_to(self.widget.win_nrs.input)
+            else
+                -- show() opens layouts but does not update the diagnostics header count
+                self.widget:render_header(
+                    "diagnostics",
+                    tostring(#diagnostics_list:get_diagnostics())
                 )
                 self.widget:show({ focus_prompt = false })
             end
@@ -374,6 +395,30 @@ function SessionManager:_handle_input_submit(input_text)
                 message_lines,
                 string.format("  - @%s", FileSystem.to_smart_path(file_path))
             )
+        end
+    end
+
+    if not self.diagnostics_list:is_empty() then
+        table.insert(message_lines, "\n- **Diagnostics**:")
+
+        local diagnostics = self.diagnostics_list:get_diagnostics()
+        self.diagnostics_list:clear()
+
+        local chat_width = WidgetLayout.calculate_width(Config.windows.width)
+        local chat_winid = self.widget.win_nrs.chat
+        if chat_winid and vim.api.nvim_win_is_valid(chat_winid) then
+            chat_width = vim.api.nvim_win_get_width(chat_winid)
+        end
+
+        local formatted_diagnostics =
+            DiagnosticsContext.format_diagnostics(diagnostics, chat_width)
+
+        for _, prompt_entry in ipairs(formatted_diagnostics.prompt_entries) do
+            table.insert(prompt, prompt_entry)
+        end
+
+        for _, summary_line in ipairs(formatted_diagnostics.summary_lines) do
+            table.insert(message_lines, summary_line)
         end
     end
 
@@ -644,6 +689,7 @@ function SessionManager:_cancel_session()
         self.todo_list:clear()
         self.file_list:clear()
         self.code_selection:clear()
+        self.diagnostics_list:clear()
     end
 
     self.session_id = nil
@@ -740,6 +786,24 @@ function SessionManager:add_file_to_session(buf)
     local buf_path = vim.api.nvim_buf_get_name(bufnr)
 
     return self.file_list:add(buf_path)
+end
+
+--- Add diagnostics at the current cursor line to context
+--- @param bufnr integer|nil Buffer number to get diagnostics from, defaults to current buffer
+--- @return integer count Number of diagnostics added
+function SessionManager:add_current_line_diagnostics_to_context(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    local diagnostics = DiagnosticsList.get_diagnostics_at_cursor(bufnr)
+    return self.diagnostics_list:add_many(diagnostics)
+end
+
+--- Add all diagnostics from the current buffer to context
+--- @param bufnr integer|nil Buffer number, defaults to current buffer
+--- @return integer count Number of diagnostics added
+function SessionManager:add_buffer_diagnostics_to_context(bufnr)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    local diagnostics = DiagnosticsList.get_buffer_diagnostics(bufnr)
+    return self.diagnostics_list:add_many(diagnostics)
 end
 
 --- @param tool_call_id string

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -5,7 +5,7 @@ local Logger = require("agentic.utils.logger")
 local WindowDecoration = require("agentic.ui.window_decoration")
 local WidgetLayout = require("agentic.ui.widget_layout")
 
---- @alias agentic.ui.ChatWidget.PanelNames "chat"|"todos"|"code"|"files"|"input"
+--- @alias agentic.ui.ChatWidget.PanelNames "chat"|"todos"|"code"|"files"|"input"|"diagnostics"
 
 --- Runtime header parts with dynamic context
 --- @class agentic.ui.ChatWidget.HeaderParts
@@ -216,11 +216,15 @@ function ChatWidget:_submit_input()
         vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
     end)
 
+    BufHelpers.with_modifiable(self.buf_nrs.diagnostics, function(bufnr)
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, {})
+    end)
+
     self.on_submit_input(prompt)
 
     self:close_optional_window("code")
     self:close_optional_window("files")
-
+    self:close_optional_window("diagnostics")
     -- Move cursor to chat buffer after submit for easy access to permission requests
     self:move_cursor_to(self.win_nrs.chat)
 end
@@ -360,6 +364,10 @@ function ChatWidget:_create_buf_nrs()
         filetype = "AgenticFiles",
     })
 
+    local diagnostics = self:_create_new_buf({
+        filetype = "AgenticDiagnostics",
+    })
+
     local input = self:_create_new_buf({
         filetype = "AgenticInput",
         modifiable = true,
@@ -369,6 +377,7 @@ function ChatWidget:_create_buf_nrs()
     pcall(vim.treesitter.start, todos, "markdown")
     pcall(vim.treesitter.start, code, "markdown")
     pcall(vim.treesitter.start, files, "markdown")
+    pcall(vim.treesitter.start, diagnostics, "markdown")
     pcall(vim.treesitter.start, input, "markdown")
 
     --- @type agentic.ui.ChatWidget.BufNrs
@@ -377,6 +386,7 @@ function ChatWidget:_create_buf_nrs()
         todos = todos,
         code = code,
         files = files,
+        diagnostics = diagnostics,
         input = input,
     }
 

--- a/lua/agentic/ui/diagnostics_context.lua
+++ b/lua/agentic/ui/diagnostics_context.lua
@@ -1,0 +1,115 @@
+local FileSystem = require("agentic.utils.file_system")
+
+local DiagnosticsContext = {}
+
+--- @class agentic.ui.DiagnosticsContext.FormatResult
+--- @field prompt_entries agentic.acp.TextContent[]
+--- @field summary_lines string[]
+
+--- @param file_path string|nil
+--- @return string normalized_path
+local function normalize_file_path(file_path)
+    if file_path == nil or file_path == "" then
+        return "<unnamed buffer>"
+    end
+
+    return file_path
+end
+
+--- @param text string
+--- @param max_width integer
+--- @return string truncated_text
+local function truncate_for_display(text, max_width)
+    if max_width < 4 or #text <= max_width then
+        return text
+    end
+
+    return text:sub(1, max_width - 3) .. "..."
+end
+
+--- @param text string
+--- @return string escaped_text
+local function escape_xml(text)
+    return (
+        text:gsub("&", "&amp;")
+            :gsub("<", "&lt;")
+            :gsub(">", "&gt;")
+            :gsub('"', "&quot;")
+            :gsub("'", "&apos;")
+    )
+end
+
+--- @param severity vim.diagnostic.Severity|nil
+--- @return string severity_label
+local function severity_to_label(severity)
+    local label = ({
+        [vim.diagnostic.severity.ERROR] = "ERROR",
+        [vim.diagnostic.severity.WARN] = "WARN",
+        [vim.diagnostic.severity.INFO] = "INFO",
+        [vim.diagnostic.severity.HINT] = "HINT",
+    })[severity]
+
+    return label or "ERROR"
+end
+
+--- @param diagnostics agentic.ui.DiagnosticsList.Diagnostic[]
+--- @param chat_width integer
+--- @return agentic.ui.DiagnosticsContext.FormatResult format_result
+function DiagnosticsContext.format_diagnostics(diagnostics, chat_width)
+    --- @type agentic.acp.TextContent[]
+    local prompt_entries = {}
+    --- @type string[]
+    local summary_lines = {}
+
+    for _, diagnostic in ipairs(diagnostics) do
+        local file_path = normalize_file_path(diagnostic.file_path)
+        local absolute_file_path = file_path
+        if file_path ~= "<unnamed buffer>" then
+            absolute_file_path = FileSystem.to_absolute_path(file_path)
+        end
+
+        local severity_label = severity_to_label(diagnostic.severity)
+        local line = diagnostic.lnum + 1
+        local column = diagnostic.col + 1
+
+        table.insert(prompt_entries, {
+            type = "text",
+            text = string.format(
+                table.concat({
+                    "<diagnostic>",
+                    "<severity>%s</severity>",
+                    "<file>%s</file>",
+                    "<line>%d</line>",
+                    "<column>%d</column>",
+                    "<message>%s</message>",
+                    "</diagnostic>",
+                }, "\n"),
+                severity_label,
+                escape_xml(absolute_file_path),
+                line,
+                column,
+                escape_xml(diagnostic.message)
+            ),
+        })
+
+        local location = string.format("%s:%d:%d", file_path, line, column)
+        local summary = string.format(
+            "  - [%s] %s - %s",
+            severity_label,
+            location,
+            diagnostic.message
+        )
+
+        table.insert(summary_lines, truncate_for_display(summary, chat_width))
+    end
+
+    --- @type agentic.ui.DiagnosticsContext.FormatResult
+    local format_result = {
+        prompt_entries = prompt_entries,
+        summary_lines = summary_lines,
+    }
+
+    return format_result
+end
+
+return DiagnosticsContext

--- a/lua/agentic/ui/diagnostics_context.test.lua
+++ b/lua/agentic/ui/diagnostics_context.test.lua
@@ -1,0 +1,74 @@
+local assert = require("tests.helpers.assert")
+local DiagnosticsContext = require("agentic.ui.diagnostics_context")
+
+describe("agentic.ui.DiagnosticsContext", function()
+    it("formats diagnostics for prompt and chat summary", function()
+        local diagnostics = {
+            {
+                bufnr = 1,
+                lnum = 9,
+                col = 4,
+                severity = vim.diagnostic.severity.WARN,
+                message = "Use <tag> & escape me",
+                file_path = "lua/agentic/session_manager.lua",
+            },
+        }
+
+        local result = DiagnosticsContext.format_diagnostics(diagnostics, 120)
+
+        assert.equal(1, #result.prompt_entries)
+        assert.equal(1, #result.summary_lines)
+        assert.truthy(
+            result.prompt_entries[1].text:find(
+                "<severity>WARN</severity>",
+                1,
+                true
+            )
+        )
+        assert.truthy(
+            result.prompt_entries[1].text:find(
+                "&lt;tag&gt; &amp; escape me",
+                1,
+                true
+            )
+        )
+        assert.truthy(
+            result.summary_lines[1]:find(
+                "[WARN] lua/agentic/session_manager.lua:10:5",
+                1,
+                true
+            )
+        )
+    end)
+
+    it("uses unnamed buffer fallback and truncates summary", function()
+        local diagnostics = {
+            {
+                bufnr = 1,
+                lnum = 0,
+                col = 0,
+                severity = vim.diagnostic.severity.ERROR,
+                message = "A very long diagnostic message that should be truncated",
+                file_path = "",
+            },
+        }
+
+        local result = DiagnosticsContext.format_diagnostics(diagnostics, 40)
+
+        assert.truthy(
+            result.prompt_entries[1].text:find(
+                "<file>&lt;unnamed buffer&gt;</file>",
+                1,
+                true
+            )
+        )
+        assert.truthy(
+            result.summary_lines[1]:find(
+                "[ERROR] <unnamed buffer>:1:1",
+                1,
+                true
+            )
+        )
+        assert.equal("...", result.summary_lines[1]:sub(-3))
+    end)
+end)

--- a/lua/agentic/ui/diagnostics_list.lua
+++ b/lua/agentic/ui/diagnostics_list.lua
@@ -1,0 +1,312 @@
+local Config = require("agentic.config")
+local FileSystem = require("agentic.utils.file_system")
+local BufHelpers = require("agentic.utils.buf_helpers")
+
+--- Get diagnostic severity icons from config
+--- @return table<number, string> Mapping of severity to icon
+local function get_diagnostic_icons()
+    local icons = Config.diagnostic_icons
+    return {
+        [vim.diagnostic.severity.ERROR] = icons.error,
+        [vim.diagnostic.severity.WARN] = icons.warn,
+        [vim.diagnostic.severity.INFO] = icons.info,
+        [vim.diagnostic.severity.HINT] = icons.hint,
+    }
+end
+
+--- @class agentic.ui.DiagnosticsList.Diagnostic : vim.Diagnostic
+--- @field file_path string Full file path
+
+--- @class agentic.ui.DiagnosticsList
+--- @field _diagnostics agentic.ui.DiagnosticsList.Diagnostic[]
+--- @field _bufnr integer the same buffer number as the ChatWidget's diagnostics buffer
+--- @field _on_change fun(diagnosticsList: agentic.ui.DiagnosticsList)
+local DiagnosticsList = {}
+DiagnosticsList.__index = DiagnosticsList
+
+--- @param bufnr integer The diagnostics buffer number from ChatWidget
+--- @param on_change fun(diagnosticsList: agentic.ui.DiagnosticsList) Callback to trigger when diagnostics list changes (e.g., update header)
+--- @return agentic.ui.DiagnosticsList
+function DiagnosticsList:new(bufnr, on_change)
+    local instance = setmetatable({
+        _diagnostics = {},
+        _bufnr = bufnr,
+        _on_change = on_change,
+    }, self)
+
+    instance:_setup_keybindings()
+
+    return instance
+end
+
+--- Add a diagnostic to the list if not already present
+--- @param diagnostic agentic.ui.DiagnosticsList.Diagnostic|nil
+--- @return boolean success
+--- @private
+function DiagnosticsList:_add_no_render(diagnostic)
+    if not diagnostic or not diagnostic.bufnr then
+        return false
+    end
+
+    local file_path = diagnostic.file_path
+    if type(file_path) ~= "string" then
+        file_path = ""
+    end
+
+    if file_path == "" and vim.api.nvim_buf_is_valid(diagnostic.bufnr) then
+        file_path = vim.api.nvim_buf_get_name(diagnostic.bufnr)
+    end
+
+    if type(file_path) ~= "string" then
+        file_path = ""
+    end
+    diagnostic.file_path = file_path
+
+    -- Check for duplicates
+    for _, existing in ipairs(self._diagnostics) do
+        if
+            existing.bufnr == diagnostic.bufnr
+            and existing.lnum == diagnostic.lnum
+            and existing.col == diagnostic.col
+            and existing.message == diagnostic.message
+            and existing.severity == diagnostic.severity
+            and existing.source == diagnostic.source
+            and existing.code == diagnostic.code
+        then
+            return false
+        end
+    end
+
+    table.insert(self._diagnostics, diagnostic)
+    return true
+end
+
+--- Add a diagnostic to the list if not already present
+--- @param diagnostic agentic.ui.DiagnosticsList.Diagnostic|nil
+--- @return boolean success
+function DiagnosticsList:add(diagnostic)
+    if not self:_add_no_render(diagnostic) then
+        return false
+    end
+
+    self:_render()
+    return true
+end
+
+--- Add multiple diagnostics at once
+--- @param diagnostics agentic.ui.DiagnosticsList.Diagnostic[]
+--- @return integer count Number of diagnostics added
+function DiagnosticsList:add_many(diagnostics)
+    local count = 0
+    for _, diagnostic in ipairs(diagnostics) do
+        if self:_add_no_render(diagnostic) then
+            count = count + 1
+        end
+    end
+
+    if count > 0 then
+        self:_render()
+    end
+
+    return count
+end
+
+--- @param index integer
+function DiagnosticsList:remove_at(index)
+    if index < 1 or index > #self._diagnostics then
+        return
+    end
+
+    table.remove(self._diagnostics, index)
+    self:_render()
+end
+
+--- @return agentic.ui.DiagnosticsList.Diagnostic[]
+function DiagnosticsList:get_diagnostics()
+    return vim.deepcopy(self._diagnostics)
+end
+
+function DiagnosticsList:clear()
+    self._diagnostics = {}
+    self:_render()
+end
+
+--- @return boolean
+function DiagnosticsList:is_empty()
+    return #self._diagnostics == 0
+end
+
+--- Get diagnostics for a specific buffer
+--- @param bufnr integer|nil If nil, uses current buffer
+--- @param opts vim.diagnostic.GetOpts|nil Options passed to vim.diagnostic.get()
+--- @return agentic.ui.DiagnosticsList.Diagnostic[] diagnostics Converted diagnostics
+function DiagnosticsList.get_buffer_diagnostics(bufnr, opts)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    opts = opts or {}
+
+    --- @type vim.Diagnostic[]
+    local vim_diagnostics = vim.diagnostic.get(bufnr, opts)
+    local file_path = vim.api.nvim_buf_get_name(bufnr)
+
+    --- @type agentic.ui.DiagnosticsList.Diagnostic[]
+    local diagnostics = {}
+
+    for _, d in ipairs(vim_diagnostics) do
+        --- @type agentic.ui.DiagnosticsList.Diagnostic
+        local diagnostic = vim.tbl_extend("force", d, { file_path = file_path }) --[[@as agentic.ui.DiagnosticsList.Diagnostic]]
+        table.insert(diagnostics, diagnostic)
+    end
+
+    return diagnostics
+end
+
+--- Get diagnostics at the cursor line
+--- @param bufnr integer|nil If nil, uses current buffer
+--- @param opts vim.diagnostic.GetOpts|nil Options passed to vim.diagnostic.get()
+--- @return agentic.ui.DiagnosticsList.Diagnostic[] diagnostics Diagnostics at the cursor line
+function DiagnosticsList.get_diagnostics_at_cursor(bufnr, opts)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+    opts = opts or {}
+
+    local winid = vim.fn.bufwinid(bufnr)
+    if winid == -1 then
+        local current_winid = vim.api.nvim_get_current_win()
+        if vim.api.nvim_win_get_buf(current_winid) ~= bufnr then
+            return {}
+        end
+        winid = current_winid
+    end
+
+    local cursor_pos = vim.api.nvim_win_get_cursor(winid)
+    local cursor_line = cursor_pos[1] - 1 -- Convert to 0-indexed
+
+    --- @type vim.Diagnostic[]
+    local vim_diagnostics = vim.diagnostic.get(bufnr, opts)
+    local file_path = vim.api.nvim_buf_get_name(bufnr)
+
+    --- @type agentic.ui.DiagnosticsList.Diagnostic[]
+    local diagnostics = {}
+
+    for _, d in ipairs(vim_diagnostics) do
+        if d.lnum == cursor_line then
+            --- @type agentic.ui.DiagnosticsList.Diagnostic
+            local diagnostic =
+                vim.tbl_extend("force", d, { file_path = file_path }) --[[@as agentic.ui.DiagnosticsList.Diagnostic]]
+            table.insert(diagnostics, diagnostic)
+        end
+    end
+
+    return diagnostics
+end
+
+--- @private
+function DiagnosticsList:_render()
+    local lines = {}
+    local icons = get_diagnostic_icons()
+
+    for _, diagnostic in ipairs(self._diagnostics) do
+        local icon = icons[diagnostic.severity]
+            or icons[vim.diagnostic.severity.ERROR]
+        local smart_path = diagnostic.file_path
+        if smart_path == "" then
+            smart_path = string.format("[unnamed:%d]", diagnostic.bufnr)
+        else
+            smart_path = FileSystem.to_smart_path(smart_path)
+        end
+        local location = string.format(
+            "%s:%d:%d",
+            smart_path,
+            diagnostic.lnum + 1,
+            diagnostic.col + 1
+        )
+
+        -- nvim_buf_set_lines rejects embedded newlines in a line item.
+        -- Keep diagnostics single-line by rendering newlines as escaped text.
+        local message = type(diagnostic.message) == "string"
+                and diagnostic.message
+            or tostring(diagnostic.message or "")
+        message = message:gsub("\r\n", "\n"):gsub("\r", "\n"):gsub("\n", "\\n")
+
+        -- Format: ICON path:line:col - message
+        local line = string.format("%s %s - %s", icon, location, message)
+        table.insert(lines, line)
+    end
+
+    local did_render = BufHelpers.with_modifiable(self._bufnr, function(bufnr)
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+        return true
+    end)
+
+    if did_render then
+        self._on_change(self)
+    end
+end
+
+--- @private
+function DiagnosticsList:_setup_keybindings()
+    BufHelpers.keymap_set(self._bufnr, "n", "d", function()
+        local cursor = vim.api.nvim_win_get_cursor(0)
+        local line = cursor[1]
+
+        local line_content =
+            vim.api.nvim_buf_get_lines(self._bufnr, line - 1, line, false)[1]
+
+        if line_content and line_content:match("%S") then
+            self:remove_at(line)
+        end
+    end, { nowait = true })
+
+    BufHelpers.keymap_set(self._bufnr, "v", "d", function()
+        local start_pos = vim.fn.getpos("v")
+        local end_pos = vim.fn.getpos(".")
+        local start_line = start_pos[2]
+        local end_line = end_pos[2]
+
+        -- Ensure start_line is always smaller than end_line (handle backward selection)
+        if start_line > end_line then
+            start_line, end_line = end_line, start_line
+        end
+
+        --- @type table<integer, true>
+        local indices_to_remove = {}
+        for line = start_line, end_line do
+            local line_content = vim.api.nvim_buf_get_lines(
+                self._bufnr,
+                line - 1,
+                line,
+                false
+            )[1]
+
+            if
+                line_content
+                and line_content:match("%S")
+                and line >= 1
+                and line <= #self._diagnostics
+            then
+                indices_to_remove[line] = true
+            end
+        end
+
+        --- @type integer[]
+        local sorted_indices = {}
+        for index in pairs(indices_to_remove) do
+            table.insert(sorted_indices, index)
+        end
+        table.sort(sorted_indices, function(a, b)
+            return a > b
+        end)
+
+        for _, index in ipairs(sorted_indices) do
+            table.remove(self._diagnostics, index)
+        end
+
+        if #sorted_indices > 0 then
+            self:_render()
+        end
+
+        -- Exit visual mode
+        BufHelpers.feed_ESC_key()
+    end, { nowait = true })
+end
+
+return DiagnosticsList

--- a/lua/agentic/ui/diagnostics_list.test.lua
+++ b/lua/agentic/ui/diagnostics_list.test.lua
@@ -1,0 +1,479 @@
+local assert = require("tests.helpers.assert")
+local spy = require("tests.helpers.spy")
+local Config = require("agentic.config")
+
+describe("agentic.ui.DiagnosticsList", function()
+    local DiagnosticsList = require("agentic.ui.diagnostics_list")
+
+    --- @type integer
+    local bufnr
+    --- @type agentic.ui.DiagnosticsList
+    local diagnostics_list
+    --- @type TestSpy
+    local on_change_spy
+
+    --- @return agentic.ui.DiagnosticsList.Diagnostic
+    local function create_diagnostic(overrides)
+        overrides = overrides or {}
+        return {
+            bufnr = overrides.bufnr or 1,
+            lnum = overrides.lnum or 10,
+            col = overrides.col or 5,
+            severity = overrides.severity or vim.diagnostic.severity.ERROR,
+            message = overrides.message or "Test error message",
+            source = overrides.source or "test",
+            code = overrides.code or "E001",
+            file_path = overrides.file_path or "/path/to/test.lua",
+        }
+    end
+
+    before_each(function()
+        bufnr = vim.api.nvim_create_buf(false, true)
+        on_change_spy = spy.new(function() end)
+
+        diagnostics_list =
+            DiagnosticsList:new(bufnr, on_change_spy --[[@as function]])
+    end)
+
+    after_each(function()
+        if on_change_spy and on_change_spy.revert then
+            on_change_spy:revert()
+        end
+
+        if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end
+    end)
+
+    describe("add and get_diagnostics", function()
+        it("adds diagnostic and retrieves it", function()
+            local diagnostic = create_diagnostic()
+
+            local success = diagnostics_list:add(diagnostic)
+
+            assert.is_true(success)
+
+            local diagnostics = diagnostics_list:get_diagnostics()
+            assert.equal(1, #diagnostics)
+            assert.equal(diagnostic.message, diagnostics[1].message)
+            assert.spy(on_change_spy).was.called(1)
+        end)
+
+        it("does not add nil diagnostic", function()
+            local success = diagnostics_list:add(nil)
+
+            assert.is_false(success)
+            assert.is_true(diagnostics_list:is_empty())
+            assert.spy(on_change_spy).was.called(0)
+        end)
+
+        it("does not add diagnostic without bufnr", function()
+            local diagnostic = create_diagnostic()
+            diagnostic.bufnr = nil
+
+            local success = diagnostics_list:add(diagnostic)
+
+            assert.is_false(success)
+            assert.is_true(diagnostics_list:is_empty())
+        end)
+
+        it("does not add duplicate diagnostic", function()
+            local diagnostic = create_diagnostic()
+
+            diagnostics_list:add(diagnostic)
+            diagnostics_list:add(diagnostic)
+
+            local diagnostics = diagnostics_list:get_diagnostics()
+            assert.equal(1, #diagnostics)
+            assert.spy(on_change_spy).was.called(1)
+        end)
+
+        it("adds diagnostics with different locations", function()
+            local diagnostic1 =
+                create_diagnostic({ lnum = 10, message = "Error 1" })
+            local diagnostic2 =
+                create_diagnostic({ lnum = 20, message = "Error 2" })
+
+            diagnostics_list:add(diagnostic1)
+            diagnostics_list:add(diagnostic2)
+
+            local diagnostics = diagnostics_list:get_diagnostics()
+            assert.equal(2, #diagnostics)
+            assert.spy(on_change_spy).was.called(2)
+        end)
+
+        it("adds diagnostics with same line but different messages", function()
+            local diagnostic1 = create_diagnostic({ message = "Error 1" })
+            local diagnostic2 = create_diagnostic({ message = "Error 2" })
+
+            diagnostics_list:add(diagnostic1)
+            diagnostics_list:add(diagnostic2)
+
+            local diagnostics = diagnostics_list:get_diagnostics()
+            assert.equal(2, #diagnostics)
+        end)
+
+        it("returns deep copy of diagnostics", function()
+            local diagnostic = create_diagnostic()
+
+            diagnostics_list:add(diagnostic)
+
+            local diagnostics1 = diagnostics_list:get_diagnostics()
+            local diagnostics2 = diagnostics_list:get_diagnostics()
+
+            diagnostics1[1].message = "modified"
+
+            assert.equal(diagnostic.message, diagnostics2[1].message)
+        end)
+    end)
+
+    describe("add_many", function()
+        it("adds multiple diagnostics at once", function()
+            local diagnostics = {
+                create_diagnostic({ lnum = 10 }),
+                create_diagnostic({ lnum = 20 }),
+                create_diagnostic({ lnum = 30 }),
+            }
+
+            local count = diagnostics_list:add_many(diagnostics)
+
+            assert.equal(3, count)
+            assert.equal(3, #diagnostics_list:get_diagnostics())
+            assert.spy(on_change_spy).was.called(1)
+        end)
+
+        it("handles empty array", function()
+            local count = diagnostics_list:add_many({})
+
+            assert.equal(0, count)
+            assert.is_true(diagnostics_list:is_empty())
+            assert.spy(on_change_spy).was.called(0)
+        end)
+
+        it("counts only successfully added diagnostics", function()
+            local diagnostics = {
+                create_diagnostic({ lnum = 10 }),
+                create_diagnostic({ lnum = 10 }), -- Duplicate
+                create_diagnostic({ lnum = 20 }),
+            }
+
+            local count = diagnostics_list:add_many(diagnostics)
+
+            assert.equal(2, count)
+            assert.equal(2, #diagnostics_list:get_diagnostics())
+        end)
+    end)
+
+    describe("is_empty", function()
+        it("returns true when no diagnostics added", function()
+            assert.is_true(diagnostics_list:is_empty())
+        end)
+
+        it("returns false when diagnostics exist", function()
+            diagnostics_list:add(create_diagnostic())
+
+            assert.is_false(diagnostics_list:is_empty())
+        end)
+    end)
+
+    describe("clear", function()
+        it("removes all diagnostics", function()
+            diagnostics_list:add(create_diagnostic({ lnum = 10 }))
+            diagnostics_list:add(create_diagnostic({ lnum = 20 }))
+            assert.is_false(diagnostics_list:is_empty())
+
+            diagnostics_list:clear()
+
+            assert.is_true(diagnostics_list:is_empty())
+            assert.spy(on_change_spy).was.called(3)
+        end)
+
+        it("clears buffer content", function()
+            local lines_before = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            diagnostics_list:add(create_diagnostic())
+            local lines_after_add =
+                vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.is_not.same(lines_before, lines_after_add)
+
+            diagnostics_list:clear()
+
+            local line_count = vim.api.nvim_buf_line_count(bufnr)
+            assert.equal(1, line_count)
+            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.equal("", lines[1])
+        end)
+    end)
+
+    describe("remove_at", function()
+        it("removes diagnostic at valid index", function()
+            local diagnostic1 = create_diagnostic({ lnum = 10 })
+            local diagnostic2 = create_diagnostic({ lnum = 20 })
+
+            diagnostics_list:add(diagnostic1)
+            diagnostics_list:add(diagnostic2)
+
+            assert.equal(2, #diagnostics_list:get_diagnostics())
+
+            diagnostics_list:remove_at(1)
+
+            local diagnostics = diagnostics_list:get_diagnostics()
+            assert.equal(1, #diagnostics)
+            assert.equal(diagnostic2.message, diagnostics[1].message)
+            assert.spy(on_change_spy).was.called(3)
+        end)
+
+        it("does not remove at invalid index (too small)", function()
+            diagnostics_list:add(create_diagnostic({ lnum = 10 }))
+            diagnostics_list:add(create_diagnostic({ lnum = 20 }))
+
+            diagnostics_list:remove_at(0)
+
+            assert.equal(2, #diagnostics_list:get_diagnostics())
+            assert.spy(on_change_spy).was.called(2)
+        end)
+
+        it("does not remove at invalid index (too large)", function()
+            diagnostics_list:add(create_diagnostic({ lnum = 10 }))
+            diagnostics_list:add(create_diagnostic({ lnum = 20 }))
+
+            diagnostics_list:remove_at(3)
+
+            assert.equal(2, #diagnostics_list:get_diagnostics())
+            assert.spy(on_change_spy).was.called(2)
+        end)
+    end)
+
+    describe("buffer rendering", function()
+        it("renders diagnostics in buffer", function()
+            local diagnostic = create_diagnostic({
+                lnum = 10,
+                col = 5,
+                message = "Test error",
+                file_path = "/path/to/test.lua",
+            })
+
+            diagnostics_list:add(diagnostic)
+
+            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.equal(1, #lines)
+            assert.truthy(lines[1]:find("Test error", 1, true))
+            assert.truthy(lines[1]:find(Config.diagnostic_icons.error, 1, true))
+        end)
+
+        it("renders multiple diagnostics", function()
+            diagnostics_list:add(
+                create_diagnostic({ lnum = 10, message = "Error 1" })
+            )
+            diagnostics_list:add(
+                create_diagnostic({ lnum = 20, message = "Error 2" })
+            )
+
+            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.equal(2, #lines)
+            assert.truthy(lines[1]:find("Error 1", 1, true))
+            assert.truthy(lines[2]:find("Error 2", 1, true))
+        end)
+
+        it("includes severity emoji", function()
+            diagnostics_list:add(create_diagnostic({
+                severity = vim.diagnostic.severity.WARN,
+                message = "Warning message",
+            }))
+
+            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.truthy(lines[1]:find("Warning message", 1, true))
+            assert.truthy(lines[1]:find(Config.diagnostic_icons.warn, 1, true))
+        end)
+
+        it("escapes newline in the middle of message", function()
+            diagnostics_list:add(create_diagnostic({
+                message = "Line one\nLine two",
+            }))
+
+            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.equal(1, #lines)
+            assert.truthy(lines[1]:find("Line one\\nLine two", 1, true))
+        end)
+
+        it("escapes trailing newline in message", function()
+            diagnostics_list:add(create_diagnostic({
+                message = "Trailing newline\n",
+            }))
+
+            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.equal(1, #lines)
+            assert.truthy(lines[1]:find("Trailing newline\\n", 1, true))
+        end)
+
+        it("includes file location", function()
+            diagnostics_list:add(create_diagnostic({
+                lnum = 10,
+                col = 5,
+                file_path = "/path/to/test.lua",
+            }))
+
+            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.truthy(lines[1]:find(":11:6", 1, true)) -- lnum+1, col+1
+        end)
+
+        it("updates buffer after removal", function()
+            diagnostics_list:add(create_diagnostic({ lnum = 10 }))
+            diagnostics_list:add(create_diagnostic({ lnum = 20 }))
+
+            local lines_before = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.equal(2, #lines_before)
+
+            diagnostics_list:remove_at(1)
+
+            local lines_after = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            assert.equal(1, #lines_after)
+        end)
+    end)
+
+    describe("get_buffer_diagnostics", function()
+        --- @type integer
+        local test_bufnr
+        --- @type integer
+        local ns
+
+        before_each(function()
+            test_bufnr = vim.api.nvim_create_buf(false, true)
+            ns = vim.api.nvim_create_namespace("test_diag_buf")
+        end)
+
+        after_each(function()
+            vim.diagnostic.reset(ns, test_bufnr)
+            if vim.api.nvim_buf_is_valid(test_bufnr) then
+                vim.api.nvim_buf_delete(test_bufnr, { force = true })
+            end
+        end)
+
+        it("returns empty array when no diagnostics", function()
+            local diagnostics =
+                DiagnosticsList.get_buffer_diagnostics(test_bufnr)
+
+            assert.equal(0, #diagnostics)
+        end)
+
+        it("converts vim diagnostics to internal format", function()
+            vim.api.nvim_buf_set_name(test_bufnr, "/test/file.lua")
+
+            vim.diagnostic.set(ns, test_bufnr, {
+                {
+                    lnum = 5,
+                    col = 10,
+                    severity = vim.diagnostic.severity.ERROR,
+                    message = "Test error",
+                    source = "test_source",
+                    code = "E123",
+                },
+            })
+
+            local diagnostics =
+                DiagnosticsList.get_buffer_diagnostics(test_bufnr)
+
+            assert.equal(1, #diagnostics)
+            assert.equal(5, diagnostics[1].lnum)
+            assert.equal(10, diagnostics[1].col)
+            assert.equal(vim.diagnostic.severity.ERROR, diagnostics[1].severity)
+            assert.equal("Test error", diagnostics[1].message)
+            assert.equal("test_source", diagnostics[1].source)
+            assert.equal("E123", diagnostics[1].code)
+            assert.equal("/test/file.lua", diagnostics[1].file_path)
+        end)
+
+        it("defaults to ERROR severity when not specified", function()
+            vim.diagnostic.set(ns, test_bufnr, {
+                {
+                    lnum = 0,
+                    col = 0,
+                    message = "Test message",
+                },
+            })
+
+            local diagnostics =
+                DiagnosticsList.get_buffer_diagnostics(test_bufnr)
+
+            assert.equal(vim.diagnostic.severity.ERROR, diagnostics[1].severity)
+        end)
+    end)
+
+    describe("get_diagnostics_at_cursor", function()
+        --- @type integer
+        local test_bufnr
+        --- @type integer
+        local ns
+
+        before_each(function()
+            test_bufnr = vim.api.nvim_create_buf(false, true)
+            ns = vim.api.nvim_create_namespace("test_diag_cursor")
+            vim.api.nvim_set_current_buf(test_bufnr)
+        end)
+
+        after_each(function()
+            vim.diagnostic.reset(ns, test_bufnr)
+            if vim.api.nvim_buf_is_valid(test_bufnr) then
+                vim.api.nvim_buf_delete(test_bufnr, { force = true })
+            end
+        end)
+
+        it("returns diagnostics at cursor line", function()
+            vim.api.nvim_buf_set_lines(
+                test_bufnr,
+                0,
+                -1,
+                false,
+                { "line1", "line2", "line3" }
+            )
+
+            vim.diagnostic.set(ns, test_bufnr, {
+                {
+                    lnum = 1,
+                    col = 0,
+                    severity = vim.diagnostic.severity.ERROR,
+                    message = "Error on line 2",
+                },
+                {
+                    lnum = 2,
+                    col = 0,
+                    severity = vim.diagnostic.severity.WARN,
+                    message = "Warning on line 3",
+                },
+            })
+
+            vim.api.nvim_win_set_cursor(0, { 2, 0 })
+
+            local diagnostics =
+                DiagnosticsList.get_diagnostics_at_cursor(test_bufnr)
+
+            assert.equal(1, #diagnostics)
+            assert.equal("Error on line 2", diagnostics[1].message)
+        end)
+
+        it("returns empty array when no diagnostics at cursor", function()
+            vim.api.nvim_buf_set_lines(
+                test_bufnr,
+                0,
+                -1,
+                false,
+                { "line1", "line2" }
+            )
+
+            vim.diagnostic.set(ns, test_bufnr, {
+                {
+                    lnum = 0,
+                    col = 0,
+                    severity = vim.diagnostic.severity.ERROR,
+                    message = "Error on line 1",
+                },
+            })
+
+            vim.api.nvim_win_set_cursor(0, { 2, 0 })
+
+            local diagnostics =
+                DiagnosticsList.get_diagnostics_at_cursor(test_bufnr)
+
+            assert.equal(0, #diagnostics)
+        end)
+    end)
+end)

--- a/lua/agentic/ui/widget_layout.lua
+++ b/lua/agentic/ui/widget_layout.lua
@@ -231,8 +231,17 @@ local function show_layout(params, position)
         split = is_bottom and "below" or "above",
     }, Config.windows.files.max_height)
 
+    ref_win = is_bottom and (win_nrs.files or win_nrs.code or win_nrs.input)
+        or win_nrs.input
+
+    open_or_resize_dynamic_window(buf_nrs, win_nrs, "diagnostics", {
+        win = ref_win,
+        split = is_bottom and "below" or "above",
+    }, Config.windows.diagnostics.max_height)
+
     if Config.windows.todos.display then
-        ref_win = is_bottom and (win_nrs.files or win_nrs.code or win_nrs.input)
+        ref_win = is_bottom
+                and (win_nrs.diagnostics or win_nrs.files or win_nrs.code or win_nrs.input)
             or win_nrs.chat
 
         open_or_resize_dynamic_window(buf_nrs, win_nrs, "todos", {

--- a/lua/agentic/ui/widget_layout.test.lua
+++ b/lua/agentic/ui/widget_layout.test.lua
@@ -231,6 +231,7 @@ describe("WidgetLayout", function()
                 input = vim.api.nvim_create_buf(false, true),
                 code = vim.api.nvim_create_buf(false, true),
                 files = vim.api.nvim_create_buf(false, true),
+                diagnostics = vim.api.nvim_create_buf(false, true),
                 todos = vim.api.nvim_create_buf(false, true),
             }
 

--- a/lua/agentic/ui/window_decoration.lua
+++ b/lua/agentic/ui/window_decoration.lua
@@ -16,8 +16,8 @@
 --- require('lualine').setup({
 ---   options = {
 ---     disabled_filetypes = {
----       statusline = { 'AgenticChat', 'AgenticInput', 'AgenticCode', 'AgenticFiles' },
----       winbar = { 'AgenticChat', 'AgenticInput', 'AgenticCode', 'AgenticFiles' },
+---       statusline = { 'AgenticChat', 'AgenticInput', 'AgenticCode', 'AgenticFiles', 'AgenticDiagnostics' },
+---       winbar = { 'AgenticChat', 'AgenticInput', 'AgenticCode', 'AgenticFiles', 'AgenticDiagnostics' },
 ---     }
 ---   }
 --- })
@@ -44,6 +44,10 @@ local WINDOW_HEADERS = {
     files = {
         title = " Referenced Files",
         suffix = "d: remove file",
+    },
+    diagnostics = {
+        title = " Diagnostics",
+        suffix = "d: remove diagnostic",
     },
     todos = {
         title = " Tasks list",

--- a/tests/integration/test_add_diagnostics_to_session.lua
+++ b/tests/integration/test_add_diagnostics_to_session.lua
@@ -1,0 +1,223 @@
+local assert = require("tests.helpers.assert")
+local Child = require("tests.helpers.child")
+
+describe("Add diagnostics to session", function()
+    local child = Child:new()
+
+    before_each(function()
+        child.setup()
+        child.cmd([[ edit tests/init.lua ]])
+    end)
+
+    after_each(function()
+        child.stop()
+    end)
+
+    it("Adds diagnostics at cursor to diagnostics window", function()
+        -- Set up a diagnostic on line 1 of the current buffer
+        local bufnr = child.lua([[
+            local bufnr = vim.api.nvim_get_current_buf()
+            local ns = vim.api.nvim_create_namespace("test_diagnostics")
+            vim.diagnostic.set(ns, bufnr, {
+                {
+                    lnum = 0,  -- Line 1 (0-indexed)
+                    col = 0,
+                    severity = vim.diagnostic.severity.ERROR,
+                    message = "Test error on line 1",
+                },
+            })
+            return bufnr
+        ]])
+
+        -- Ensure the session exists by opening the widget first
+        child.lua([[ require("agentic").toggle() ]])
+        child.flush()
+
+        -- Close it so we can add diagnostics properly
+        child.lua([[ require("agentic").close() ]])
+        child.flush()
+
+        -- Now set the buffer again and add diagnostics
+        -- This simulates the user being in their file buffer
+        child.lua(([[
+            vim.api.nvim_set_current_buf(%d)
+            vim.api.nvim_win_set_cursor(0, {1, 0})
+        ]]):format(bufnr))
+
+        -- Add diagnostics at cursor (cursor should be on line 1)
+        child.lua([[ require("agentic").add_current_line_diagnostics() ]])
+        child.flush()
+
+        -- Get diagnostics from diagnostics_list
+        local diagnostics = child.lua([[
+            local session = require("agentic.session_registry").get_session_for_tab_page()
+            return session.diagnostics_list:get_diagnostics()
+        ]])
+
+        assert.equal(1, #diagnostics)
+        assert.equal("Test error on line 1", diagnostics[1].message)
+        assert.equal(0, diagnostics[1].lnum)
+        assert.equal(vim.diagnostic.severity.ERROR, diagnostics[1].severity)
+
+        -- Clean up
+        child.lua(([[
+            vim.diagnostic.reset(vim.api.nvim_create_namespace("test_diagnostics"), %d)
+        ]]):format(bufnr))
+    end)
+
+    it("Adds all buffer diagnostics to session", function()
+        -- Set up multiple diagnostics on the current buffer
+        local bufnr = child.lua([[
+            local bufnr = vim.api.nvim_get_current_buf()
+            local ns = vim.api.nvim_create_namespace("test_diagnostics")
+            vim.diagnostic.set(ns, bufnr, {
+                {
+                    lnum = 0,
+                    col = 0,
+                    severity = vim.diagnostic.severity.ERROR,
+                    message = "First error",
+                },
+                {
+                    lnum = 5,
+                    col = 10,
+                    severity = vim.diagnostic.severity.WARN,
+                    message = "Warning message",
+                },
+                {
+                    lnum = 10,
+                    col = 0,
+                    severity = vim.diagnostic.severity.HINT,
+                    message = "Hint for improvement",
+                },
+            })
+            return bufnr
+        ]])
+
+        -- Ensure the session exists by opening the widget first
+        child.lua([[ require("agentic").toggle() ]])
+        child.flush()
+
+        -- Close it so we can add diagnostics properly
+        child.lua([[ require("agentic").close() ]])
+        child.flush()
+
+        -- Now set the buffer again and add diagnostics
+        child.lua(([[
+            vim.api.nvim_set_current_buf(%d)
+        ]]):format(bufnr))
+
+        -- Add all buffer diagnostics
+        child.lua([[ require("agentic").add_buffer_diagnostics() ]])
+        child.flush()
+
+        -- Get diagnostics from diagnostics_list
+        local diagnostics = child.lua([[
+            local session = require("agentic.session_registry").get_session_for_tab_page()
+            return session.diagnostics_list:get_diagnostics()
+        ]])
+
+        assert.equal(3, #diagnostics)
+
+        -- Verify first diagnostic
+        assert.equal("First error", diagnostics[1].message)
+        assert.equal(vim.diagnostic.severity.ERROR, diagnostics[1].severity)
+
+        -- Verify second diagnostic
+        assert.equal("Warning message", diagnostics[2].message)
+        assert.equal(vim.diagnostic.severity.WARN, diagnostics[2].severity)
+
+        -- Verify third diagnostic
+        assert.equal("Hint for improvement", diagnostics[3].message)
+        assert.equal(vim.diagnostic.severity.HINT, diagnostics[3].severity)
+
+        -- Clean up
+        child.lua(([[
+            vim.diagnostic.reset(vim.api.nvim_create_namespace("test_diagnostics"), %d)
+        ]]):format(bufnr))
+    end)
+
+    it("Shows diagnostics window when diagnostics are added", function()
+        -- Set up a diagnostic on the current buffer
+        local bufnr = child.lua([[
+            local bufnr = vim.api.nvim_get_current_buf()
+            local ns = vim.api.nvim_create_namespace("test_diagnostics")
+            vim.diagnostic.set(ns, bufnr, {
+                {
+                    lnum = 0,
+                    col = 0,
+                    severity = vim.diagnostic.severity.ERROR,
+                    message = "Test error",
+                },
+            })
+            return bufnr
+        ]])
+
+        -- Ensure the session exists by opening the widget first
+        child.lua([[ require("agentic").toggle() ]])
+        child.flush()
+
+        -- Close it so we can add diagnostics properly
+        child.lua([[ require("agentic").close() ]])
+        child.flush()
+
+        -- Now set the buffer again and add diagnostics
+        child.lua(([[
+            vim.api.nvim_set_current_buf(%d)
+        ]]):format(bufnr))
+
+        -- Add diagnostics
+        child.lua([[ require("agentic").add_current_line_diagnostics() ]])
+        child.flush()
+
+        -- Check if diagnostics window is valid
+        local diagnostics_winid = child.lua([[
+            local session = require("agentic.session_registry")
+                .get_session_for_tab_page()
+            return session.widget.win_nrs.diagnostics
+        ]])
+
+        local diagnostics_count = child.lua([[
+            local session = require("agentic.session_registry").get_session_for_tab_page()
+            return #session.diagnostics_list:get_diagnostics()
+        ]])
+
+        assert.is_true(diagnostics_count > 0)
+        assert.truthy(diagnostics_winid)
+        assert.is_true(child.api.nvim_win_is_valid(diagnostics_winid))
+
+        -- Clean up
+        child.lua(([[
+            vim.diagnostic.reset(vim.api.nvim_create_namespace("test_diagnostics"), %d)
+        ]]):format(bufnr))
+    end)
+
+    it("Does not show widget when no diagnostics exist", function()
+        -- Open widget first
+        child.lua([[ require("agentic").toggle() ]])
+        child.flush()
+
+        -- Close widget
+        child.lua([[ require("agentic").close() ]])
+        child.flush()
+
+        -- Try to add diagnostics when none exist
+        child.lua([[ require("agentic").add_current_line_diagnostics() ]])
+        child.flush()
+
+        -- Widget was opened then closed above; adding diagnostics with no
+        -- entries should not reopen the diagnostics window.
+        local diagnostics_list = child.lua([[
+            local session = require("agentic.session_registry").get_session_for_tab_page()
+            return session.diagnostics_list:get_diagnostics()
+        ]])
+
+        -- No diagnostics should have been added
+        assert.equal(0, #diagnostics_list)
+
+        local is_open = child.lua([[
+            local session = require("agentic.session_registry").get_session_for_tab_page()
+            return session.widget:is_open()
+        ]])
+        assert.is_false(is_open)
+    end)
+end)


### PR DESCRIPTION
Add `add_diagnostics()` and `add_buffer_diagnostics()` functions to send diagnostics as context to the agent. Includes dedicated UI panel, rendering, and full test coverage.

Tested using `lua_ls` with my nvim config. Added some gibberish and ran the following:

```
:lua require("agentic").toggle()
:lua require("agentic").add_buffer_diagnostics()
```

<img width="2560" height="952" alt="image" src="https://github.com/user-attachments/assets/51099a20-0c84-4ea4-bd67-70d41d588894" />

Fix #33