### PR TITLE
refactor(acp): dedupe tool call handling into base ACPClient

### DIFF
--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -7,7 +7,26 @@ CRITICAL: Type annotations in this file are essential for Lua Language Server su
 DO NOT REMOVE them. Only update them if the underlying types change.
 --]]
 
---- @class agentic.acp.ACPClient
+--- Known ACP protocol tool call kinds.
+--- Used to detect unknown kinds from providers we don't use daily.
+local KNOWN_ACP_KINDS = {
+    read = true,
+    edit = true,
+    delete = true,
+    move = true,
+    search = true,
+    execute = true,
+    think = true,
+    fetch = true,
+    other = true,
+    create = true,
+    switch_mode = true,
+}
+
+--- Data fields set in the constructor. Separated from the full class
+--- so LuaLS validates instance fields without requiring methods that
+--- live on the prototype via __index.
+--- @class agentic.acp.ACPClientData
 --- @field provider_config agentic.acp.ACPProviderConfig
 --- @field id_counter number
 --- @field state agentic.acp.ClientConnectionState
@@ -18,9 +37,9 @@ DO NOT REMOVE them. Only update them if the underlying types change.
 --- @field callbacks table<number, fun(result: table|nil, err: agentic.acp.ACPError|nil)>
 --- @field transport? agentic.acp.ACPTransportInstance
 --- @field subscribers table<string, agentic.acp.ClientHandlers>
+
+--- @class agentic.acp.ACPClient : agentic.acp.ACPClientData
 --- @field _on_ready fun(client: agentic.acp.ACPClient)
---- @field __handle_tool_call? fun(self: agentic.acp.ACPClient, session_id: string, update: agentic.acp.ToolCallMessage) Protected method to allow for overriding in adapters
---- @field __handle_tool_call_update? fun(self: agentic.acp.ACPClient, session_id: string, update: agentic.acp.ToolCallUpdate) Protected method to allow for overriding in adapters
 local ACPClient = {}
 ACPClient.__index = ACPClient
 
