### PR TITLE
change sample key-bindings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,13 +170,13 @@ tools like `nvm`, `fnm`, etc...
       desc = "Toggle Agentic Chat"
     },
     {
-      "<C-'>",
+      "<M-'>",
       function() require("agentic").add_selection_or_file_to_context() end,
       mode = { "n", "v" },
       desc = "Add file or selection to Agentic to Context"
     },
     {
-      "<C-,>",
+      "<M-,>",
       function() require("agentic").new_session() end,
       mode = { "n", "v", "i" },
       desc = "New Agentic Session"


### PR DESCRIPTION
Many terminals don't pass <Ctrl + punctuation> to nvim, changed them to <Alt + punctuation>