### PR TITLE
feat: move currently selected model to the head of the selector list

### DIFF
--- a/lua/agentic/acp/agent_config_options.lua
+++ b/lua/agentic/acp/agent_config_options.lua
@@ -1,6 +1,7 @@
 local BufHelpers = require("agentic.utils.buf_helpers")
 local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
+local List = require("agentic.utils.list")
 
 --- @class agentic.acp.AgentConfigOptions
 --- @field mode? agentic.acp.ConfigOption
@@ -246,7 +247,10 @@ function AgentConfigOptions:_show_selector(target, prompt, handle_change)
         return false
     end
 
-    vim.ui.select(target.options, {
+    local ordered_options =
+        List.move_to_head(target.options, "value", target.currentValue)
+
+    vim.ui.select(ordered_options, {
         prompt = prompt,
         format_item = function(item)
             --- @cast item agentic.acp.ConfigOption.Option -- need to cast because `select` has a Generic, but not for `format_item`

--- a/lua/agentic/acp/agent_models.lua
+++ b/lua/agentic/acp/agent_models.lua
@@ -2,6 +2,7 @@
 --- Provides model selection via vim.ui.select
 
 local Logger = require("agentic.utils.logger")
+local List = require("agentic.utils.list")
 
 --- @class agentic.acp.AgentModels
 --- @field _models agentic.acp.Model[]
@@ -44,7 +45,10 @@ function AgentModels:show_model_selector(set_model_callback)
         return false
     end
 
-    vim.ui.select(self._models, {
+    local ordered_models =
+        List.move_to_head(self._models, "modelId", self.current_model_id or "")
+
+    vim.ui.select(ordered_models, {
         prompt = "Select Model:",
         format_item = function(item)
             --- @cast item agentic.acp.Model

--- a/lua/agentic/config_selector.test.lua
+++ b/lua/agentic/config_selector.test.lua
@@ -75,11 +75,11 @@ describe("config selector", function()
             local first_render = {}
             select_stub:invokes(function(items, opts, on_choice)
                 first_render = format_all(items, opts)
-                on_choice(items[1]) -- select m1
+                on_choice(items[2]) -- select m1
             end)
             config:show_model_selector(handle_model_change)
 
-            assert.same({ "  M1", "● M2" }, first_render)
+            assert.same({ "● M2", "  M1" }, first_render)
 
             -- Re-open to verify it was updated
             local second_render = {}
@@ -129,7 +129,7 @@ describe("config selector", function()
             end)
             session.config_options:show_model_selector(function() end)
 
-            assert.same({ "  M1: D1", "● M2: D2" }, first_render)
+            assert.same({ "● M2: D2", "  M1: D1" }, first_render)
 
             -- Call the REAL _handle_model_change
             ---@diagnostic disable-next-line: invisible

--- a/lua/agentic/utils/list.lua
+++ b/lua/agentic/utils/list.lua
@@ -1,0 +1,24 @@
+--- @class agentic.utils.list
+local M = {}
+
+--- Moves an item where item[key] == value to the head of a copy of the list.
+--- @param items table[] Original array of tables
+--- @param key string The key to match against
+--- @param value any The value to find
+--- @return table[] ordered_items New shallow copy of the list with the item at head
+function M.move_to_head(items, key, value)
+    -- Create a shallow copy to avoid mutating the original array
+    local ordered_items = vim.list_extend({}, items)
+
+    for i, item in ipairs(ordered_items) do
+        if item[key] == value then
+            table.remove(ordered_items, i)
+            table.insert(ordered_items, 1, item)
+            break
+        end
+    end
+
+    return ordered_items
+end
+
+return M


### PR DESCRIPTION
Adds a new List utility to handle array reordering and updates both modern and legacy model selectors to display the active model first.

Discussed here https://github.com/carlos-algms/agentic.nvim/pull/149#issuecomment-4096361733