### PR TITLE
fix(opencode): skill, read, and web search tool calls format

### DIFF
--- a/lua/agentic/acp/adapters/opencode_acp_adapter.lua
+++ b/lua/agentic/acp/adapters/opencode_acp_adapter.lua
@@ -39,7 +39,7 @@ function OpenCodeACPAdapter:__handle_tool_call(session_id, update)
         -- hack to keep consistency with other Providers
         -- OpenCode uses `read`, and the message writer will omit it's output if we kept this as read.
         message.kind = "search"
-    elseif update.title == "websearch" then
+    elseif update.title == "websearch" or update.title == "google_search" then
         message.kind = "WebSearch"
     elseif update.title == "task" then
         -- rawInput is empty in tool_call, only populated in tool_call_update
@@ -123,6 +123,7 @@ function OpenCodeACPAdapter:__handle_tool_call_update(session_id, update)
             elseif update.rawInput.url then -- fetch command
                 message.argument = update.rawInput.url
             elseif update.rawInput.query then -- WebSearch command
+                message.argument = update.rawInput.query
                 message.body = vim.split(update.rawInput.query, "\n")
             elseif update.rawInput.command then
                 message.argument = update.rawInput.command


### PR DESCRIPTION
## Summary
- Handle OpenCode `skill` tool call kind, displaying skill name as the argument
- Fix `read` tool call to show file path via `FileSystem.to_smart_path`
- Fix `websearch` and `google_search` mapped to same `WebSearch` kind (merged duplicate `elseif` branches)
- Fix `google_search` argument showing tool name instead of query; set `argument` from `rawInput.query` on update
- Avoid showing redundant title when it matches the kind