### PR TITLE
feat: Add support for scheduling header re-rendering

### DIFF
--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -64,6 +64,7 @@ end
 --- @field _is_restoring_session boolean
 --- @field _connection_error boolean
 --- @field _session_ready_callbacks fun()[]
+--- @field _header_refresh_scheduled boolean Guards coalesced header refresh
 local SessionManager = {}
 SessionManager.__index = SessionManager
 
@@ -118,6 +119,7 @@ function SessionManager:new(tab_page_id)
         _connection_error = false,
         history_to_send = nil,
         _session_ready_callbacks = {},
+        _header_refresh_scheduled = false,
     }, self)
 
     local agent = AgentInstance.get_instance(Config.provider, function(_client)
@@ -582,6 +584,29 @@ function SessionManager:_handle_model_change(model_id, is_legacy)
             callback
         )
     end
+end
+
+--- Schedule a coalesced re-render of function-based headers.
+--- Multiple calls within the same event loop tick collapse into one render.
+function SessionManager:schedule_header_refresh()
+    if self._header_refresh_scheduled then
+        return
+    end
+    if not Config.headers then
+        return
+    end
+
+    self._header_refresh_scheduled = true
+    -- Debounce updates within 150ms of each other to avoid excessive
+    -- re-renders when multiple updates come in quick succession
+    vim.defer_fn(function()
+        self._header_refresh_scheduled = false
+        for panel_name, header_config in pairs(Config.headers) do
+            if type(header_config) == "function" then
+                self.widget:render_header(panel_name)
+            end
+        end
+    end, 150)
 end
 
 --- @param mode_id string


### PR DESCRIPTION
Basically, hooks may need to trigger re-rendering of the different window headers if they're injecting new state that custom header functions will use. To do this efficiently, there should be a method on the session manager to refresh the headers efficiently so that hooks that run frequently don't cause excessive re-renders.

To this, I added a `schedule_header_refresh` method that hooks can use by getting the current session and calling it from with. For example:

```
on_session_update = function(data)
  local needs_refresh = false
  if data.update.sessionUpdate == "usage_update" then
    vim.t[data.tab_page_id].agentic_usage = data.update
    needs_refresh = true
  end
  if data.update.sessionUpdate == "config_option_update" then
    update_model_from_config(data.tab_page_id, data.update.configOptions)
    needs_refresh = true
  end

  if not needs_refresh then
    return
  end

  local SessionRegistry = require("agentic.session_registry")
  SessionRegistry.get_session_for_tab_page(data.tab_page_id, function(session)
    session.schedule_header_refresh()
  end)
end,
```