### PR TITLE
feat: fold long tool call bodies in chat buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,6 +502,30 @@ header parts:
 }
 ```
 
+### Folding
+
+Long tool call outputs are automatically folded to keep the chat buffer
+readable. Toggle the master switch or tune the line threshold.
+
+```lua
+--- @type agentic.PartialUserConfig
+opts = {
+  folding = {
+    tool_calls = {
+      enabled = true,
+      threshold = 10,
+    },
+  },
+}
+```
+
+Set `threshold = 0` to always fold every tool call body. Negative values are
+clamped to 0. Set `enabled = false` to disable folding entirely.
+
+The fold hides the body only - the tool call header and completion status
+remain visible. Use standard Vim fold commands (`za`, `zo`, `zc`) to toggle
+individual folds, or `zR`/`zM` to open/close all folds in the chat window.
+
 ## 🚀 Usage (Public Lua API)
 
 ### Commands

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -759,6 +759,20 @@ Image paste ~
   }
 <
 
+                                                *agentic-folding-config*
+Folding ~
+>lua
+  --- @type agentic.PartialUserConfig
+  opts = {
+    folding = {
+      tool_calls = {
+        enabled = true,  -- Master switch for tool call body folding
+        threshold = 10,  -- Fold when interior exceeds N lines. 0 = always.
+      },
+    },
+  }
+<
+
 ==============================================================================
 INTEGRATIONS                                      *agentic-integrations*
 

--- a/doc/tags
+++ b/doc/tags
@@ -18,6 +18,7 @@ agentic-diff-preview	agentic.txt	/*agentic-diff-preview*
 agentic-features	agentic.txt	/*agentic-features*
 agentic-file-picker	agentic.txt	/*agentic-file-picker*
 agentic-file-picker-config	agentic.txt	/*agentic-file-picker-config*
+agentic-folding-config	agentic.txt	/*agentic-folding-config*
 agentic-health-check	agentic.txt	/*agentic-health-check*
 agentic-highlight-groups	agentic.txt	/*agentic-highlight-groups*
 agentic-hooks	agentic.txt	/*agentic-hooks*

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -147,6 +147,15 @@
 --- @field layout "inline" | "split"
 --- @field center_on_navigate_hunks boolean
 
+--- Tool call folding configuration
+--- @class agentic.UserConfig.Folding.ToolCalls
+--- @field enabled boolean Whether to fold tool call bodies.
+--- @field threshold integer Fold when interior exceeds this many lines. 0 always folds. Negative values are clamped to 0.
+
+--- Folding behavior in the chat buffer
+--- @class agentic.UserConfig.Folding
+--- @field tool_calls agentic.UserConfig.Folding.ToolCalls
+
 --- @class agentic.UserConfig.Hooks
 --- @field on_prompt_submit? fun(data: agentic.UserConfig.PromptSubmitData): nil
 --- @field on_response_complete? fun(data: agentic.UserConfig.ResponseCompleteData): nil
@@ -174,6 +183,7 @@
 --- @class (partial) agentic.PartialUserConfig.ImagePaste: agentic.UserConfig.ImagePaste
 --- @class (partial) agentic.PartialUserConfig.AutoScroll: agentic.UserConfig.AutoScroll
 --- @class (partial) agentic.PartialUserConfig.DiffPreview: agentic.UserConfig.DiffPreview
+--- @class (partial) agentic.PartialUserConfig.Folding.ToolCalls: agentic.UserConfig.Folding.ToolCalls
 --- @class (partial) agentic.PartialUserConfig.Settings: agentic.UserConfig.Settings
 
 --- Windows partial with nested type overrides
@@ -184,6 +194,10 @@
 --- @field files? agentic.PartialUserConfig.Windows.Files
 --- @field diagnostics? agentic.PartialUserConfig.Windows.Diagnostics
 --- @field todos? agentic.PartialUserConfig.Windows.Todos
+
+--- Folding partial with nested type overrides
+--- @class (partial) agentic.PartialUserConfig.Folding: agentic.UserConfig.Folding
+--- @field tool_calls? agentic.PartialUserConfig.Folding.ToolCalls
 
 --- Top-level partial config -- all UserConfig fields become optional
 --- Nested fields override to use partial variants
@@ -200,6 +214,7 @@
 --- @field image_paste? agentic.PartialUserConfig.ImagePaste
 --- @field auto_scroll? agentic.PartialUserConfig.AutoScroll
 --- @field diff_preview? agentic.PartialUserConfig.DiffPreview
+--- @field folding? agentic.PartialUserConfig.Folding
 --- @field settings? agentic.PartialUserConfig.Settings
 
 --- @class agentic.UserConfig
@@ -218,6 +233,7 @@
 --- @field image_paste agentic.UserConfig.ImagePaste
 --- @field auto_scroll agentic.UserConfig.AutoScroll
 --- @field diff_preview agentic.UserConfig.DiffPreview
+--- @field folding agentic.UserConfig.Folding
 --- @field hooks agentic.UserConfig.Hooks
 --- @field headers agentic.UserConfig.Headers
 --- @field settings agentic.UserConfig.Settings
@@ -436,6 +452,13 @@ local ConfigDefault = {
         enabled = true,
         layout = "split",
         center_on_navigate_hunks = true,
+    },
+
+    folding = {
+        tool_calls = {
+            enabled = true,
+            threshold = 10,
+        },
     },
 
     hooks = {

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -1022,6 +1022,7 @@ function SessionManager:_cancel_session()
     self.chat_history = ChatHistory:new()
     self.history_to_send = nil
     self.message_writer:reset_sender_tracking()
+    self.message_writer.tool_call_blocks = {}
 end
 
 function SessionManager:add_selection_or_file_to_session()
@@ -1208,6 +1209,9 @@ end
 function SessionManager:destroy()
     self:_cancel_session()
     self.widget:destroy()
+    if self.message_writer then
+        self.message_writer:destroy()
+    end
 end
 
 --- Load an existing ACP session by ID, subscribing to its updates

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -72,7 +72,7 @@ function MessageWriter:new(bufnr)
     }, self)
 
     Fold.register(bufnr, function()
-        return instance:_get_fold_geometry()
+        return instance:_get_fold_geometry() --- @diagnostic disable-line: invisible
     end)
 
     return instance

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -4,6 +4,7 @@ local Config = require("agentic.config")
 local DiffHighlighter = require("agentic.utils.diff_highlighter")
 local DiffPreview = require("agentic.ui.diff_preview")
 local ExtmarkBlock = require("agentic.utils.extmark_block")
+local Fold = require("agentic.ui.tool_call_fold")
 local Logger = require("agentic.utils.logger")
 local Theme = require("agentic.theme")
 
@@ -95,6 +96,13 @@ function MessageWriter:_clear_thinking_state()
     self._thinking_extmark_id = nil
     self._thinking_start_line = nil
     self._thinking_end_line = nil
+end
+
+--- Projects tool_call_blocks into the geometry format Fold expects.
+--- @private
+--- @return agentic.ui.ToolCallFold.Block[]
+function MessageWriter:_get_fold_geometry()
+    return {}
 end
 
 --- Writes a structural message (e.g. welcome banner) without triggering
@@ -1150,6 +1158,11 @@ function MessageWriter:_apply_status_highlights_if_present(
         self:_apply_header_highlight(start_row, status)
         self:_apply_status_footer(end_row, status)
     end
+end
+
+--- Clean up the MessageWriter: unregister fold state.
+function MessageWriter:destroy()
+    local _ = Fold
 end
 
 return MessageWriter

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -102,6 +102,21 @@ function MessageWriter:_clear_thinking_state()
     self._thinking_end_line = nil
 end
 
+--- Whether a block of this shape would be folded by _get_fold_geometry.
+--- Kept in sync with the threshold/diff logic below.
+--- @private
+--- @param interior integer Number of lines between header and footer
+--- @param is_diff boolean Whether the block is a diff kind
+--- @return boolean
+function MessageWriter:_will_fold(interior, is_diff)
+    local cfg = Config.folding and Config.folding.tool_calls
+    if not cfg or not cfg.enabled or is_diff then
+        return false
+    end
+    local threshold = math.max(0, cfg.threshold or 0)
+    return interior > threshold
+end
+
 --- Projects tool_call_blocks into the geometry format Fold expects.
 --- @private
 --- @return agentic.ui.ToolCallFold.Block[]
@@ -443,7 +458,39 @@ function MessageWriter:write_tool_call_block(tool_call_block)
         local lines, highlight_ranges =
             self:_prepare_block_lines(tool_call_block)
 
-        self:_append_lines(lines)
+        -- Pre-fold: if the block will fold, first append an empty skeleton
+        -- of the same line count and register the extmark + tracker. The
+        -- subsequent set_lines triggers foldexpr with the tracker in place,
+        -- which closes the fold synchronously with the content write -- no
+        -- visible expand then collapse.
+        local will_fold =
+            self:_will_fold(#lines - 2, tool_call_block.diff ~= nil)
+        if will_fold then
+            local skeleton = {}
+            for _ = 1, #lines do
+                table.insert(skeleton, "")
+            end
+            self:_append_lines(skeleton)
+            local skel_end = vim.api.nvim_buf_line_count(bufnr) - 1
+            tool_call_block.extmark_id = vim.api.nvim_buf_set_extmark(
+                bufnr,
+                NS_TOOL_BLOCKS,
+                start_row,
+                0,
+                { end_row = skel_end, right_gravity = false }
+            )
+            self.tool_call_blocks[tool_call_block.tool_call_id] =
+                tool_call_block
+            vim.api.nvim_buf_set_lines(
+                bufnr,
+                start_row,
+                skel_end + 1,
+                false,
+                lines
+            )
+        else
+            self:_append_lines(lines)
+        end
 
         local end_row = vim.api.nvim_buf_line_count(bufnr) - 1
 
@@ -466,6 +513,7 @@ function MessageWriter:write_tool_call_block(tool_call_block)
 
         tool_call_block.extmark_id =
             vim.api.nvim_buf_set_extmark(bufnr, NS_TOOL_BLOCKS, start_row, 0, {
+                id = tool_call_block.extmark_id,
                 end_row = end_row,
                 right_gravity = false,
             })
@@ -580,13 +628,51 @@ function MessageWriter:update_tool_call_block(tool_call_block)
 
         local new_lines, highlight_ranges = self:_prepare_block_lines(tracker)
 
-        vim.api.nvim_buf_set_lines(
-            bufnr,
-            start_row,
-            old_end_row + 1,
-            false,
-            new_lines
-        )
+        -- Pre-fold: if this update transitions the block into foldable,
+        -- resize the buffer to the new line count with an empty skeleton and
+        -- sync the extmark first. The subsequent set_lines runs foldexpr
+        -- with the foldable tracker in place and closes the fold in the same
+        -- edit that places the content -- no visible expand then collapse.
+        local new_interior = #new_lines - 2
+        local old_interior = old_end_row - start_row - 1
+        local is_diff = tracker.diff ~= nil
+        local now_folds = self:_will_fold(new_interior, is_diff)
+        local was_folding = self:_will_fold(old_interior, is_diff)
+        if now_folds and not was_folding then
+            local skeleton = { new_lines[1] }
+            for _ = 1, new_interior do
+                table.insert(skeleton, "")
+            end
+            table.insert(skeleton, new_lines[#new_lines])
+            vim.api.nvim_buf_set_lines(
+                bufnr,
+                start_row,
+                old_end_row + 1,
+                false,
+                skeleton
+            )
+            local skel_end = start_row + #skeleton - 1
+            vim.api.nvim_buf_set_extmark(bufnr, NS_TOOL_BLOCKS, start_row, 0, {
+                id = tracker.extmark_id,
+                end_row = skel_end,
+                right_gravity = false,
+            })
+            vim.api.nvim_buf_set_lines(
+                bufnr,
+                start_row,
+                skel_end + 1,
+                false,
+                new_lines
+            )
+        else
+            vim.api.nvim_buf_set_lines(
+                bufnr,
+                start_row,
+                old_end_row + 1,
+                false,
+                new_lines
+            )
+        end
 
         local new_end_row = start_row + #new_lines - 1
 

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -102,7 +102,40 @@ end
 --- @private
 --- @return agentic.ui.ToolCallFold.Block[]
 function MessageWriter:_get_fold_geometry()
-    return {}
+    local cfg = Config.folding and Config.folding.tool_calls
+    if not cfg or not cfg.enabled then
+        return {}
+    end
+    -- Clamp negatives to 0. threshold=0 means always fold (any interior > 0).
+    local threshold = math.max(0, cfg.threshold or 0)
+
+    --- @type agentic.ui.ToolCallFold.Block[]
+    local geometry = {}
+
+    for _, block in pairs(self.tool_call_blocks) do
+        if block.extmark_id then
+            local pos = vim.api.nvim_buf_get_extmark_by_id(
+                self.bufnr,
+                NS_TOOL_BLOCKS,
+                block.extmark_id,
+                { details = true }
+            )
+            if pos and pos[1] and pos[3] and pos[3].end_row then
+                local start_row = pos[1]
+                local end_row = pos[3].end_row
+                local interior = end_row - start_row - 1
+                local is_diff = block.diff ~= nil
+
+                table.insert(geometry, {
+                    start_row = start_row,
+                    end_row = end_row,
+                    foldable = not is_diff and interior > threshold,
+                })
+            end
+        end
+    end
+
+    return geometry
 end
 
 --- Writes a structural message (e.g. welcome banner) without triggering

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -71,6 +71,10 @@ function MessageWriter:new(bufnr)
         _is_restoring = false,
     }, self)
 
+    Fold.register(bufnr, function()
+        return instance:_get_fold_geometry()
+    end)
+
     return instance
 end
 
@@ -1195,7 +1199,7 @@ end
 
 --- Clean up the MessageWriter: unregister fold state.
 function MessageWriter:destroy()
-    local _ = Fold
+    Fold.unregister(self.bufnr)
 end
 
 return MessageWriter

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -104,7 +104,6 @@ end
 
 --- Returns the fold threshold when folding is enabled, nil otherwise.
 --- Negative thresholds are clamped to 0 (threshold=0 folds any interior > 0).
---- @private
 --- @return integer|nil threshold
 function MessageWriter:_resolve_fold_threshold()
     local cfg = Config.folding and Config.folding.tool_calls
@@ -116,7 +115,6 @@ end
 
 --- Returns a list of `count` empty strings, used to reserve space for a
 --- pre-fold two-step write.
---- @private
 --- @param count integer
 --- @return string[]
 function MessageWriter:_make_skeleton(count)
@@ -129,7 +127,6 @@ end
 
 --- Whether a block of this shape would be folded by _get_fold_geometry.
 --- Kept in sync with the threshold/diff logic below.
---- @private
 --- @param interior integer Number of lines between header and footer
 --- @param is_diff boolean Whether the block is a diff kind
 --- @return boolean
@@ -142,7 +139,6 @@ function MessageWriter:_will_fold(interior, is_diff)
 end
 
 --- Projects tool_call_blocks into the geometry format Fold expects.
---- @private
 --- @return agentic.ui.ToolCallFold.Block[]
 function MessageWriter:_get_fold_geometry()
     --- @type agentic.ui.ToolCallFold.Block[]

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -62,7 +62,7 @@ function MessageWriter:new(bufnr)
         error("Invalid buffer number: " .. tostring(bufnr))
     end
 
-    local instance = setmetatable({
+    self = setmetatable({
         bufnr = bufnr,
         tool_call_blocks = {},
         _last_message_type = nil,
@@ -72,10 +72,10 @@ function MessageWriter:new(bufnr)
     }, self)
 
     Fold.register(bufnr, function()
-        return instance:_get_fold_geometry() --- @diagnostic disable-line: invisible
+        return self:_get_fold_geometry()
     end)
 
-    return instance
+    return self
 end
 
 --- @param callback fun()|nil

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -102,6 +102,31 @@ function MessageWriter:_clear_thinking_state()
     self._thinking_end_line = nil
 end
 
+--- Returns the fold threshold when folding is enabled, nil otherwise.
+--- Negative thresholds are clamped to 0 (threshold=0 folds any interior > 0).
+--- @private
+--- @return integer|nil threshold
+function MessageWriter:_resolve_fold_threshold()
+    local cfg = Config.folding and Config.folding.tool_calls
+    if not cfg or not cfg.enabled then
+        return nil
+    end
+    return math.max(0, cfg.threshold or 0)
+end
+
+--- Returns a list of `count` empty strings, used to reserve space for a
+--- pre-fold two-step write.
+--- @private
+--- @param count integer
+--- @return string[]
+function MessageWriter:_make_skeleton(count)
+    local skeleton = {}
+    for _ = 1, count do
+        table.insert(skeleton, "")
+    end
+    return skeleton
+end
+
 --- Whether a block of this shape would be folded by _get_fold_geometry.
 --- Kept in sync with the threshold/diff logic below.
 --- @private
@@ -109,27 +134,23 @@ end
 --- @param is_diff boolean Whether the block is a diff kind
 --- @return boolean
 function MessageWriter:_will_fold(interior, is_diff)
-    local cfg = Config.folding and Config.folding.tool_calls
-    if not cfg or not cfg.enabled or is_diff then
+    if is_diff then
         return false
     end
-    local threshold = math.max(0, cfg.threshold or 0)
-    return interior > threshold
+    local threshold = self:_resolve_fold_threshold()
+    return threshold ~= nil and interior > threshold
 end
 
 --- Projects tool_call_blocks into the geometry format Fold expects.
 --- @private
 --- @return agentic.ui.ToolCallFold.Block[]
 function MessageWriter:_get_fold_geometry()
-    local cfg = Config.folding and Config.folding.tool_calls
-    if not cfg or not cfg.enabled then
-        return {}
-    end
-    -- Clamp negatives to 0. threshold=0 means always fold (any interior > 0).
-    local threshold = math.max(0, cfg.threshold or 0)
-
     --- @type agentic.ui.ToolCallFold.Block[]
     local geometry = {}
+
+    if self:_resolve_fold_threshold() == nil then
+        return geometry
+    end
 
     for _, block in pairs(self.tool_call_blocks) do
         if block.extmark_id then
@@ -143,12 +164,11 @@ function MessageWriter:_get_fold_geometry()
                 local start_row = pos[1]
                 local end_row = pos[3].end_row
                 local interior = end_row - start_row - 1
-                local is_diff = block.diff ~= nil
 
                 table.insert(geometry, {
                     start_row = start_row,
                     end_row = end_row,
-                    foldable = not is_diff and interior > threshold,
+                    foldable = self:_will_fold(interior, block.diff ~= nil),
                 })
             end
         end
@@ -466,11 +486,7 @@ function MessageWriter:write_tool_call_block(tool_call_block)
         local will_fold =
             self:_will_fold(#lines - 2, tool_call_block.diff ~= nil)
         if will_fold then
-            local skeleton = {}
-            for _ = 1, #lines do
-                table.insert(skeleton, "")
-            end
-            self:_append_lines(skeleton)
+            self:_append_lines(self:_make_skeleton(#lines))
             local skel_end = vim.api.nvim_buf_line_count(bufnr) - 1
             tool_call_block.extmark_id = vim.api.nvim_buf_set_extmark(
                 bufnr,
@@ -639,11 +655,9 @@ function MessageWriter:update_tool_call_block(tool_call_block)
         local now_folds = self:_will_fold(new_interior, is_diff)
         local was_folding = self:_will_fold(old_interior, is_diff)
         if now_folds and not was_folding then
-            local skeleton = { new_lines[1] }
-            for _ = 1, new_interior do
-                table.insert(skeleton, "")
-            end
-            table.insert(skeleton, new_lines[#new_lines])
+            local skeleton = self:_make_skeleton(#new_lines)
+            skeleton[1] = new_lines[1]
+            skeleton[#skeleton] = new_lines[#new_lines]
             vim.api.nvim_buf_set_lines(
                 bufnr,
                 start_row,

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -942,5 +942,55 @@ describe("agentic.ui.MessageWriter", function()
             assert.equal(#geo, 1)
             assert.is_true(geo[1].foldable)
         end)
+
+        it("returns foldable=false for interior <= threshold", function()
+            Config.folding = {
+                tool_calls = { enabled = true, threshold = 10 },
+            }
+            seed_block(10, false) -- interior exactly 10
+            local geo = writer:_get_fold_geometry()
+            assert.equal(#geo, 1)
+            assert.is_false(geo[1].foldable)
+        end)
+
+        it("threshold=0 folds any block with interior >= 1", function()
+            Config.folding = {
+                tool_calls = { enabled = true, threshold = 0 },
+            }
+            seed_block(1, false)
+            local geo = writer:_get_fold_geometry()
+            assert.equal(#geo, 1)
+            assert.is_true(geo[1].foldable)
+        end)
+
+        it("threshold=0 does not fold empty body (interior=0)", function()
+            Config.folding = {
+                tool_calls = { enabled = true, threshold = 0 },
+            }
+            seed_block(0, false)
+            local geo = writer:_get_fold_geometry()
+            assert.equal(#geo, 1)
+            assert.is_false(geo[1].foldable)
+        end)
+
+        it("clamps negative threshold to 0", function()
+            Config.folding = {
+                tool_calls = { enabled = true, threshold = -5 },
+            }
+            seed_block(1, false)
+            local geo = writer:_get_fold_geometry()
+            assert.equal(#geo, 1)
+            assert.is_true(geo[1].foldable)
+        end)
+
+        it("never folds a diff block regardless of size", function()
+            Config.folding = {
+                tool_calls = { enabled = true, threshold = 0 },
+            }
+            seed_block(100, true) -- is_diff=true
+            local geo = writer:_get_fold_geometry()
+            assert.equal(#geo, 1)
+            assert.is_false(geo[1].foldable)
+        end)
     end)
 end)

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -1018,6 +1018,16 @@ describe("agentic.ui.MessageWriter", function()
 
     describe("Fold integration", function()
         local Fold = require("agentic.ui.tool_call_fold")
+        --- @type agentic.UserConfig.Folding|nil
+        local saved_folding
+
+        before_each(function()
+            saved_folding = Config.folding
+        end)
+
+        after_each(function()
+            Config.folding = saved_folding --- @diagnostic disable-line: assign-type-mismatch
+        end)
 
         --- @return integer bufnr, agentic.ui.MessageWriter writer
         local function make_writer()

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -886,4 +886,51 @@ describe("agentic.ui.MessageWriter", function()
             end
         )
     end)
+
+    describe("_get_fold_geometry", function()
+        --- @type agentic.UserConfig.Folding|nil
+        local saved_folding
+
+        before_each(function()
+            saved_folding = Config.folding
+        end)
+
+        after_each(function()
+            Config.folding = saved_folding --- @diagnostic disable-line: assign-type-mismatch
+        end)
+
+        --- @param body_count integer
+        --- @param is_diff boolean
+        local function seed_block(body_count, is_diff)
+            -- Buffer: HEADER + body_count lines + blank footer
+            local lines = { "HEADER" }
+            for i = 1, body_count do
+                table.insert(lines, "b" .. i)
+            end
+            table.insert(lines, "")
+            vim.api.nvim_buf_set_lines(writer.bufnr, 0, -1, false, lines)
+
+            local NS = vim.api.nvim_create_namespace("agentic_tool_blocks")
+            local ext_id = vim.api.nvim_buf_set_extmark(
+                writer.bufnr,
+                NS,
+                0,
+                0,
+                { end_row = body_count + 1, right_gravity = false }
+            )
+            writer.tool_call_blocks["t1"] = {
+                tool_call_id = "t1",
+                extmark_id = ext_id,
+                diff = is_diff and { old = {}, new = {} } or nil,
+            }
+        end
+
+        it("returns empty when folding disabled", function()
+            Config.folding = {
+                tool_calls = { enabled = false, threshold = 10 },
+            }
+            seed_block(50, false)
+            assert.same(writer:_get_fold_geometry(), {})
+        end)
+    end)
 end)

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -993,4 +993,59 @@ describe("agentic.ui.MessageWriter", function()
             assert.is_false(geo[1].foldable)
         end)
     end)
+
+    describe("Fold integration", function()
+        it("registers a getter on construction", function()
+            local Fold = require("agentic.ui.tool_call_fold")
+            local test_bufnr = vim.api.nvim_create_buf(false, true)
+            local test_writer =
+                require("agentic.ui.message_writer"):new(test_bufnr)
+
+            Config.folding = {
+                tool_calls = { enabled = true, threshold = 0 },
+            }
+
+            local NS = vim.api.nvim_create_namespace("agentic_tool_blocks")
+            vim.api.nvim_buf_set_lines(
+                test_bufnr,
+                0,
+                -1,
+                false,
+                { "H", "b1", "b2", "" }
+            )
+            local ext_id = vim.api.nvim_buf_set_extmark(
+                test_bufnr,
+                NS,
+                0,
+                0,
+                { end_row = 3, right_gravity = false }
+            )
+            test_writer.tool_call_blocks["t1"] =
+                { tool_call_id = "t1", extmark_id = ext_id }
+
+            -- If registration happened, foldexpr can see the block and return 1
+            -- for an interior line (line 2 in 1-indexed).
+            assert.equal(Fold.foldexpr(test_bufnr, 2), 1)
+
+            Fold.unregister(test_bufnr)
+            vim.api.nvim_buf_delete(test_bufnr, { force = true })
+        end)
+
+        it("unregisters on destroy", function()
+            local Fold = require("agentic.ui.tool_call_fold")
+            local test_bufnr = vim.api.nvim_create_buf(false, true)
+            local test_writer =
+                require("agentic.ui.message_writer"):new(test_bufnr)
+
+            test_writer:destroy()
+
+            -- After destroy, foldexpr should not find any getter
+            -- (no crash, returns 0)
+            assert.equal(Fold.foldexpr(test_bufnr, 5), 0)
+
+            if vim.api.nvim_buf_is_valid(test_bufnr) then
+                vim.api.nvim_buf_delete(test_bufnr, { force = true })
+            end
+        end)
+    end)
 end)

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -925,81 +925,109 @@ describe("agentic.ui.MessageWriter", function()
             }
         end
 
-        it("returns empty when folding disabled", function()
-            Config.folding = {
-                tool_calls = { enabled = false, threshold = 10 },
-            }
-            seed_block(50, false)
-            assert.same(writer:_get_fold_geometry(), {})
-        end)
+        --- @class FoldGeometryCase
+        --- @field name string
+        --- @field enabled boolean
+        --- @field threshold integer
+        --- @field body_count integer
+        --- @field is_diff boolean
+        --- @field expect_empty? boolean
+        --- @field expect_foldable? boolean
 
-        it("returns foldable=true for interior > threshold", function()
-            Config.folding = {
-                tool_calls = { enabled = true, threshold = 10 },
-            }
-            seed_block(11, false)
-            local geo = writer:_get_fold_geometry()
-            assert.equal(#geo, 1)
-            assert.is_true(geo[1].foldable)
-        end)
+        --- @type FoldGeometryCase[]
+        local cases = {
+            {
+                name = "returns empty when folding disabled",
+                enabled = false,
+                threshold = 10,
+                body_count = 50,
+                is_diff = false,
+                expect_empty = true,
+            },
+            {
+                name = "foldable=true when interior > threshold",
+                enabled = true,
+                threshold = 10,
+                body_count = 11,
+                is_diff = false,
+                expect_foldable = true,
+            },
+            {
+                name = "foldable=false when interior == threshold",
+                enabled = true,
+                threshold = 10,
+                body_count = 10,
+                is_diff = false,
+                expect_foldable = false,
+            },
+            {
+                name = "threshold=0 folds any block with interior >= 1",
+                enabled = true,
+                threshold = 0,
+                body_count = 1,
+                is_diff = false,
+                expect_foldable = true,
+            },
+            {
+                name = "threshold=0 does not fold empty body",
+                enabled = true,
+                threshold = 0,
+                body_count = 0,
+                is_diff = false,
+                expect_foldable = false,
+            },
+            {
+                name = "clamps negative threshold to 0",
+                enabled = true,
+                threshold = -5,
+                body_count = 1,
+                is_diff = false,
+                expect_foldable = true,
+            },
+            {
+                name = "never folds a diff block regardless of size",
+                enabled = true,
+                threshold = 0,
+                body_count = 100,
+                is_diff = true,
+                expect_foldable = false,
+            },
+        }
 
-        it("returns foldable=false for interior <= threshold", function()
-            Config.folding = {
-                tool_calls = { enabled = true, threshold = 10 },
-            }
-            seed_block(10, false) -- interior exactly 10
-            local geo = writer:_get_fold_geometry()
-            assert.equal(#geo, 1)
-            assert.is_false(geo[1].foldable)
-        end)
+        for _, case in ipairs(cases) do
+            it(case.name, function()
+                Config.folding = {
+                    tool_calls = {
+                        enabled = case.enabled,
+                        threshold = case.threshold,
+                    },
+                }
+                seed_block(case.body_count, case.is_diff)
 
-        it("threshold=0 folds any block with interior >= 1", function()
-            Config.folding = {
-                tool_calls = { enabled = true, threshold = 0 },
-            }
-            seed_block(1, false)
-            local geo = writer:_get_fold_geometry()
-            assert.equal(#geo, 1)
-            assert.is_true(geo[1].foldable)
-        end)
+                local geo = writer:_get_fold_geometry()
 
-        it("threshold=0 does not fold empty body (interior=0)", function()
-            Config.folding = {
-                tool_calls = { enabled = true, threshold = 0 },
-            }
-            seed_block(0, false)
-            local geo = writer:_get_fold_geometry()
-            assert.equal(#geo, 1)
-            assert.is_false(geo[1].foldable)
-        end)
-
-        it("clamps negative threshold to 0", function()
-            Config.folding = {
-                tool_calls = { enabled = true, threshold = -5 },
-            }
-            seed_block(1, false)
-            local geo = writer:_get_fold_geometry()
-            assert.equal(#geo, 1)
-            assert.is_true(geo[1].foldable)
-        end)
-
-        it("never folds a diff block regardless of size", function()
-            Config.folding = {
-                tool_calls = { enabled = true, threshold = 0 },
-            }
-            seed_block(100, true) -- is_diff=true
-            local geo = writer:_get_fold_geometry()
-            assert.equal(#geo, 1)
-            assert.is_false(geo[1].foldable)
-        end)
+                if case.expect_empty then
+                    assert.same(geo, {})
+                else
+                    assert.equal(#geo, 1)
+                    assert.equal(geo[1].foldable, case.expect_foldable)
+                end
+            end)
+        end
     end)
 
     describe("Fold integration", function()
+        local Fold = require("agentic.ui.tool_call_fold")
+
+        --- @return integer bufnr, agentic.ui.MessageWriter writer
+        local function make_writer()
+            local b = vim.api.nvim_create_buf(false, true)
+            local w = require("agentic.ui.message_writer"):new(b)
+            return b, w
+        end
+
         it("registers a getter on construction", function()
-            local Fold = require("agentic.ui.tool_call_fold")
-            local test_bufnr = vim.api.nvim_create_buf(false, true)
-            local test_writer =
-                require("agentic.ui.message_writer"):new(test_bufnr)
+            local test_bufnr, test_writer = make_writer()
 
             Config.folding = {
                 tool_calls = { enabled = true, threshold = 0 },
@@ -1023,8 +1051,8 @@ describe("agentic.ui.MessageWriter", function()
             test_writer.tool_call_blocks["t1"] =
                 { tool_call_id = "t1", extmark_id = ext_id }
 
-            -- If registration happened, foldexpr can see the block and return 1
-            -- for an interior line (line 2 in 1-indexed).
+            -- If registration happened, foldexpr returns 1 for an interior
+            -- line (line 2 in 1-indexed).
             assert.equal(Fold.foldexpr(test_bufnr, 2), 1)
 
             Fold.unregister(test_bufnr)
@@ -1032,15 +1060,10 @@ describe("agentic.ui.MessageWriter", function()
         end)
 
         it("unregisters on destroy", function()
-            local Fold = require("agentic.ui.tool_call_fold")
-            local test_bufnr = vim.api.nvim_create_buf(false, true)
-            local test_writer =
-                require("agentic.ui.message_writer"):new(test_bufnr)
+            local test_bufnr, test_writer = make_writer()
 
             test_writer:destroy()
 
-            -- After destroy, foldexpr should not find any getter
-            -- (no crash, returns 0)
             assert.equal(Fold.foldexpr(test_bufnr, 5), 0)
 
             if vim.api.nvim_buf_is_valid(test_bufnr) then

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -932,5 +932,15 @@ describe("agentic.ui.MessageWriter", function()
             seed_block(50, false)
             assert.same(writer:_get_fold_geometry(), {})
         end)
+
+        it("returns foldable=true for interior > threshold", function()
+            Config.folding = {
+                tool_calls = { enabled = true, threshold = 10 },
+            }
+            seed_block(11, false)
+            local geo = writer:_get_fold_geometry()
+            assert.equal(#geo, 1)
+            assert.is_true(geo[1].foldable)
+        end)
     end)
 end)

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -36,6 +36,9 @@ describe("agentic.ui.MessageWriter", function()
 
     after_each(function()
         Config.auto_scroll = original_auto_scroll --- @diagnostic disable-line: assign-type-mismatch
+        if writer then
+            writer:destroy()
+        end
         if winid and vim.api.nvim_win_is_valid(winid) then
             vim.api.nvim_win_close(winid, true)
         end

--- a/lua/agentic/ui/tool_call_fold.lua
+++ b/lua/agentic/ui/tool_call_fold.lua
@@ -53,7 +53,8 @@ end
 --- Foldtext: renders collapsed fold text.
 --- @return string
 function Fold.foldtext()
-    return ""
+    local hidden = vim.v.foldend - vim.v.foldstart + 1
+    return string.format("  %d lines hidden (zo open | zc close)", hidden)
 end
 
 --- Apply fold-related window options to the chat window.

--- a/lua/agentic/ui/tool_call_fold.lua
+++ b/lua/agentic/ui/tool_call_fold.lua
@@ -56,7 +56,10 @@ end
 --- @return string
 function Fold.foldtext()
     local hidden = vim.v.foldend - vim.v.foldstart + 1
-    return string.format("  %d lines hidden (zo open | zc close)", hidden)
+    return string.format(
+        "  %d lines hidden (Fold: `zo` open | `zc` close)",
+        hidden
+    )
 end
 
 --- Apply fold-related window options to the chat window.

--- a/lua/agentic/ui/tool_call_fold.lua
+++ b/lua/agentic/ui/tool_call_fold.lua
@@ -1,0 +1,57 @@
+--- @class agentic.ui.ToolCallFold.Block
+--- @field start_row integer 0-indexed header row of the block
+--- @field end_row integer 0-indexed footer row of the block (inclusive)
+--- @field foldable boolean Whether this block should be folded
+
+--- @alias agentic.ui.ToolCallFold.Getter fun(): agentic.ui.ToolCallFold.Block[]
+
+--- @class agentic.ui.ToolCallFold
+local Fold = {}
+
+--- Strong table: bufnr -> { getter = agentic.ui.ToolCallFold.Getter }
+--- Strong because the getter closure has no other referent.
+--- Must be cleaned up via unregister().
+--- @type table<integer, { getter: agentic.ui.ToolCallFold.Getter }>
+local instances_by_buffer = {}
+
+--- Register a getter for a buffer. Called once per MessageWriter instance.
+--- @param bufnr integer
+--- @param getter agentic.ui.ToolCallFold.Getter
+function Fold.register(bufnr, getter)
+    local _ = bufnr
+    local _ = getter
+    local _ = instances_by_buffer
+end
+
+--- Remove a buffer's getter. Safe to call on an already-unregistered bufnr.
+--- @param bufnr integer
+function Fold.unregister(bufnr)
+    local _ = bufnr
+end
+
+--- Foldexpr: called by Neovim for each line. Returns 0 (not foldable) or 1 (foldable).
+--- Not a method - dispatched via v:lua, which cannot invoke instance methods.
+--- @param bufnr integer
+--- @param lnum integer 1-indexed line number
+--- @return integer fold_level 0 or 1
+function Fold.foldexpr(bufnr, lnum)
+    local _ = bufnr
+    local _ = lnum
+    return 0
+end
+
+--- Foldtext: renders collapsed fold text.
+--- @return string
+function Fold.foldtext()
+    return ""
+end
+
+--- Apply fold-related window options to the chat window.
+--- @param winid integer
+--- @param bufnr integer
+function Fold.setup_window(winid, bufnr)
+    local _ = winid
+    local _ = bufnr
+end
+
+return Fold

--- a/lua/agentic/ui/tool_call_fold.lua
+++ b/lua/agentic/ui/tool_call_fold.lua
@@ -1,3 +1,5 @@
+local Config = require("agentic.config")
+
 --- @class agentic.ui.ToolCallFold.Block
 --- @field start_row integer 0-indexed header row of the block
 --- @field end_row integer 0-indexed footer row of the block (inclusive)
@@ -61,8 +63,28 @@ end
 --- @param winid integer
 --- @param bufnr integer
 function Fold.setup_window(winid, bufnr)
-    local _ = winid
-    local _ = bufnr
+    local cfg = Config.folding and Config.folding.tool_calls
+    if not cfg or not cfg.enabled then
+        return
+    end
+
+    local desired_expr = string.format(
+        "v:lua.require'agentic.ui.tool_call_fold'.foldexpr(%d, v:lnum)",
+        bufnr
+    )
+
+    -- Idempotent: if this window has already been configured by us, skip.
+    -- Reapplying would reset foldlevel=0, re-closing folds the user opened.
+    if vim.wo[winid].foldexpr == desired_expr then
+        return
+    end
+
+    vim.wo[winid].foldmethod = "expr"
+    vim.wo[winid].foldexpr = desired_expr
+    vim.wo[winid].foldlevel = 0
+    vim.wo[winid].foldenable = true
+    vim.wo[winid].foldtext =
+        "v:lua.require'agentic.ui.tool_call_fold'.foldtext()"
 end
 
 return Fold

--- a/lua/agentic/ui/tool_call_fold.lua
+++ b/lua/agentic/ui/tool_call_fold.lua
@@ -18,15 +18,13 @@ local instances_by_buffer = {}
 --- @param bufnr integer
 --- @param getter agentic.ui.ToolCallFold.Getter
 function Fold.register(bufnr, getter)
-    local _ = bufnr
-    local _ = getter
-    local _ = instances_by_buffer
+    instances_by_buffer[bufnr] = { getter = getter }
 end
 
 --- Remove a buffer's getter. Safe to call on an already-unregistered bufnr.
 --- @param bufnr integer
 function Fold.unregister(bufnr)
-    local _ = bufnr
+    instances_by_buffer[bufnr] = nil
 end
 
 --- Foldexpr: called by Neovim for each line. Returns 0 (not foldable) or 1 (foldable).
@@ -35,8 +33,20 @@ end
 --- @param lnum integer 1-indexed line number
 --- @return integer fold_level 0 or 1
 function Fold.foldexpr(bufnr, lnum)
-    local _ = bufnr
-    local _ = lnum
+    local state = instances_by_buffer[bufnr]
+    if not state then
+        return 0
+    end
+    local blocks = state.getter()
+    for _, block in ipairs(blocks) do
+        if
+            block.foldable
+            and lnum >= block.start_row + 2
+            and lnum <= block.end_row
+        then
+            return 1
+        end
+    end
     return 0
 end
 

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -172,7 +172,7 @@ describe("agentic.ui.ToolCallFold", function()
             vim.v.foldend = 12
             assert.equal(
                 Fold.foldtext(),
-                "  10 lines hidden (zo open | zc close)"
+                "  10 lines hidden (Fold: `zo` open | `zc` close)"
             )
         end)
     end)

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -21,5 +21,21 @@ describe("agentic.ui.ToolCallFold", function()
             assert.equal(Fold.foldexpr(bufnr, 1), 0)
             assert.equal(Fold.foldexpr(bufnr, 10), 0)
         end)
+
+        it("returns 1 for lnum inside a foldable block interior", function()
+            Fold.register(bufnr, function()
+                return {
+                    {
+                        start_row = 0,
+                        end_row = 16,
+                        foldable = true,
+                    },
+                }
+            end)
+            -- Interior is start_row+2..end_row in 1-indexed: lines 2..16
+            assert.equal(Fold.foldexpr(bufnr, 2), 1)
+            assert.equal(Fold.foldexpr(bufnr, 10), 1)
+            assert.equal(Fold.foldexpr(bufnr, 16), 1)
+        end)
     end)
 end)

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -134,6 +134,16 @@ describe("agentic.ui.ToolCallFold", function()
         )
     end)
 
+    describe("foldtext", function()
+        it("formats the hidden line count", function()
+            -- Simulate v:foldstart and v:foldend
+            vim.v.foldstart = 3
+            vim.v.foldend = 12
+            local text = Fold.foldtext()
+            assert.equal(text, "  10 lines hidden (zo open | zc close)")
+        end)
+    end)
+
     describe("register and unregister", function()
         it("register adds an entry foldexpr can find", function()
             Fold.register(bufnr, function()

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -134,6 +134,55 @@ describe("agentic.ui.ToolCallFold", function()
         )
     end)
 
+    describe("setup_window", function()
+        local Config = require("agentic.config")
+        --- @type agentic.UserConfig.Folding|nil
+        local saved_folding
+
+        before_each(function()
+            saved_folding = Config.folding
+            Config.folding = {
+                tool_calls = { enabled = true, threshold = 10 },
+            }
+        end)
+
+        after_each(function()
+            Config.folding = saved_folding --- @diagnostic disable-line: assign-type-mismatch
+        end)
+
+        it(
+            "applies foldmethod, foldexpr, foldlevel, foldenable, foldtext to the window",
+            function()
+                local winid = vim.api.nvim_open_win(bufnr, false, {
+                    relative = "editor",
+                    row = 0,
+                    col = 0,
+                    width = 40,
+                    height = 20,
+                })
+
+                Fold.setup_window(winid, bufnr)
+
+                assert.equal(vim.wo[winid].foldmethod, "expr")
+                assert.equal(
+                    vim.wo[winid].foldexpr,
+                    string.format(
+                        "v:lua.require'agentic.ui.tool_call_fold'.foldexpr(%d, v:lnum)",
+                        bufnr
+                    )
+                )
+                assert.equal(vim.wo[winid].foldlevel, 0)
+                assert.is_true(vim.wo[winid].foldenable)
+                assert.equal(
+                    vim.wo[winid].foldtext,
+                    "v:lua.require'agentic.ui.tool_call_fold'.foldtext()"
+                )
+
+                vim.api.nvim_win_close(winid, true)
+            end
+        )
+    end)
+
     describe("foldtext", function()
         it("formats the hidden line count", function()
             -- Simulate v:foldstart and v:foldend

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -37,5 +37,100 @@ describe("agentic.ui.ToolCallFold", function()
             assert.equal(Fold.foldexpr(bufnr, 10), 1)
             assert.equal(Fold.foldexpr(bufnr, 16), 1)
         end)
+
+        it("returns 0 when getter returns empty list", function()
+            Fold.register(bufnr, function()
+                return {}
+            end)
+            assert.equal(Fold.foldexpr(bufnr, 1), 0)
+            assert.equal(Fold.foldexpr(bufnr, 50), 0)
+        end)
+
+        it("returns 0 for lnum on header line", function()
+            Fold.register(bufnr, function()
+                return {
+                    {
+                        start_row = 0,
+                        end_row = 16,
+                        foldable = true,
+                    },
+                }
+            end)
+            -- Header is start_row+1 in 1-indexed: line 1
+            assert.equal(Fold.foldexpr(bufnr, 1), 0)
+        end)
+
+        it("returns 0 for lnum on footer line", function()
+            Fold.register(bufnr, function()
+                return {
+                    {
+                        start_row = 0,
+                        end_row = 16,
+                        foldable = true,
+                    },
+                }
+            end)
+            -- Footer is end_row+1 in 1-indexed: line 17
+            assert.equal(Fold.foldexpr(bufnr, 17), 0)
+        end)
+
+        it("returns 0 for lnum outside the block", function()
+            Fold.register(bufnr, function()
+                return {
+                    {
+                        start_row = 5,
+                        end_row = 20,
+                        foldable = true,
+                    },
+                }
+            end)
+            assert.equal(Fold.foldexpr(bufnr, 1), 0)
+            assert.equal(Fold.foldexpr(bufnr, 5), 0)
+            assert.equal(Fold.foldexpr(bufnr, 22), 0)
+        end)
+
+        it("returns 0 for non-foldable block even in interior", function()
+            Fold.register(bufnr, function()
+                return {
+                    {
+                        start_row = 0,
+                        end_row = 16,
+                        foldable = false,
+                    },
+                }
+            end)
+            assert.equal(Fold.foldexpr(bufnr, 2), 0)
+            assert.equal(Fold.foldexpr(bufnr, 10), 0)
+        end)
+
+        it("handles multiple mixed blocks correctly per lnum", function()
+            Fold.register(bufnr, function()
+                return {
+                    { start_row = 0, end_row = 5, foldable = false },
+                    { start_row = 10, end_row = 30, foldable = true },
+                    { start_row = 35, end_row = 40, foldable = false },
+                }
+            end)
+            assert.equal(Fold.foldexpr(bufnr, 3), 0)
+            assert.equal(Fold.foldexpr(bufnr, 8), 0)
+            assert.equal(Fold.foldexpr(bufnr, 12), 1)
+            assert.equal(Fold.foldexpr(bufnr, 25), 1)
+            assert.equal(Fold.foldexpr(bufnr, 30), 1)
+            assert.equal(Fold.foldexpr(bufnr, 11), 0)
+            assert.equal(Fold.foldexpr(bufnr, 38), 0)
+        end)
+
+        it(
+            "returns 0 for block with empty interior (end_row <= start_row+1)",
+            function()
+                Fold.register(bufnr, function()
+                    return {
+                        { start_row = 0, end_row = 1, foldable = true },
+                    }
+                end)
+                assert.equal(Fold.foldexpr(bufnr, 1), 0)
+                assert.equal(Fold.foldexpr(bufnr, 2), 0)
+            end
+        )
     end)
 end)

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -209,6 +209,32 @@ describe("agentic.ui.ToolCallFold", function()
 
             vim.api.nvim_win_close(winid, true)
         end)
+
+        it(
+            "does not reset foldlevel on subsequent calls to the same window",
+            function()
+                local winid = vim.api.nvim_open_win(bufnr, false, {
+                    relative = "editor",
+                    row = 0,
+                    col = 0,
+                    width = 40,
+                    height = 20,
+                })
+
+                Fold.setup_window(winid, bufnr)
+                assert.equal(vim.wo[winid].foldlevel, 0)
+
+                -- Simulate a fold being opened by the user (raise foldlevel).
+                vim.wo[winid].foldlevel = 99
+
+                -- Re-applying must NOT reset foldlevel, or the user's opened fold
+                -- would close again on the next chat widget rerender.
+                Fold.setup_window(winid, bufnr)
+                assert.equal(vim.wo[winid].foldlevel, 99)
+
+                vim.api.nvim_win_close(winid, true)
+            end
+        )
     end)
 
     describe("foldtext", function()

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -16,271 +16,186 @@ describe("agentic.ui.ToolCallFold", function()
         end
     end)
 
+    --- @param blocks agentic.ui.ToolCallFold.Block[]
+    local function register_blocks(blocks)
+        Fold.register(bufnr, function()
+            return blocks
+        end)
+    end
+
     describe("foldexpr", function()
         it("returns 0 when no instance is registered", function()
             assert.equal(Fold.foldexpr(bufnr, 1), 0)
             assert.equal(Fold.foldexpr(bufnr, 10), 0)
         end)
 
-        it("returns 1 for lnum inside a foldable block interior", function()
-            Fold.register(bufnr, function()
-                return {
-                    {
-                        start_row = 0,
-                        end_row = 16,
-                        foldable = true,
-                    },
-                }
-            end)
-            -- Interior is start_row+2..end_row in 1-indexed: lines 2..16
-            assert.equal(Fold.foldexpr(bufnr, 2), 1)
-            assert.equal(Fold.foldexpr(bufnr, 10), 1)
-            assert.equal(Fold.foldexpr(bufnr, 16), 1)
-        end)
-
         it("returns 0 when getter returns empty list", function()
-            Fold.register(bufnr, function()
-                return {}
-            end)
+            register_blocks({})
             assert.equal(Fold.foldexpr(bufnr, 1), 0)
             assert.equal(Fold.foldexpr(bufnr, 50), 0)
         end)
 
-        it("returns 0 for lnum on header line", function()
-            Fold.register(bufnr, function()
-                return {
-                    {
-                        start_row = 0,
-                        end_row = 16,
-                        foldable = true,
-                    },
-                }
-            end)
-            -- Header is start_row+1 in 1-indexed: line 1
-            assert.equal(Fold.foldexpr(bufnr, 1), 0)
-        end)
-
-        it("returns 0 for lnum on footer line", function()
-            Fold.register(bufnr, function()
-                return {
-                    {
-                        start_row = 0,
-                        end_row = 16,
-                        foldable = true,
-                    },
-                }
-            end)
-            -- Footer is end_row+1 in 1-indexed: line 17
-            assert.equal(Fold.foldexpr(bufnr, 17), 0)
-        end)
-
-        it("returns 0 for lnum outside the block", function()
-            Fold.register(bufnr, function()
-                return {
-                    {
-                        start_row = 5,
-                        end_row = 20,
-                        foldable = true,
-                    },
-                }
-            end)
-            assert.equal(Fold.foldexpr(bufnr, 1), 0)
-            assert.equal(Fold.foldexpr(bufnr, 5), 0)
-            assert.equal(Fold.foldexpr(bufnr, 22), 0)
+        -- Single foldable block spanning rows 0..16 (header=line 1, footer=line 17,
+        -- interior=lines 2..16 in 1-indexed). Covers header/footer/interior/outside
+        -- boundaries for a foldable block.
+        it("folds only the interior lines of a foldable block", function()
+            register_blocks({
+                { start_row = 0, end_row = 16, foldable = true },
+            })
+            --- @type { lnum: integer, expected: integer, label: string }[]
+            local cases = {
+                { lnum = 1, expected = 0, label = "header" },
+                { lnum = 2, expected = 1, label = "first interior" },
+                { lnum = 10, expected = 1, label = "mid interior" },
+                { lnum = 16, expected = 1, label = "last interior" },
+                { lnum = 17, expected = 0, label = "footer" },
+                { lnum = 50, expected = 0, label = "outside" },
+            }
+            for _, c in ipairs(cases) do
+                assert.equal(Fold.foldexpr(bufnr, c.lnum), c.expected)
+            end
         end)
 
         it("returns 0 for non-foldable block even in interior", function()
-            Fold.register(bufnr, function()
-                return {
-                    {
-                        start_row = 0,
-                        end_row = 16,
-                        foldable = false,
-                    },
-                }
-            end)
+            register_blocks({
+                { start_row = 0, end_row = 16, foldable = false },
+            })
             assert.equal(Fold.foldexpr(bufnr, 2), 0)
             assert.equal(Fold.foldexpr(bufnr, 10), 0)
         end)
 
-        it("handles multiple mixed blocks correctly per lnum", function()
-            Fold.register(bufnr, function()
-                return {
-                    { start_row = 0, end_row = 5, foldable = false },
-                    { start_row = 10, end_row = 30, foldable = true },
-                    { start_row = 35, end_row = 40, foldable = false },
-                }
-            end)
-            assert.equal(Fold.foldexpr(bufnr, 3), 0)
-            assert.equal(Fold.foldexpr(bufnr, 8), 0)
-            assert.equal(Fold.foldexpr(bufnr, 12), 1)
-            assert.equal(Fold.foldexpr(bufnr, 25), 1)
-            assert.equal(Fold.foldexpr(bufnr, 30), 1)
-            assert.equal(Fold.foldexpr(bufnr, 11), 0)
-            assert.equal(Fold.foldexpr(bufnr, 38), 0)
+        it("returns 0 for block with empty interior", function()
+            register_blocks({
+                { start_row = 0, end_row = 1, foldable = true },
+            })
+            assert.equal(Fold.foldexpr(bufnr, 1), 0)
+            assert.equal(Fold.foldexpr(bufnr, 2), 0)
         end)
 
-        it(
-            "returns 0 for block with empty interior (end_row <= start_row+1)",
-            function()
-                Fold.register(bufnr, function()
-                    return {
-                        { start_row = 0, end_row = 1, foldable = true },
-                    }
-                end)
-                assert.equal(Fold.foldexpr(bufnr, 1), 0)
-                assert.equal(Fold.foldexpr(bufnr, 2), 0)
+        it("handles multiple mixed blocks per lnum", function()
+            register_blocks({
+                { start_row = 0, end_row = 5, foldable = false },
+                { start_row = 10, end_row = 30, foldable = true },
+                { start_row = 35, end_row = 40, foldable = false },
+            })
+            --- @type { lnum: integer, expected: integer }[]
+            local cases = {
+                { lnum = 3, expected = 0 },
+                { lnum = 8, expected = 0 },
+                { lnum = 11, expected = 0 },
+                { lnum = 12, expected = 1 },
+                { lnum = 25, expected = 1 },
+                { lnum = 30, expected = 1 },
+                { lnum = 38, expected = 0 },
+            }
+            for _, c in ipairs(cases) do
+                assert.equal(Fold.foldexpr(bufnr, c.lnum), c.expected)
             end
-        )
+        end)
     end)
 
     describe("setup_window", function()
         local Config = require("agentic.config")
         --- @type agentic.UserConfig.Folding|nil
         local saved_folding
+        --- @type integer
+        local winid
+
+        --- @return string
+        local function expected_foldexpr()
+            return string.format(
+                "v:lua.require'agentic.ui.tool_call_fold'.foldexpr(%d, v:lnum)",
+                bufnr
+            )
+        end
 
         before_each(function()
             saved_folding = Config.folding
             Config.folding = {
                 tool_calls = { enabled = true, threshold = 10 },
             }
-        end)
-
-        after_each(function()
-            Config.folding = saved_folding --- @diagnostic disable-line: assign-type-mismatch
-        end)
-
-        it(
-            "applies foldmethod, foldexpr, foldlevel, foldenable, foldtext to the window",
-            function()
-                local winid = vim.api.nvim_open_win(bufnr, false, {
-                    relative = "editor",
-                    row = 0,
-                    col = 0,
-                    width = 40,
-                    height = 20,
-                })
-
-                Fold.setup_window(winid, bufnr)
-
-                assert.equal(vim.wo[winid].foldmethod, "expr")
-                assert.equal(
-                    vim.wo[winid].foldexpr,
-                    string.format(
-                        "v:lua.require'agentic.ui.tool_call_fold'.foldexpr(%d, v:lnum)",
-                        bufnr
-                    )
-                )
-                assert.equal(vim.wo[winid].foldlevel, 0)
-                assert.is_true(vim.wo[winid].foldenable)
-                assert.equal(
-                    vim.wo[winid].foldtext,
-                    "v:lua.require'agentic.ui.tool_call_fold'.foldtext()"
-                )
-
-                vim.api.nvim_win_close(winid, true)
-            end
-        )
-
-        it("does not apply options when folding is disabled", function()
-            Config.folding = {
-                tool_calls = { enabled = false, threshold = 10 },
-            }
-
-            local winid = vim.api.nvim_open_win(bufnr, false, {
+            winid = vim.api.nvim_open_win(bufnr, false, {
                 relative = "editor",
                 row = 0,
                 col = 0,
                 width = 40,
                 height = 20,
             })
+        end)
+
+        after_each(function()
+            if vim.api.nvim_win_is_valid(winid) then
+                vim.api.nvim_win_close(winid, true)
+            end
+            Config.folding = saved_folding --- @diagnostic disable-line: assign-type-mismatch
+        end)
+
+        it("applies fold options to the window", function()
+            Fold.setup_window(winid, bufnr)
+
+            assert.equal(vim.wo[winid].foldmethod, "expr")
+            assert.equal(vim.wo[winid].foldexpr, expected_foldexpr())
+            assert.equal(vim.wo[winid].foldlevel, 0)
+            assert.is_true(vim.wo[winid].foldenable)
+            assert.equal(
+                vim.wo[winid].foldtext,
+                "v:lua.require'agentic.ui.tool_call_fold'.foldtext()"
+            )
+        end)
+
+        it("does not apply options when folding is disabled", function()
+            Config.folding = {
+                tool_calls = { enabled = false, threshold = 10 },
+            }
 
             Fold.setup_window(winid, bufnr)
 
-            -- Default Neovim values are preserved; our foldmethod/foldexpr are not applied.
             assert.equal(vim.wo[winid].foldmethod, "manual")
-            assert.is_not.equal(
-                vim.wo[winid].foldexpr,
-                string.format(
-                    "v:lua.require'agentic.ui.tool_call_fold'.foldexpr(%d, v:lnum)",
-                    bufnr
-                )
-            )
-
-            vim.api.nvim_win_close(winid, true)
+            assert.is_not.equal(vim.wo[winid].foldexpr, expected_foldexpr())
         end)
 
-        it(
-            "does not reset foldlevel on subsequent calls to the same window",
-            function()
-                local winid = vim.api.nvim_open_win(bufnr, false, {
-                    relative = "editor",
-                    row = 0,
-                    col = 0,
-                    width = 40,
-                    height = 20,
-                })
+        it("does not reset foldlevel on subsequent calls", function()
+            Fold.setup_window(winid, bufnr)
+            assert.equal(vim.wo[winid].foldlevel, 0)
 
-                Fold.setup_window(winid, bufnr)
-                assert.equal(vim.wo[winid].foldlevel, 0)
-
-                -- Simulate a fold being opened by the user (raise foldlevel).
-                vim.wo[winid].foldlevel = 99
-
-                -- Re-applying must NOT reset foldlevel, or the user's opened fold
-                -- would close again on the next chat widget rerender.
-                Fold.setup_window(winid, bufnr)
-                assert.equal(vim.wo[winid].foldlevel, 99)
-
-                vim.api.nvim_win_close(winid, true)
-            end
-        )
+            -- Simulate a fold opened by the user. Re-applying must NOT reset
+            -- foldlevel, or the fold would close on the next widget rerender.
+            vim.wo[winid].foldlevel = 99
+            Fold.setup_window(winid, bufnr)
+            assert.equal(vim.wo[winid].foldlevel, 99)
+        end)
     end)
 
     describe("foldtext", function()
         it("formats the hidden line count", function()
-            -- Simulate v:foldstart and v:foldend
             vim.v.foldstart = 3
             vim.v.foldend = 12
-            local text = Fold.foldtext()
-            assert.equal(text, "  10 lines hidden (zo open | zc close)")
+            assert.equal(
+                Fold.foldtext(),
+                "  10 lines hidden (zo open | zc close)"
+            )
         end)
     end)
 
     describe("register and unregister", function()
-        it("register adds an entry foldexpr can find", function()
-            Fold.register(bufnr, function()
-                return {
-                    { start_row = 0, end_row = 16, foldable = true },
-                }
-            end)
-            assert.equal(Fold.foldexpr(bufnr, 5), 1)
-        end)
-
         it("unregister removes the entry", function()
-            Fold.register(bufnr, function()
-                return {
-                    { start_row = 0, end_row = 16, foldable = true },
-                }
-            end)
+            register_blocks({
+                { start_row = 0, end_row = 16, foldable = true },
+            })
             Fold.unregister(bufnr)
             assert.equal(Fold.foldexpr(bufnr, 5), 0)
         end)
 
         it("re-register replaces the previous getter", function()
-            Fold.register(bufnr, function()
-                return {
-                    { start_row = 0, end_row = 16, foldable = true },
-                }
-            end)
-            Fold.register(bufnr, function()
-                return {}
-            end)
+            register_blocks({
+                { start_row = 0, end_row = 16, foldable = true },
+            })
+            register_blocks({})
             assert.equal(Fold.foldexpr(bufnr, 5), 0)
         end)
 
         it("unregister is safe when bufnr not registered", function()
-            Fold.unregister(bufnr) -- no error
+            Fold.unregister(bufnr)
             assert.equal(Fold.foldexpr(bufnr, 1), 0)
         end)
     end)

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -133,4 +133,42 @@ describe("agentic.ui.ToolCallFold", function()
             end
         )
     end)
+
+    describe("register and unregister", function()
+        it("register adds an entry foldexpr can find", function()
+            Fold.register(bufnr, function()
+                return {
+                    { start_row = 0, end_row = 16, foldable = true },
+                }
+            end)
+            assert.equal(Fold.foldexpr(bufnr, 5), 1)
+        end)
+
+        it("unregister removes the entry", function()
+            Fold.register(bufnr, function()
+                return {
+                    { start_row = 0, end_row = 16, foldable = true },
+                }
+            end)
+            Fold.unregister(bufnr)
+            assert.equal(Fold.foldexpr(bufnr, 5), 0)
+        end)
+
+        it("re-register replaces the previous getter", function()
+            Fold.register(bufnr, function()
+                return {
+                    { start_row = 0, end_row = 16, foldable = true },
+                }
+            end)
+            Fold.register(bufnr, function()
+                return {}
+            end)
+            assert.equal(Fold.foldexpr(bufnr, 5), 0)
+        end)
+
+        it("unregister is safe when bufnr not registered", function()
+            Fold.unregister(bufnr) -- no error
+            assert.equal(Fold.foldexpr(bufnr, 1), 0)
+        end)
+    end)
 end)

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -181,6 +181,34 @@ describe("agentic.ui.ToolCallFold", function()
                 vim.api.nvim_win_close(winid, true)
             end
         )
+
+        it("does not apply options when folding is disabled", function()
+            Config.folding = {
+                tool_calls = { enabled = false, threshold = 10 },
+            }
+
+            local winid = vim.api.nvim_open_win(bufnr, false, {
+                relative = "editor",
+                row = 0,
+                col = 0,
+                width = 40,
+                height = 20,
+            })
+
+            Fold.setup_window(winid, bufnr)
+
+            -- Default Neovim values are preserved; our foldmethod/foldexpr are not applied.
+            assert.equal(vim.wo[winid].foldmethod, "manual")
+            assert.is_not.equal(
+                vim.wo[winid].foldexpr,
+                string.format(
+                    "v:lua.require'agentic.ui.tool_call_fold'.foldexpr(%d, v:lnum)",
+                    bufnr
+                )
+            )
+
+            vim.api.nvim_win_close(winid, true)
+        end)
     end)
 
     describe("foldtext", function()

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -1,0 +1,25 @@
+local assert = require("tests.helpers.assert")
+local Fold = require("agentic.ui.tool_call_fold")
+
+describe("agentic.ui.ToolCallFold", function()
+    --- @type number
+    local bufnr
+
+    before_each(function()
+        bufnr = vim.api.nvim_create_buf(false, true)
+    end)
+
+    after_each(function()
+        Fold.unregister(bufnr)
+        if vim.api.nvim_buf_is_valid(bufnr) then
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end
+    end)
+
+    describe("foldexpr", function()
+        it("returns 0 when no instance is registered", function()
+            assert.equal(Fold.foldexpr(bufnr, 1), 0)
+            assert.equal(Fold.foldexpr(bufnr, 10), 0)
+        end)
+    end)
+end)

--- a/lua/agentic/ui/widget_layout.lua
+++ b/lua/agentic/ui/widget_layout.lua
@@ -1,6 +1,7 @@
 local Config = require("agentic.config")
 local DefaultConfig = require("agentic.config_default")
 local BufHelpers = require("agentic.utils.buf_helpers")
+local Fold = require("agentic.ui.tool_call_fold")
 local WindowDecoration = require("agentic.ui.window_decoration")
 local Logger = require("agentic.utils.logger")
 
@@ -204,6 +205,8 @@ local function show_layout(params, position)
         winfixheight = is_bottom,
         winfixwidth = not is_bottom,
     })
+
+    Fold.setup_window(win_nrs.chat, buf_nrs.chat)
 
     -- Input window: right splits below chat with height, bottom splits right
     -- of chat with computed stack width


### PR DESCRIPTION
## Summary

- Auto-fold tool call bodies whose interior exceeds a configurable line threshold (default 10)
- Diff-kind tool calls are never folded (preserves diff context)
- New `agentic.ui.tool_call_fold` module owns fold logic (foldexpr, foldtext, setup_window, register/unregister)
- Uses Neovim's `foldmethod=expr` with a getter closure over MessageWriter's `tool_call_blocks`; no cache, Neovim re-evaluates on buffer edits
- Config: `folding.tool_calls = { enabled = true, threshold = 10 }` (threshold = 0 always folds, negatives clamp to 0, enabled = false disables)
- Folded display: `  N lines hidden (zo open | zc close)`
- closes #154 

## Test Plan

- [ ] Unit: 17 new tests in `tool_call_fold.test.lua` (foldexpr, foldtext, setup_window, register/unregister) — all pass
- [ ] Unit: 7 new tests in `message_writer.test.lua` (`_get_fold_geometry`, Fold integration) — all pass
- [ ] Manual: trigger tool call with < 10 body lines → no fold
- [ ] Manual: trigger tool call with > 10 body lines → body collapses, header/footer visible
- [ ] Manual: trigger diff edit → no fold regardless of size
- [ ] Manual: `zo`/`zc`/`zR`/`zM` work on folded blocks
- [ ] Manual: `enabled = false` → no folds form
- [ ] Manual: `threshold = 0` → 1-line body folds; `threshold = -5` behaves like 0