### PR TITLE
feat(message_icons): make message icons overridable and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,6 +874,97 @@ You can customize the icons used for diagnostics in the context panel:
 Default icons use emoji characters (❌, ⚠️, ℹ️, ✨) but you can use any string,
 including Nerd Font icons or plain text.
 
+### Customizing Status Icons
+
+You can customize the icons used to indicate tool call status in the chat:
+
+```lua
+{
+  "carlos-algms/agentic.nvim",
+  opts = {
+    status_icons = {
+      pending = "󰔛",
+      in_progress = "󰔛",
+      completed = "✔",
+      failed = "",
+    },
+  },
+}
+```
+
+- `pending`: Tool call awaiting execution
+- `in_progress`: Tool currently executing
+- `completed`: Tool executed successfully
+- `failed`: Tool execution failed
+
+### Customizing Permission Icons
+
+You can customize the icons used in the permission approval workflow:
+
+```lua
+{
+  "carlos-algms/agentic.nvim",
+  opts = {
+    permission_icons = {
+      allow_once = "",
+      allow_always = "",
+      reject_once = "",
+      reject_always = "󰜺",
+    },
+  },
+}
+```
+
+- `allow_once`: Allow this execution only
+- `allow_always`: Allow all future executions
+- `reject_once`: Reject this execution only
+- `reject_always`: Reject all future executions
+
+### Customizing Chat Icons
+
+You can customize the icons used to identify user and agent messages in the chat:
+
+```lua
+{
+  "carlos-algms/agentic.nvim",
+  opts = {
+    chat_icons = {
+      user = " ",
+      agent = "󱚠 ",
+    },
+  },
+}
+```
+
+- `user`: Icon shown for user messages
+- `agent`: Icon shown for agent/AI messages
+
+### Customizing Message Icons
+
+You can customize the icons used for messages and interaction states:
+
+```lua
+{
+  "carlos-algms/agentic.nvim",
+  opts = {
+    message_icons = {
+      thinking = "🧠",
+      finished = "🏁",
+      stopped = "🛑",
+      error = "❌",
+    },
+  },
+}
+```
+
+- `thinking`: Shown when the agent is thinking/reasoning
+- `finished`: Shown when the interaction completes successfully
+- `stopped`: Shown when the user cancels the generation
+- `error`: Shown when the interaction ends with an error
+
+Default icons use emoji characters but you can use any string, including Nerd
+Font icons or plain text.
+
 ## Integration with other Plugins
 
 ### Prompt suggestions with Copilot

--- a/README.md
+++ b/README.md
@@ -862,10 +862,10 @@ You can customize the icons used for diagnostics in the context panel:
   "carlos-algms/agentic.nvim",
   opts = {
     diagnostic_icons = {
-      error = "❌",
-      warn = "⚠️",
-      info = "ℹ️",
-      hint = "✨",
+      error = "❌",    -- Diagnostic severity: error
+      warn = "⚠️",     -- Diagnostic severity: warning
+      info = "ℹ️",      -- Diagnostic severity: information
+      hint = "✨",     -- Diagnostic severity: hint
     },
   },
 }
@@ -883,19 +883,14 @@ You can customize the icons used to indicate tool call status in the chat:
   "carlos-algms/agentic.nvim",
   opts = {
     status_icons = {
-      pending = "󰔛",
-      in_progress = "󰔛",
-      completed = "✔",
-      failed = "",
+      pending = "󰔛",      -- Tool call awaiting execution
+      in_progress = "󰔛",  -- Tool currently executing
+      completed = "✔",    -- Tool executed successfully
+      failed = "",       -- Tool execution failed
     },
   },
 }
 ```
-
-- `pending`: Tool call awaiting execution
-- `in_progress`: Tool currently executing
-- `completed`: Tool executed successfully
-- `failed`: Tool execution failed
 
 ### Customizing Permission Icons
 
@@ -906,19 +901,14 @@ You can customize the icons used in the permission approval workflow:
   "carlos-algms/agentic.nvim",
   opts = {
     permission_icons = {
-      allow_once = "",
-      allow_always = "",
-      reject_once = "",
-      reject_always = "󰜺",
+      allow_once = "",    -- Allow this execution only
+      allow_always = "",  -- Allow all future executions
+      reject_once = "",    -- Reject this execution only
+      reject_always = "󰜺",  -- Reject all future executions
     },
   },
 }
 ```
