### PR TITLE
Add theme support by linking custom highlight groups to commonly defined groups

### DIFF
--- a/lua/agentic/theme.lua
+++ b/lua/agentic/theme.lua
@@ -22,21 +22,6 @@ Theme.HL_GROUPS = {
     SPINNER_BUSY = "AgenticSpinnerBusy",
 }
 
-local COLORS = {
-    diff_delete_word_bg = "#9a3c3c",
-    diff_add_word_bg = "#155729",
-    status_pending_bg = "#5f4d8f",
-    status_completed_bg = "#2d5a3d",
-    status_failed_bg = "#7a2d2d",
-
-    title_bg = "#2787b0",
-    title_fg = "#000000",
-
-    spinner_generating_fg = "#61afef",
-    spinner_thinking_fg = "#c678dd",
-    spinner_searching_fg = "#e5c07b",
-}
-
 --- A lang map of extension to language identifier for markdown code fences
 --- Keep only possible unknown mappings
 local lang_map = {
@@ -72,22 +57,23 @@ function Theme.setup()
         -- Diff highlights
         { Theme.HL_GROUPS.DIFF_DELETE, { link = "DiffDelete" } },
         { Theme.HL_GROUPS.DIFF_ADD, { link = "DiffAdd" } },
-        { Theme.HL_GROUPS.DIFF_DELETE_WORD, { bg = COLORS.diff_delete_word_bg, bold = true } },
-        { Theme.HL_GROUPS.DIFF_ADD_WORD, { bg = COLORS.diff_add_word_bg, bold = true } },
+        -- TODO: Add better link for these two groups
+        { Theme.HL_GROUPS.DIFF_DELETE_WORD, { link = "DiffDelete", bold = true } },
+        { Theme.HL_GROUPS.DIFF_ADD_WORD, { link = "DiffAdd", bold = true } },
 
         -- Status highlights
-        { Theme.HL_GROUPS.STATUS_PENDING, { bg = COLORS.status_pending_bg } },
-        { Theme.HL_GROUPS.STATUS_COMPLETED, { bg = COLORS.status_completed_bg } },
-        { Theme.HL_GROUPS.STATUS_FAILED, { bg = COLORS.status_failed_bg } },
+        { Theme.HL_GROUPS.STATUS_PENDING, { link = "InfoFloat" } },
+        { Theme.HL_GROUPS.STATUS_COMPLETED, { link = "OkFloat" } },
+        { Theme.HL_GROUPS.STATUS_FAILED, { link = "ErrorFloat" } },
         { Theme.HL_GROUPS.CODE_BLOCK_FENCE, { link = "Directory" } },
 
         -- Title highlight
-        { Theme.HL_GROUPS.WIN_BAR_TITLE, { bg = COLORS.title_bg, fg = COLORS.title_fg, bold = true } },
+        { Theme.HL_GROUPS.WIN_BAR_TITLE, { link = "Title", bold = true } },
 
         -- Spinner highlights
-        { Theme.HL_GROUPS.SPINNER_GENERATING, { fg = COLORS.spinner_generating_fg, bold = true } },
-        { Theme.HL_GROUPS.SPINNER_THINKING, { fg = COLORS.spinner_thinking_fg, bold = true } },
-        { Theme.HL_GROUPS.SPINNER_SEARCHING, { fg = COLORS.spinner_searching_fg, bold = true } },
+        { Theme.HL_GROUPS.SPINNER_GENERATING, { link = "Constant", bold = true } },
+        { Theme.HL_GROUPS.SPINNER_THINKING, { link = "Float", bold = true } },
+        { Theme.HL_GROUPS.SPINNER_SEARCHING, { link = "Structure", bold = true } },
         { Theme.HL_GROUPS.SPINNER_BUSY, { link = "Comment" } },
     }
     -- stylua: ignore end


### PR DESCRIPTION
I noticed some color mismatches between the plugin and my theme and wanted to see if there was a way to get the two to conform. I ended up getting rid of the custom colors and linking the custom groups to commonly defined highlight groups.

I know many themes add custom support for highlight groups, and this possibility still exists, but in the short term at least this should help the plugin conform thematically to each users theme!

As far as the particular groups I chose, I was looking at my [themes source code](https://github.com/sainnhe/gruvbox-material/blob/master/colors/gruvbox-material.vim) and did my best to choose generic groups with similar colors to the ones specified, but I'm sure it's not perfect.

Let me know what you think and if there's anything I need to change!

| Before  | After |
| ------------- | ------------- |
| <img width="1512" height="982" alt="before Screenshot 2026-03-17 at 8 42 16 PM" src="https://github.com/user-attachments/assets/14a83915-77d0-4a6b-b4a9-c0933a611c6e" /> | <img width="1501" height="981" alt="Screenshot 2026-03-17 at 8 52 23 PM" src="https://github.com/user-attachments/assets/9811f50e-a56c-4556-8126-3ce3ae36cd97" />  |
| <img width="1512" height="982" alt="before Screenshot 2026-03-17 at 8 59 27 PM" src="https://github.com/user-attachments/assets/e8958817-9406-4e86-a9e9-6f2a671d995c" /> | <img width="1512" height="982" alt="Screenshot 2026-03-17 at 8 57 54 PM" src="https://github.com/user-attachments/assets/32284cf9-eff3-4adc-9384-a262a1777119" />  |
