### PR TITLE
Msgpack uses special vim.NIL value and it causes exception in edit code handling

### DIFF
--- a/lua/agentic/acp/adapters/codex_acp_adapter.lua
+++ b/lua/agentic/acp/adapters/codex_acp_adapter.lua
@@ -113,7 +113,8 @@ function CodexACPAdapter:__handle_tool_call_update(session_id, update)
         local content = update.content[1]
 
         if content.type == "content" then
-            message.body = vim.split(normalize_msgpack_string(content.content.text), "\n")
+            local content_inner = type(content.content) == "table" and content.content or nil
+            message.body = vim.split(normalize_msgpack_string(content_inner and content_inner.text), "\n")
         elseif content.type == "diff" then
             -- ignore, already handled in tool call, we don't want to rerender diffs, as they don't change during updates
         else


### PR DESCRIPTION
With codex edit actions triggers following error:

```
Error executing callback:
vim/shared.lua:0: s: expected string, got userdata
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        vim/shared.lua: in function 'gsplit'
        vim/shared.lua: in function 'split'
        ...ntic.nvim/lua/agentic/acp/adapters/codex_acp_adapter.lua:63: in function '__handle_tool_call'
        ...re/nvim/lazy/agentic.nvim/lua/agentic/acp/acp_client.lua:300: in function '__handle_session_update'
        ...re/nvim/lazy/agentic.nvim/lua/agentic/acp/acp_client.lua:268: in function '_handle_notification'
        ...re/nvim/lazy/agentic.nvim/lua/agentic/acp/acp_client.lua:244: in function '_handle_message'
        ...re/nvim/lazy/agentic.nvim/lua/agentic/acp/acp_client.lua:114: in function 'on_message'
        ...nvim/lazy/agentic.nvim/lua/agentic/acp/acp_transport.lua:197: in function <...nvim/lazy/agentic.nvim/lua/agentic/acp/acp_transport.lua:178>
```
My fix compares returned text values with vim.NIL constant.