@@ -39,7 +58,7 @@ ACPClient.ERROR_CODES = {
 --- @param on_ready fun(client: agentic.acp.ACPClient)
 --- @return agentic.acp.ACPClient
 function ACPClient:new(config, on_ready)
-    --- @type agentic.acp.ACPClient
+    --- @type agentic.acp.ACPClientData
     local instance = {
         provider_config = config,
         subscribers = {},
@@ -60,10 +79,10 @@ function ACPClient:new(config, on_ready)
         transport = nil,
         state = "disconnected",
         reconnect_count = 0,
-        _on_ready = on_ready,
     }
 
-    local client = setmetatable(instance, self)
+    local client = setmetatable(instance, self) --[[@as agentic.acp.ACPClient]]
+    client._on_ready = on_ready
 
     client:_setup_transport()
     client:_connect()
@@ -296,18 +315,99 @@ function ACPClient:__handle_session_update(params)
 
     local session_update_type = update.sessionUpdate
 
-    if session_update_type == "tool_call" and self.__handle_tool_call then
+    if session_update_type == "tool_call" then
+        if not KNOWN_ACP_KINDS[update.kind] then
+            -- Using notify intentionally so users of providers
+            -- we don't use daily report unknown kinds as issues
+            Logger.notify(
+                "Unknown ACP tool call kind: "
+                    .. tostring(update.kind)
+                    .. "\n\n"
+                    .. "Please report this so we can add support for it!\n\n"
+                    .. "https://github.com/carlos-algms/agentic.nvim/issues/new",
+                vim.log.levels.WARN
+            )
+        end
+
         self:__handle_tool_call(session_id, update)
-    elseif
-        session_update_type == "tool_call_update"
-        and self.__handle_tool_call_update
-    then
+    elseif session_update_type == "tool_call_update" then
         self:__handle_tool_call_update(session_id, update)
     else
         self:__with_subscriber(session_id, function(subscriber)
             subscriber.on_session_update(update)
         end)
     end
+end
+
+--- Extract body text from standard ACP content field.
+--- Adapters should use this to avoid duplicating content extraction logic.
+--- @param update agentic.acp.ToolCallMessage|agentic.acp.ToolCallUpdate
+--- @return string[]|nil body
+function ACPClient:extract_content_body(update)
+    local content = update.content and update.content[1]
+
+    if
+        content
+        and content.type == "content"
+        and content.content
+        and content.content.text
+    then
+        return vim.split(content.content.text, "\n")
+    end
+
+    return nil
+end
+
+--- Default handler for tool_call session updates.
+--- Builds a generic ToolCallBlock from standard ACP fields.
+--- Adapters override this for provider-specific transformations.
+--- @protected
+--- @param session_id string
+--- @param update agentic.acp.ToolCallMessage
+function ACPClient:__handle_tool_call(session_id, update)
+    --- @type agentic.ui.MessageWriter.ToolCallBlock
+    local message = {
+        tool_call_id = update.toolCallId,
+        kind = update.kind,
+        status = update.status,
+        argument = update.title,
+        body = self:extract_content_body(update),
+    }
+
+    self:__with_subscriber(session_id, function(subscriber)
+        subscriber.on_tool_call(message)
+    end)
+end
+
+--- Build the message for a tool_call_update.
+--- Adapters override this to add provider-specific fields.
+--- @protected
+--- @param update agentic.acp.ToolCallUpdate
+--- @return agentic.ui.MessageWriter.ToolCallBase message
+function ACPClient:__build_tool_call_update(update)
+    --- @type agentic.ui.MessageWriter.ToolCallBase
+    local message = {
+        tool_call_id = update.toolCallId,
+        status = update.status,
+        body = self:extract_content_body(update),
+    }
+    return message
+end
+
+--- Default handler for tool_call_update session updates.
+--- @protected
+--- @param session_id string
+--- @param update agentic.acp.ToolCallUpdate
+function ACPClient:__handle_tool_call_update(session_id, update)
+    if not update.status then
+        return
+    end
+
+    local message = self:__build_tool_call_update(update)
+
+    self:__with_subscriber(session_id, function(subscriber)
+        subscriber.on_tool_call_update(message)
+    end)
 end
 
 --- @protected

--- a/lua/agentic/acp/adapters/auggie_acp_adapter.lua
+++ b/lua/agentic/acp/adapters/auggie_acp_adapter.lua
@@ -1,6 +1,5 @@
 local ACPClient = require("agentic.acp.acp_client")
 local FileSystem = require("agentic.utils.file_system")
-local Logger = require("agentic.utils.logger")
 
 --- Auggie-specific adapter that extends ACPClient with Auggie-specific behaviors
 --- @class agentic.acp.AuggieACPAdapter : agentic.acp.ACPClient
@@ -80,44 +79,6 @@ function AuggieACPAdapter:__handle_tool_call(session_id, update)
 
     self:__with_subscriber(session_id, function(subscriber)
         subscriber.on_tool_call(message)
-    end)
-end
-
---- @protected
---- @param session_id string
---- @param update agentic.acp.ToolCallUpdate
-function AuggieACPAdapter:__handle_tool_call_update(session_id, update)
-    if not update.status then
-        return
-    end
-
-    --- @type agentic.ui.MessageWriter.ToolCallBase
-    local message = {
-        tool_call_id = update.toolCallId,
-        status = update.status,
-    }
-
-    if update.content and update.content[1] then
-        local content = update.content[1]
-
-        if
-            content.type == "content"
-            and content.content
-            and content.content.text
-        then
-            message.body = vim.split(content.content.text, "\n")
-        else
-            Logger.debug("Unknown tool call update content type", {
-                content_type = content.type,
-                content = content.content,
-                session_id = session_id,
-                tool_call_id = update.toolCallId,
-            })
-        end
-    end
-
-    self:__with_subscriber(session_id, function(subscriber)
-        subscriber.on_tool_call_update(message)
     end)
 end
 

--- a/lua/agentic/acp/adapters/claude_acp_adapter.lua
+++ b/lua/agentic/acp/adapters/claude_acp_adapter.lua
@@ -1,6 +1,5 @@
 local ACPClient = require("agentic.acp.acp_client")
 local FileSystem = require("agentic.utils.file_system")
-local Logger = require("agentic.utils.logger")
 
 --- @class agentic.acp.ClaudeRawInput : agentic.acp.RawInput
 --- @field content? string For creating new files instead of new_string
@@ -117,50 +116,11 @@ function ClaudeACPAdapter:__handle_tool_call(session_id, update)
         end
 
         message.argument = command or update.title or ""
+        message.body = self:extract_content_body(update)
     end
 
     self:__with_subscriber(session_id, function(subscriber)
         subscriber.on_tool_call(message)
-    end)
-end
-
---- @protected
---- @param session_id string
---- @param update agentic.acp.ToolCallUpdate
-function ClaudeACPAdapter:__handle_tool_call_update(session_id, update)
-    if not update.status then
-        return
-    end
-
-    --- @type agentic.ui.MessageWriter.ToolCallBase
-    local message = {
-        tool_call_id = update.toolCallId,
-        status = update.status,
-    }
-
-    if update.content and update.content[1] then
-        local content = update.content[1]
-
-        if
-            content.type == "content"
-            and content.content
-            and content.content.text
-        then
-            message.body = vim.split(content.content.text, "\n")
-        elseif content.type == "diff" then
-            -- ignore on purpose, diffs come only on tool call, not updates
-        else
-            Logger.debug("Unknown tool call update content type", {
-                content_type = content.type,
-                content = content.content,
-                session_id = session_id,
-                tool_call_id = update.toolCallId,
-            })
-        end
-    end
-
-    self:__with_subscriber(session_id, function(subscriber)
-        subscriber.on_tool_call_update(message)
     end)
 end
 

--- a/lua/agentic/acp/adapters/codex_acp_adapter.lua
+++ b/lua/agentic/acp/adapters/codex_acp_adapter.lua
@@ -1,6 +1,5 @@
 local ACPClient = require("agentic.acp.acp_client")
 local FileSystem = require("agentic.utils.file_system")
-local Logger = require("agentic.utils.logger")
 
 --- @class agentic.acp.CodexParsedCommand
 --- @field cmd? string
@@ -84,40 +83,16 @@ function CodexACPAdapter:__handle_tool_call(session_id, update)
 end
 
 --- @protected
---- @param session_id string
 --- @param update agentic.acp.ToolCallUpdate
-function CodexACPAdapter:__handle_tool_call_update(session_id, update)
-    if not update.status then
-        return
-    end
+--- @return agentic.ui.MessageWriter.ToolCallBase message
+function CodexACPAdapter:__build_tool_call_update(update)
+    local message = ACPClient.__build_tool_call_update(self, update)
 
-    --- @type agentic.ui.MessageWriter.ToolCallBase
-    local message = {
-        tool_call_id = update.toolCallId,
-        status = update.status,
-    }
-
-    if update.content and update.content[1] then
-        local content = update.content[1]
-
-        if content.type == "content" then
-            message.body = vim.split(content.content.text, "\n")
-        elseif content.type == "diff" then
-            -- ignore, already handled in tool call, we don't want to rerender diffs, as they don't change during updates
-        else
-            Logger.debug(
-                "Unknown tool call update content type: "
-                    ---@diagnostic disable-next-line: undefined-field -- it's expected this to be unknown
-                    .. tostring(content.type)
-            )
-        end
-    elseif update.rawOutput then
+    if not message.body and update.rawOutput then
         message.body = vim.split(update.rawOutput.formatted_output or "", "\n")
     end
 
-    self:__with_subscriber(session_id, function(subscriber)
-        subscriber.on_tool_call_update(message)
-    end)
+    return message
 end
 
 return CodexACPAdapter

--- a/lua/agentic/acp/adapters/cursor_acp_adapter.lua
+++ b/lua/agentic/acp/adapters/cursor_acp_adapter.lua
@@ -93,25 +93,4 @@ function CursorACPAdapter:__handle_tool_call(session_id, update)
     end)
 end
 
