### PR TITLE
feat: Add on_create_session_response hook for ACP session creation feedback

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,7 @@ trim_trailing_whitespace = false
 
 [*.lua]
 indent_size = 4
+insert_final_newline = true
 
 [Makefile]
 indent_style = tab

--- a/README.md
+++ b/README.md
@@ -822,6 +822,21 @@ integrating with other plugins.
   --- @type agentic.PartialUserConfig
   opts = {
     hooks = {
+      -- Called when a new ACP session is created (or fails to create)
+      on_create_session_response = function(data)
+        -- data.session_id: string|nil - The ACP session ID (nil if err is set)
+        -- data.tab_page_id: number - The Neovim tabpage ID
+        -- data.response: table|nil - The ACP session creation response (nil if err is set)
+        -- data.err: table|nil - Error details if session creation failed
+        if data.response then
+          vim.notify("New session: " .. data.response.sessionId)
+        end
+
+        if vim.api.nvim_tabpage_is_valid(data.tab_page_id) then
+          vim.t[data.tab_page_id].agentic_usage = nil
+        end
+      end,
+
       -- Called when the user submits a prompt
       on_prompt_submit = function(data)
         -- data.prompt: string - The user's prompt text

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -594,6 +594,12 @@ Event hooks ~
   --- @type agentic.PartialUserConfig
   opts = {
     hooks = {
+      on_create_session_response = function(data)
+        -- data.response: table|nil - The ACP session creation response (nil if err is set)
+        -- data.err: table|nil - Error details if session creation failed
+        -- data.session_id: string
+        -- data.tab_page_id: number
+      end,
       on_prompt_submit = function(data)
         -- data.prompt: string
         -- data.session_id: string

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -23,6 +23,13 @@
 ---
 --- @alias agentic.UserConfig.Headers table<agentic.ui.ChatWidget.PanelNames, agentic.ui.ChatWidget.HeaderParts|agentic.UserConfig.HeaderRenderFn|nil>
 
+--- Data passed to the on_create_session_response hook
+--- @class agentic.UserConfig.CreateSessionResponseData
+--- @field session_id string|nil
+--- @field tab_page_id number
+--- @field response agentic.acp.SessionCreationResponse|nil
+--- @field err? agentic.acp.ACPError
+
 --- Data passed to the on_prompt_submit hook
 --- @class agentic.UserConfig.PromptSubmitData
 --- @field prompt string The user's prompt text
@@ -164,6 +171,7 @@
 --- @field tool_calls agentic.UserConfig.Folding.ToolCalls
 
 --- @class agentic.UserConfig.Hooks
+--- @field on_create_session_response? fun(data: agentic.UserConfig.CreateSessionResponseData): nil
 --- @field on_prompt_submit? fun(data: agentic.UserConfig.PromptSubmitData): nil
 --- @field on_response_complete? fun(data: agentic.UserConfig.ResponseCompleteData): nil
 --- @field on_session_update? fun(data: agentic.UserConfig.SessionUpdateData): nil
@@ -470,6 +478,7 @@ local ConfigDefault = {
     },
 
     hooks = {
+        on_create_session_response = nil,
         on_prompt_submit = nil,
         on_response_complete = nil,
         on_session_update = nil,

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -27,8 +27,8 @@ local FILE_MUTATING_KINDS = {
 }
 
 --- Safely invoke a user-configured hook
---- @param hook_name "on_prompt_submit" | "on_response_complete" | "on_session_update" | "on_file_edit"
---- @param data agentic.UserConfig.PromptSubmitData | agentic.UserConfig.ResponseCompleteData | agentic.UserConfig.SessionUpdateData | agentic.UserConfig.FileEditData
+--- @param hook_name "on_create_session_response" | "on_prompt_submit" | "on_response_complete" | "on_session_update" | "on_file_edit"
+--- @param data agentic.UserConfig.CreateSessionResponseData | agentic.UserConfig.PromptSubmitData | agentic.UserConfig.ResponseCompleteData | agentic.UserConfig.SessionUpdateData | agentic.UserConfig.FileEditData
 function P.invoke_hook(hook_name, data)
     local hook = Config.hooks and Config.hooks[hook_name]
 
@@ -952,6 +952,16 @@ function SessionManager:new_session(opts)
 
     self.agent:create_session(handlers, function(response, err)
         self.status_animation:stop()
+
+        --- @type agentic.UserConfig.CreateSessionResponseData
+        local hook_data = {
+            session_id = response and response.sessionId,
+            tab_page_id = self.tab_page_id,
+            response = response,
+            err = err,
+        }
+
+        P.invoke_hook("on_create_session_response", hook_data)
 
         if err or not response then
             -- no log here, already logged in create_session


### PR DESCRIPTION
I'm currently using this hook to reset some state whenever a session is created. For example, I'm storing the context used/total via the `on_session_update` hook, but if a new session is created, those values need to be reset. 

I also considered a `on_new_session` hook as an alternative, however I feel like tying the hooks to the ACP events makes more sense, as it's closer to the protocol and thus doesn't have to be adapted as much when the internals of agentic change.

This is based on top of #161 since for my use-case, the state I'm reseting is displayed in the header, so the header needs to be re-rendered