### PR TITLE
fix: add default value `other` to `kind` when not specified in tool_call

### DIFF
--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -321,6 +321,8 @@ function ACPClient:__handle_session_update(params)
     end
 
     if session_update_type == "tool_call" then
+        -- kind is optional and has default value
+        update.kind = update.kind or "other"
         if not KNOWN_ACP_KINDS[update.kind] then
             -- Using notify intentionally so users of providers
             -- we don't use daily report unknown kinds as issues


### PR DESCRIPTION
`codex-acp` may not always send a kind in `tool_call` notification especially for dynamic tool calling. The ACP spec also states (see https://agentclientprotocol.com/protocol/tool-calls) `kind` as optional with default value "other". 

This one liner fix just avoids unnecessary error popups about "Unknown ACP tool call kind".

Tested locally.