---- @protected
---- @param session_id string
---- @param update agentic.acp.ToolCallUpdate
-function CursorACPAdapter:__handle_tool_call_update(session_id, update)
-    if not update.status then
-        return
-    end
-
-    --- @type agentic.ui.MessageWriter.ToolCallBase
-    local message = {
-        tool_call_id = update.toolCallId,
-        status = update.status,
-    }
-
-    -- TODO: implement Cursor-agent tool call updates
-
-    self:__with_subscriber(session_id, function(subscriber)
-        subscriber.on_tool_call_update(message)
-    end)
-end
-
 return CursorACPAdapter

--- a/lua/agentic/acp/adapters/gemini_acp_adapter.lua
+++ b/lua/agentic/acp/adapters/gemini_acp_adapter.lua
@@ -74,30 +74,6 @@ function GeminiACPAdapter:__handle_tool_call(session_id, update)
     end)
 end
 
---- @protected
---- @param session_id string
---- @param update agentic.acp.ToolCallUpdate
-function GeminiACPAdapter:__handle_tool_call_update(session_id, update)
-    --- @type agentic.ui.MessageWriter.ToolCallBase
-    local message = {
-        tool_call_id = update.toolCallId,
-        status = update.status,
-    }
-
-    if update.content and update.content[1] then
-        local content = update.content[1]
-
-        if content.type == "content" then
-            message.body = content.content
-                and vim.split(content.content.text, "\n")
-        end
-    end
-
-    self:__with_subscriber(session_id, function(subscriber)
-        subscriber.on_tool_call_update(message)
-    end)
-end
-
 --- Specific Gemini ToolCall structure - created to avoid confusion with the standard ACP types, as only Gemini sends these fields
 --- @class agentic.acp.GeminiToolCall : agentic.acp.ToolCall
 --- @field kind? agentic.acp.ToolKind

