### PR TITLE
feat(ui): Don't apply Comment highlight to Plans and switch_mode

### DIFF
--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -675,7 +675,7 @@ function MessageWriter:_apply_block_highlights(
 )
     if #highlight_ranges > 0 then
         self:_apply_diff_highlights(start_row, highlight_ranges)
-    elseif kind ~= "edit" then
+    elseif kind ~= "edit" and kind ~= "switch_mode" then
         -- Apply Comment highlight for non-edit blocks without diffs
         for line_idx = start_row + 1, end_row - 1 do
             local line = vim.api.nvim_buf_get_lines(


### PR DESCRIPTION
When the agent wants to switch from plan-mode to editing, it sends the whole plan along with the permission request. 

It's easier to read if it's not highlighted as a comment, but normal Markdown. 