### PR TITLE
refactor: replace manual PartialUserConfig with (partial) class inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ by configuring the `acp_providers` property:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     acp_providers = {
       -- Override existing provider (e.g., add API key)
@@ -367,6 +368,7 @@ configure it per provider:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     acp_providers = {
       ["claude-agent-acp"] = {
@@ -389,6 +391,7 @@ default:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     acp_providers = {
       ["claude-agent-acp"] = {
@@ -410,6 +413,7 @@ Configure the widget layout position and sizing:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     windows = {
       position = "right",  -- "right", "left", or "bottom"
@@ -459,6 +463,7 @@ a table configuration or a custom render function.
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     headers = {
       chat = {
@@ -479,6 +484,7 @@ header parts:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     headers = {
       chat = function(parts)
@@ -591,6 +597,7 @@ your setup:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     keymaps = {
       -- Keybindings for ALL buffers in the widget (chat, prompt, code, files)
@@ -657,6 +664,7 @@ before you accept or reject them. You can configure the diff preview layout:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     diff_preview = {
       enabled = true,
@@ -787,6 +795,7 @@ integrating with other plugins.
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     hooks = {
       -- Called when the user submits a prompt
@@ -861,6 +870,7 @@ You can customize the icons used for diagnostics in the context panel:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     diagnostic_icons = {
       error = "❌",    -- Diagnostic severity: error
@@ -882,6 +892,7 @@ You can customize the icons used to indicate tool call status in the chat:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     status_icons = {
       pending = "󰔛",      -- Tool call awaiting execution
@@ -900,6 +911,7 @@ You can customize the icons used in the permission approval workflow:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     permission_icons = {
       allow_once = "",    -- Allow this execution only
@@ -918,6 +930,7 @@ You can customize the icons used to identify user and agent messages in the chat
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     chat_icons = {
       user = " ",    -- Icon shown for user messages
@@ -934,6 +947,7 @@ You can customize the icons used for messages and interaction states:
 ```lua
 {
   "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
   opts = {
     message_icons = {
       thinking = "🧠",   -- Shown when the agent is thinking/reasoning
@@ -1086,6 +1100,7 @@ Enable debug logging to troubleshoot issues:
 ```lua
 {
    "carlos-algms/agentic.nvim",
+    --- @type agentic.PartialUserConfig
     opts = {
       debug = true,
       -- ... rest of your options

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ tools like `nvm`, `fnm`, etc...
 {
   "carlos-algms/agentic.nvim",
 
+  --- @type agentic.PartialUserConfig
   opts = {
     -- Any ACP-compatible provider works. Built-in: "claude-agent-acp" | "gemini-acp" | "codex-acp" | "opencode-acp" | "cursor-acp" | "copilot-acp" | "auggie-acp" | "mistral-vibe-acp" | "cline-acp" | "goose-acp"
     provider = "claude-agent-acp", -- setting the name here is all you need to get started

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -147,6 +147,7 @@ Using lazy.nvim: ~
   {
     "carlos-algms/agentic.nvim",
 
+    --- @type agentic.PartialUserConfig
     opts = {
       -- Any ACP-compatible provider works. Built-in:
       -- "claude-agent-acp" | "gemini-acp" | "codex-acp"

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -238,6 +238,7 @@ acp_providers ~
                    widget to see available models.
 
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     acp_providers = {
       ["claude-agent-acp"] = {
@@ -304,6 +305,7 @@ headers ~
   header parts and returns a custom string.
 
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     headers = {
       chat = {
@@ -468,6 +470,7 @@ Customizing keymaps ~
 
 Override default keybindings via the `keymaps` config option:
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     keymaps = {
       widget = {
@@ -513,6 +516,7 @@ changes before you accept or reject them.
                                         *agentic-config-diff-preview*
 Configuration: ~
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     diff_preview = {
       enabled = true,
@@ -587,6 +591,7 @@ This reduces time to first response by providing immediate context.
 Event hooks ~
                                                      *agentic-hooks*
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     hooks = {
       on_prompt_submit = function(data)
@@ -642,6 +647,7 @@ can be set via |nvim_set_hl()|):
                                               *agentic-diagnostic-icons*
 Diagnostic icons ~
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     diagnostic_icons = {
       error = "X",
@@ -655,6 +661,7 @@ Diagnostic icons ~
                                                 *agentic-status-icons*
 Status icons ~
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     status_icons = {
       pending = "...",
@@ -668,6 +675,7 @@ Status icons ~
                                             *agentic-permission-icons*
 Permission icons ~
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     permission_icons = {
       allow_once = "y",
@@ -681,6 +689,7 @@ Permission icons ~
                                                   *agentic-chat-icons*
 Chat icons ~
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     chat_icons = {
       user = " ",
@@ -692,6 +701,7 @@ Chat icons ~
                                                *agentic-message-icons*
 Message icons ~
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     message_icons = {
       thinking = "...",
@@ -705,6 +715,7 @@ Message icons ~
                                               *agentic-spinner-chars*
 Spinner characters ~
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     spinner_chars = {
       generating = { ".", "..", "..." },
@@ -718,6 +729,7 @@ Spinner characters ~
                                                *agentic-auto-scroll*
 Auto scroll ~
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     auto_scroll = {
       threshold = 10,  -- Lines from bottom to trigger
@@ -728,6 +740,7 @@ Auto scroll ~
                                                 *agentic-file-picker-config*
 File picker ~
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     file_picker = {
       enabled = true,  -- Enable @ file completion
@@ -738,6 +751,7 @@ File picker ~
                                                 *agentic-image-paste*
 Image paste ~
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     image_paste = {
       enabled = true,  -- Enable drag-and-drop
@@ -876,6 +890,7 @@ DEBUG                                                    *agentic-debug*
 
 Enable debug logging:
 >lua
+  --- @type agentic.PartialUserConfig
   opts = {
     debug = true,
   }

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -200,6 +200,7 @@
 --- @field auto_scroll? agentic.PartialUserConfig.AutoScroll
 --- @field diff_preview? agentic.PartialUserConfig.DiffPreview
 --- @field settings? agentic.PartialUserConfig.Settings
+
 --- @class agentic.UserConfig
 --- @field debug boolean Enable printing debug messages which can be read via `:messages`
 --- @field provider agentic.UserConfig.ProviderName

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -105,6 +105,7 @@
 --- @class agentic.UserConfig.StatusIcons
 --- @field pending string
 --- @field in_progress string
+--- @field completed string
 --- @field failed string
 
 --- Icons used for diagnostics in the context panel

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -155,26 +155,51 @@
 --- @class agentic.UserConfig.Settings
 --- @field move_cursor_to_chat_on_submit boolean Automatically move cursor to chat window after submitting a prompt
 
---- All the user config configurable options are optional
---- @class agentic.PartialUserConfig
---- @field debug? boolean Enable printing debug messages which can be read via `:messages`
---- @field provider? agentic.UserConfig.ProviderName
---- @field acp_providers? table<agentic.UserConfig.ProviderName, agentic.acp.ACPProviderConfig|nil>
---- @field windows? agentic.UserConfig.Windows
---- @field keymaps? agentic.UserConfig.Keymaps
---- @field spinner_chars? agentic.UserConfig.SpinnerChars
---- @field status_icons? agentic.UserConfig.StatusIcons
---- @field diagnostic_icons? agentic.UserConfig.DiagnosticIcons
---- @field permission_icons? agentic.UserConfig.PermissionIcons
---- @field chat_icons? agentic.UserConfig.ChatIcons
---- @field message_icons? agentic.UserConfig.MessageIcons
---- @field file_picker? agentic.UserConfig.FilePicker
---- @field image_paste? agentic.UserConfig.ImagePaste
---- @field auto_scroll? agentic.UserConfig.AutoScroll
---- @field diff_preview? agentic.UserConfig.DiffPreview
---- @field hooks? agentic.UserConfig.Hooks
---- @field headers? agentic.UserConfig.Headers
---- @field settings? agentic.UserConfig.Settings
+--- Nested partial types for user config overrides
+--- @class (partial) agentic.PartialUserConfig.Windows.Chat: agentic.UserConfig.Windows.Chat
+--- @class (partial) agentic.PartialUserConfig.Windows.Input: agentic.UserConfig.Windows.Input
+--- @class (partial) agentic.PartialUserConfig.Windows.Code: agentic.UserConfig.Windows.Code
+--- @class (partial) agentic.PartialUserConfig.Windows.Files: agentic.UserConfig.Windows.Files
+--- @class (partial) agentic.PartialUserConfig.Windows.Diagnostics: agentic.UserConfig.Windows.Diagnostics
+--- @class (partial) agentic.PartialUserConfig.Windows.Todos: agentic.UserConfig.Windows.Todos
+--- @class (partial) agentic.PartialUserConfig.Keymaps: agentic.UserConfig.Keymaps
+--- @class (partial) agentic.PartialUserConfig.SpinnerChars: agentic.UserConfig.SpinnerChars
+--- @class (partial) agentic.PartialUserConfig.StatusIcons: agentic.UserConfig.StatusIcons
+--- @class (partial) agentic.PartialUserConfig.DiagnosticIcons: agentic.UserConfig.DiagnosticIcons
+--- @class (partial) agentic.PartialUserConfig.PermissionIcons: agentic.UserConfig.PermissionIcons
+--- @class (partial) agentic.PartialUserConfig.ChatIcons: agentic.UserConfig.ChatIcons
+--- @class (partial) agentic.PartialUserConfig.MessageIcons: agentic.UserConfig.MessageIcons
+--- @class (partial) agentic.PartialUserConfig.FilePicker: agentic.UserConfig.FilePicker
+--- @class (partial) agentic.PartialUserConfig.ImagePaste: agentic.UserConfig.ImagePaste
+--- @class (partial) agentic.PartialUserConfig.AutoScroll: agentic.UserConfig.AutoScroll
+--- @class (partial) agentic.PartialUserConfig.DiffPreview: agentic.UserConfig.DiffPreview
+--- @class (partial) agentic.PartialUserConfig.Settings: agentic.UserConfig.Settings
+
+--- Windows partial with nested type overrides
+--- @class (partial) agentic.PartialUserConfig.Windows: agentic.UserConfig.Windows
+--- @field chat? agentic.PartialUserConfig.Windows.Chat
+--- @field input? agentic.PartialUserConfig.Windows.Input
+--- @field code? agentic.PartialUserConfig.Windows.Code
+--- @field files? agentic.PartialUserConfig.Windows.Files
+--- @field diagnostics? agentic.PartialUserConfig.Windows.Diagnostics
+--- @field todos? agentic.PartialUserConfig.Windows.Todos
+
+--- Top-level partial config -- all UserConfig fields become optional
+--- Nested fields override to use partial variants
+--- @class (partial) agentic.PartialUserConfig: agentic.UserConfig
+--- @field windows? agentic.PartialUserConfig.Windows
+--- @field keymaps? agentic.PartialUserConfig.Keymaps
+--- @field spinner_chars? agentic.PartialUserConfig.SpinnerChars
+--- @field status_icons? agentic.PartialUserConfig.StatusIcons
+--- @field diagnostic_icons? agentic.PartialUserConfig.DiagnosticIcons
+--- @field permission_icons? agentic.PartialUserConfig.PermissionIcons
+--- @field chat_icons? agentic.PartialUserConfig.ChatIcons
+--- @field message_icons? agentic.PartialUserConfig.MessageIcons
+--- @field file_picker? agentic.PartialUserConfig.FilePicker
+--- @field image_paste? agentic.PartialUserConfig.ImagePaste
+--- @field auto_scroll? agentic.PartialUserConfig.AutoScroll
+--- @field diff_preview? agentic.PartialUserConfig.DiffPreview
+--- @field settings? agentic.PartialUserConfig.Settings
 --- @class agentic.UserConfig
 --- @field debug boolean Enable printing debug messages which can be read via `:messages`
 --- @field provider agentic.UserConfig.ProviderName

--- a/lua/agentic/config_default.test.lua
+++ b/lua/agentic/config_default.test.lua
@@ -1,0 +1,89 @@
+local assert = require("tests.helpers.assert")
+
+describe("config_default", function()
+    describe("agentic.PartialUserConfig type", function()
+        it("accepts a partial top-level config without warnings", function()
+            --- @type agentic.PartialUserConfig
+            local cfg = {
+                debug = true,
+                provider = "claude-agent-acp",
+            }
+
+            assert.equal(true, cfg.debug)
+            assert.equal("claude-agent-acp", cfg.provider)
+        end)
+
+        it("accepts partial nested windows config", function()
+            --- @type agentic.PartialUserConfig
+            local cfg = {
+                windows = {
+                    width = "50%",
+                    position = "left",
+                },
+            }
+
+            assert.equal("50%", cfg.windows.width)
+            assert.equal("left", cfg.windows.position)
+        end)
+
+        it("accepts partial nested sub-window config", function()
+            --- @type agentic.PartialUserConfig
+            local cfg = {
+                windows = {
+                    input = { height = 20 },
+                    todos = { display = false },
+                },
+            }
+
+            assert.equal(20, cfg.windows.input.height)
+            assert.equal(false, cfg.windows.todos.display)
+        end)
+
+        it("accepts partial icon overrides", function()
+            --- @type agentic.PartialUserConfig
+            local cfg = {
+                status_icons = { pending = "?" },
+                chat_icons = { user = "U" },
+            }
+
+            assert.equal("?", cfg.status_icons.pending)
+            assert.equal("U", cfg.chat_icons.user)
+        end)
+
+        it("accepts partial keymaps", function()
+            --- @type agentic.PartialUserConfig
+            local cfg = {
+                keymaps = {
+                    widget = { close = "x" },
+                },
+            }
+
+            assert.equal("x", cfg.keymaps.widget.close)
+        end)
+
+        it("accepts partial diff_preview", function()
+            --- @type agentic.PartialUserConfig
+            local cfg = {
+                diff_preview = { enabled = false },
+            }
+
+            assert.equal(false, cfg.diff_preview.enabled)
+        end)
+
+        it("accepts partial settings", function()
+            --- @type agentic.PartialUserConfig
+            local cfg = {
+                settings = { move_cursor_to_chat_on_submit = false },
+            }
+
+            assert.equal(false, cfg.settings.move_cursor_to_chat_on_submit)
+        end)
+
+        it("accepts an empty config", function()
+            --- @type agentic.PartialUserConfig
+            local cfg = {}
+
+            assert.is_table(cfg)
+        end)
+    end)
+end)

--- a/lua/agentic/config_default.test.lua
+++ b/lua/agentic/config_default.test.lua
@@ -1,5 +1,9 @@
 local assert = require("tests.helpers.assert")
 
+-- These tests exist to force LuaLS type checking and Selene linting on
+-- PartialUserConfig usage. They are NOT testing runtime config behavior --
+-- they validate that the (partial) type annotations allow incomplete
+-- nested tables without triggering type errors or lint warnings.
 describe("config_default", function()
     describe("agentic.PartialUserConfig type", function()
         it("accepts a partial top-level config without warnings", function()


### PR DESCRIPTION
## Summary

- Replace the manually-duplicated `agentic.PartialUserConfig` class (where every field was copied with `?`) with LuaLS `(partial)` class inheritance
- Create 20 `(partial)` type variants so users can pass incomplete nested config tables (e.g., `{ windows = { width = "50%" } }`) without LuaLS warnings
- Add type validation tests that exercise partial configs at every nesting level

## Motivation

Adding a new config field previously required updating both `UserConfig` and `PartialUserConfig` manually. With `(partial)`, new fields added to `UserConfig` are automatically available and optional in `PartialUserConfig`.

## Test plan

- [x] `make validate` passes (format, luals, selene, tests)
- [x] New test file `config_default.test.lua` validates partial types at top-level, nested windows, sub-windows, icons, keymaps, diff_preview, settings, and empty config
- [x] Zero runtime changes -- purely type annotation refactor