### PR TITLE
feat: Add on_session_update hook for ACP session updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,6 +698,23 @@ integrating with other plugins.
           vim.notify("Agent error: " .. vim.inspect(data.error), vim.log.levels.ERROR)
         end
       end,
+
+      -- Called when the session is updated.
+      on_session_update = function(data)
+        -- data.session_id: string - The ACP session ID
+        -- data.tab_page_id: number - The Neovim tabpage ID
+        -- data.update: table -- The update
+
+          if data.update.sessionUpdate == "usage_update" then
+            -- Use this in your status line, scoped per tab/session.
+            if vim.api.nvim_tabpage_is_valid(data.tab_page_id) then
+              vim.t[data.tab_page_id].agentic_usage = {
+                used = data.update.used,
+                size = data.update.size,
+              }
+            end
+          end
+      end
     }
   }
 }

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -25,10 +25,17 @@
 --- @field tab_page_id number The tabpage ID
 --- @field success boolean Whether response completed without error
 --- @field error? table Error details if failed
+---
+--- Data passed to the on_session_update hook
+--- @class agentic.UserConfig.SessionUpdateData
+--- @field session_id string The ACP session ID
+--- @field tab_page_id number The tabpage ID
+--- @field update agentic.acp.SessionUpdateMessage ACP session update details.
 
 --- @class agentic.UserConfig.Hooks
 --- @field on_prompt_submit? fun(data: agentic.UserConfig.PromptSubmitData): nil
 --- @field on_response_complete? fun(data: agentic.UserConfig.ResponseCompleteData): nil
+--- @field on_session_update? fun(data: agentic.UserConfig.SessionUpdateData): nil
 
 --- @class agentic.UserConfig.KeymapEntry
 --- @field [1] string The key binding
@@ -293,6 +300,7 @@ local ConfigDefault = {
     hooks = {
         on_prompt_submit = nil,
         on_response_complete = nil,
+        on_session_update = nil,
     },
 
     --- Customize window headers for each panel in the chat widget.

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -27,7 +27,7 @@ local FILE_MUTATING_KINDS = {
 }
 
 --- Safely invoke a user-configured hook
---- @param hook_name "on_prompt_submit" | "on_response_complete"
+--- @param hook_name "on_prompt_submit" | "on_response_complete" | "on_session_update"
 --- @param data table
 function P.invoke_hook(hook_name, data)
     local hook = Config.hooks and Config.hooks[hook_name]
@@ -255,6 +255,14 @@ function SessionManager:_on_session_update(update)
             { title = "⚠️ Unknown session update" }
         )
     end
+
+    -- This is being done after handling specific updates but one could argue
+    -- there should be pre/post hooks for everything.
+    P.invoke_hook("on_session_update", {
+        session_id = self.session_id,
+        tab_page_id = self.tab_page_id,
+        update = update,
+    })
 end
 
 --- Handle tool call update: update UI, history, diff preview, permissions, and reload buffers


### PR DESCRIPTION
Related: https://github.com/carlos-algms/agentic.nvim/issues/155

I'm successfully using this locally to display my context usage with claude code using the example provided with a custom lualine component.

I also tried integrating this directly into my agentic chat header, but the problem was that the chat widget header isn't updated until certain events happen, so I couldn't figure out a good way to tell it to re-render after my hook ran. I'll create a separate issue for that if this gets merged.