### PR TITLE
fix(codex): default missing status and distinguish WebSearch from fetch

### DIFF
--- a/lua/agentic/acp/adapters/codex_acp_adapter.lua
+++ b/lua/agentic/acp/adapters/codex_acp_adapter.lua
@@ -51,7 +51,7 @@ function CodexACPAdapter:__handle_tool_call(session_id, update)
     local message = {
         tool_call_id = update.toolCallId,
         kind = kind,
-        status = update.status or "pending...",
+        status = update.status or "pending",
         argument = update.title or "unknown codex command",
     }
 


### PR DESCRIPTION
## Summary
- Default status to `"pending..."` when Codex omits it in initial `tool_call`
- Detect `action.type` in `tool_call_update` to set correct kind: `"search"` → `WebSearch`, `"open_page"` → `fetch`
- Extract query/URL from `rawInput.action` for proper argument display