-
-- `allow_once`: Allow this execution only
-- `allow_always`: Allow all future executions
-- `reject_once`: Reject this execution only
-- `reject_always`: Reject all future executions
 
 ### Customizing Chat Icons
 
@@ -929,15 +919,12 @@ You can customize the icons used to identify user and agent messages in the chat
   "carlos-algms/agentic.nvim",
   opts = {
     chat_icons = {
-      user = " ",
-      agent = "󱚠 ",
+      user = " ",    -- Icon shown for user messages
+      agent = "󱚠 ",  -- Icon shown for agent/AI messages
     },
   },
 }
 ```
-
-- `user`: Icon shown for user messages
-- `agent`: Icon shown for agent/AI messages
 
 ### Customizing Message Icons
 
@@ -948,22 +935,14 @@ You can customize the icons used for messages and interaction states:
   "carlos-algms/agentic.nvim",
   opts = {
     message_icons = {
-      thinking = "🧠",
-      finished = "🏁",
-      stopped = "🛑",
-      error = "❌",
+      thinking = "🧠",   -- Shown when the agent is thinking/reasoning
+      finished = "🏁",   -- Shown when the interaction completes successfully
+      stopped = "🛑",     -- Shown when the user cancels the generation
+      error = "❌",      -- Shown when the interaction ends with an error
     },
   },
 }
 ```
-
-- `thinking`: Shown when the agent is thinking/reasoning
-- `finished`: Shown when the interaction completes successfully
-- `stopped`: Shown when the user cancels the generation
-- `error`: Shown when the interaction ends with an error
-
-Default icons use emoji characters but you can use any string, including Nerd
-Font icons or plain text.
 
 ## Integration with other Plugins
 
@@ -1142,8 +1121,7 @@ the the acknowledgments 😊.
   and sidebar structured with multiple panels
 
 [claude-agent-acp]: https://github.com/agentclientprotocol/claude-agent-acp
-[claude-agent-acp-releases]:
-  https://github.com/agentclientprotocol/claude-agent-acp/releases
+[claude-agent-acp-releases]: https://github.com/agentclientprotocol/claude-agent-acp/releases
 [gemini-cli]: https://github.com/gemini-cli/gemini-cli
 [codex-acp]: https://github.com/zed-industries/codex-acp
 [codex-acp-releases]: https://github.com/zed-industries/codex-acp/releases
@@ -1153,10 +1131,8 @@ the the acknowledgments 😊.
 [auggie-docs]: https://docs.augmentcode.com/cli/setup-auggie
 [mistral-vibe]: https://github.com/mistralai/mistral-vibe
 [mistral-vibe-releases]: https://github.com/mistralai/mistral-vibe/releases
-[preview-diff-side-by-side-image]:
-  https://github.com/user-attachments/assets/aef778af-815c-412b-a514-e3dec4280b6d
-[preview-diff-inline-image]:
-  https://github.com/user-attachments/assets/6f824ec9-023b-4cc4-aca6-647a6b191183
+[preview-diff-side-by-side-image]: https://github.com/user-attachments/assets/aef778af-815c-412b-a514-e3dec4280b6d
+[preview-diff-inline-image]: https://github.com/user-attachments/assets/6f824ec9-023b-4cc4-aca6-647a6b191183
 [copilot-cli]: https://github.com/github/copilot-cli
 [cline]: https://github.com/cline/cline
 [cline-docs]: https://docs.cline.bot/getting-started/installing-cline

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -377,6 +377,13 @@ local ConfigDefault = {
         agent = "󱚠 ",
     },
 
+    message_icons = {
+        thinking = "🧠",
+        finished = "🏁",
+        stopped = "🛑",
+        error = "❌",
+    },
+
     file_picker = {
         enabled = true,
     },

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -124,6 +124,13 @@
 --- @field user string
 --- @field agent string
 
+--- Icons used for message states in the chat widget
+--- @class agentic.UserConfig.MessageIcons
+--- @field thinking string
+--- @field finished string
+--- @field stopped string
+--- @field error string
+
 --- @class agentic.UserConfig.FilePicker
 --- @field enabled boolean
 
@@ -160,6 +167,7 @@
 --- @field diagnostic_icons? agentic.UserConfig.DiagnosticIcons
 --- @field permission_icons? agentic.UserConfig.PermissionIcons
 --- @field chat_icons? agentic.UserConfig.ChatIcons
