### PR TITLE
ci: add neovim v0.12.1 to test and typecheck matrices

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        neovim-version: ['v0.11.5', 'nightly']
+        neovim-version: ['v0.11.5', 'v0.12.1', 'nightly']
 
     steps:
       - uses: actions/checkout@v4
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        neovim-version: ['v0.11.5', 'nightly']
+        neovim-version: ['v0.11.5', 'v0.12.1', 'nightly']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add pinned `v0.12.1` alongside `v0.11.5` and `nightly` in the `test` and `typecheck` job matrices
- No other changes needed: download URL and cache key already parameterized on `matrix.neovim-version`; stable versions stay cached indefinitely