### PR TITLE
feat: add on_file_edit hook for post-write callbacks

### DIFF
--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -32,10 +32,18 @@
 --- @field tab_page_id number The tabpage ID
 --- @field update agentic.acp.SessionUpdateMessage ACP session update details.
 
+--- Data passed to the on_file_edit hook
+--- @class agentic.UserConfig.FileEditData
+--- @field filepath string Absolute path to the edited file
+--- @field session_id string The ACP session ID
+--- @field tab_page_id number The tabpage ID
+--- @field bufnr number|nil Buffer number if the file is loaded in a buffer
+
 --- @class agentic.UserConfig.Hooks
 --- @field on_prompt_submit? fun(data: agentic.UserConfig.PromptSubmitData): nil
 --- @field on_response_complete? fun(data: agentic.UserConfig.ResponseCompleteData): nil
 --- @field on_session_update? fun(data: agentic.UserConfig.SessionUpdateData): nil
+--- @field on_file_edit? fun(data: agentic.UserConfig.FileEditData): nil
 
 --- @class agentic.UserConfig.KeymapEntry
 --- @field [1] string The key binding
@@ -301,6 +309,7 @@ local ConfigDefault = {
         on_prompt_submit = nil,
         on_response_complete = nil,
         on_session_update = nil,
+        on_file_edit = nil,
     },
 
     --- Customize window headers for each panel in the chat widget.

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -27,7 +27,7 @@ local FILE_MUTATING_KINDS = {
 }
 
 --- Safely invoke a user-configured hook
---- @param hook_name "on_prompt_submit" | "on_response_complete" | "on_session_update"
+--- @param hook_name "on_prompt_submit" | "on_response_complete" | "on_session_update" | "on_file_edit"
 --- @param data table
 function P.invoke_hook(hook_name, data)
     local hook = Config.hooks and Config.hooks[hook_name]
@@ -299,6 +299,21 @@ function SessionManager:_on_tool_call_update(tool_call_update)
 
         if tracker and tracker.kind and FILE_MUTATING_KINDS[tracker.kind] then
             vim.cmd.checktime()
+
+            -- Invoke on_file_edit hook for file-mutating tool calls
+            local filepath = tracker.argument
+            if filepath then
+                local bufnr = vim.fn.bufnr(FileSystem.to_absolute_path(filepath))
+                if bufnr == -1 then
+                    bufnr = nil
+                end
+                P.invoke_hook("on_file_edit", {
+                    filepath = FileSystem.to_absolute_path(filepath),
+                    session_id = self.session_id,
+                    tab_page_id = self.widget.tabpage,
+                    bufnr = bufnr,
+                })
+            end
         end
     end
 


### PR DESCRIPTION
## Problem

The existing `on_response_complete` hook doesn't provide information about which files were modified. Users who want to auto-format, lint, or post-process edited files have no clean way to do so.

Current workaround requires tracking all buffer writes with BufWritePost autocmd, which captures non-Agentic writes too.

## Solution

Added new `on_file_edit` hook that fires after Agentic writes to a file:

```lua
hooks = {
  on_file_edit = function(data)
    -- data.filepath: Absolute path to edited file
    -- data.session_id: ACP session ID
    -- data.tab_page_id: Neovim tabpage ID
    -- data.bufnr: Buffer number if loaded

    vim.lsp.buf.format({ bufnr = data.bufnr, timeout_ms = 5000 })
  end,
}
```

## Validation

- Hook fires correctly after each file edit
- All data fields (filepath, session_id, tab_page_id, bufnr) are populated
- LSP formatting works as expected

Fixes #110