+--- @field message_icons? agentic.UserConfig.MessageIcons
 --- @field file_picker? agentic.UserConfig.FilePicker
 --- @field image_paste? agentic.UserConfig.ImagePaste
 --- @field auto_scroll? agentic.UserConfig.AutoScroll
@@ -178,6 +186,7 @@
 --- @field diagnostic_icons agentic.UserConfig.DiagnosticIcons
 --- @field permission_icons agentic.UserConfig.PermissionIcons
 --- @field chat_icons agentic.UserConfig.ChatIcons
+--- @field message_icons agentic.UserConfig.MessageIcons
 --- @field file_picker agentic.UserConfig.FilePicker
 --- @field image_paste agentic.UserConfig.ImagePaste
 --- @field auto_scroll agentic.UserConfig.AutoScroll

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -786,19 +786,22 @@ function SessionManager:_handle_input_submit(input_text)
             self.is_generating = false
 
             local finish_message = string.format(
-                "\n### 🏁 %s\n-----",
+                "\n### %s %s\n-----",
+                Config.message_icons.finished,
                 os.date("%Y-%m-%d %H:%M:%S")
             )
 
             if err then
                 finish_message = string.format(
-                    "\n### ❌ Agent finished with error: %s\n%s",
+                    "\n### %s Agent finished with error: %s\n%s",
+                    Config.message_icons.error,
                     vim.inspect(err),
                     finish_message
                 )
             elseif response and response.stopReason == "cancelled" then
                 finish_message = string.format(
-                    "\n### 🛑 Generation stopped by the user request\n%s",
+                    "\n### %s Generation stopped by the user request\n%s",
+                    Config.message_icons.stopped,
                     finish_message
                 )
             end
@@ -1284,7 +1287,8 @@ function SessionManager:load_acp_session(session_id, title, timestamp)
             end
 
             local finish_message = string.format(
-                "\n### 🏁 Session restored - %s\n-----",
+                "\n### %s Session restored - %s\n-----",
+                Config.message_icons.finished,
                 os.date("%Y-%m-%d %H:%M:%S")
             )
 

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -230,7 +230,7 @@ function MessageWriter:write_message_chunk(update)
 
     -- Prepend emoji on first thought chunk of a block
     if is_thought and not self._thinking_extmark_id then
-        text = "🧠 " .. text
+        text = Config.message_icons.thinking .. " " .. text
     end
 
     local header_written = self:_maybe_write_sender_header(update.sessionUpdate)
@@ -905,7 +905,7 @@ function MessageWriter:replay_history_messages(messages)
         elseif msg.type == "thought" then
             self:_maybe_write_sender_header("agent_thought_chunk")
 
-            local text = "🧠 " .. msg.text
+            local text = Config.message_icons.thinking .. " " .. msg.text
             local lines = vim.split(text, "\n", { plain = true })
             local start_line
 


### PR DESCRIPTION
Tested with several different variations and worked fine

```lua
return {
    config = function()
        local agentic = require("agentic")
        local sequence = { "", "", "", "" }
        local spinner = vim.fn.mapnew(vim.fn.range(38), function(_, i)
            return sequence[i % #sequence + 1]
        end)

        agentic.setup({
            chat_icons = {
                agent = "",
                user = "",
            },
            diagnostic_icons = {
                error = "",
                hint = "",
                info = "",
                warn = "",
            },
            message_icons = {
                --     error = "🧠",
                finished = "🧠",
                --     stopped = "🧠",
                --     thinking = "🧠",
            },
            permission_icons = {
                allow_always = "󱍷",
                allow_once = "",
                reject_always = "",
                reject_once = "󰍶",
            },
            provider = "opencode-acp",
            spinner_chars = {
                busy = spinner,
                generating = spinner,
                searching = spinner,
                thinking = spinner,
            },
            status_icons = {
                completed = "",
                failed = "",
                in_progress = "",
                pending = "",
            },
        })

        vim.keymap.set({ "i", "n", "x" }, "<a-a>", agentic.toggle)
    end,
    defer = true,
    src = "https://github.com/mezdelex/agentic.nvim",
}
```

<img width="1919" height="1024" alt="image" src="https://github.com/user-attachments/assets/f41176e7-f88c-4383-b2ef-6f183080aa08" />