--- a/lua/agentic/acp/adapters/opencode_acp_adapter.lua
+++ b/lua/agentic/acp/adapters/opencode_acp_adapter.lua
@@ -88,12 +88,7 @@ function OpenCodeACPAdapter:__handle_tool_call_update(session_id, update)
     end
 
     if update.status == "completed" or update.status == "failed" then
-        if update.content and update.content[1] then
-            local content = update.content[1].content
-            if content and content.text then
-                message.body = vim.split(content.text, "\n")
-            end
-        end
+        message.body = self:extract_content_body(update)
     else
         if update.rawInput then
             if update.rawInput.newString then

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -432,17 +432,6 @@ function MessageWriter:_prepare_block_lines(tool_call_block)
 
             table.insert(highlight_ranges, range)
         end
-    elseif
-        kind == "fetch"
-        or kind == "WebSearch"
-        or kind == "execute"
-        or kind == "search"
-        or kind == "SubAgent"
-        or kind == "Skill"
-    then
-        if tool_call_block.body then
-            vim.list_extend(lines, tool_call_block.body)
-        end
     elseif tool_call_block.diff then
         local diff_blocks = ToolCallDiff.extract_diff_blocks({
             path = argument,
@@ -541,7 +530,9 @@ function MessageWriter:_prepare_block_lines(tool_call_block)
             table.insert(lines, "```")
         end
     else
-        Logger.debug("Unknown tool call kind or missing diff: " .. kind)
+        if tool_call_block.body then
+            vim.list_extend(lines, tool_call_block.body)
+        end
     end
 
     table.insert(lines, "")


### PR DESCRIPTION
- Simplify _prepare_block_lines by removing hardcoded kind list; default else branch shows body content for any kind
- Add extract_content_body() to base ACPClient for standard ACP content extraction, replacing 5 duplicate implementations
- Add base __handle_tool_call and __handle_tool_call_update with __build_tool_call_update hook for adapter customization
- Add KNOWN_ACP_KINDS table with unknown kind notification
- Fix switch_mode tool calls showing empty body by extracting content in Claude adapter's else block
- Split ACPClientData from ACPClient class for proper LuaLS field validation without suppressing missing-fields diagnostic