### PR TITLE
feat(hooks): add on_file_edit hook for post-write callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,7 +858,20 @@ integrating with other plugins.
               }
             end
           end
-      end
+      end,
+
+      -- Called after Agentic writes to a file (file-mutating tool call completed).
+      -- Note: mutating the file here (e.g. formatters that save) can cause the
+      -- agent to re-read or retry edits on its next action.
+      on_file_edit = function(data)
+        -- data.filepath: string - Absolute path to the edited file
+        -- data.session_id: string - The ACP session ID
+        -- data.tab_page_id: number - The Neovim tabpage ID
+        -- data.bufnr: number|nil - Buffer number if the file is loaded
+        if data.bufnr then
+          vim.lsp.buf.format({ bufnr = data.bufnr, timeout_ms = 5000 })
+        end
+      end,
     }
   }
 }

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -610,9 +610,20 @@ Event hooks ~
         -- data.tab_page_id: number
         -- data.update: table
       end,
+      on_file_edit = function(data)
+        -- data.filepath: string (absolute path)
+        -- data.session_id: string
+        -- data.tab_page_id: number
+        -- data.bufnr: number|nil (if file is loaded in a buffer)
+      end,
     },
   }
 <
+Note: mutating the file inside `on_file_edit` (for example
+formatters that save) may cause the agent to re-read or retry
+edits on its next action. Prefer agent-side validation via
+CLAUDE.md / AGENTS.md when possible.
+
 
 ==============================================================================
 CUSTOMIZATION                                    *agentic-customization*

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -42,6 +42,13 @@
 --- @field tab_page_id number The tabpage ID
 --- @field update agentic.acp.SessionUpdateMessage ACP session update details.
 
+--- Data passed to the on_file_edit hook
+--- @class agentic.UserConfig.FileEditData
+--- @field filepath string Absolute path to the edited file
+--- @field session_id string The ACP session ID
+--- @field tab_page_id number The tabpage ID
+--- @field bufnr? number Buffer number if the file is loaded in a buffer
+
 --- @class agentic.UserConfig.KeymapEntry
 --- @field [1] string The key binding
 --- @field mode string|string[] The mode(s) for this binding
@@ -160,6 +167,7 @@
 --- @field on_prompt_submit? fun(data: agentic.UserConfig.PromptSubmitData): nil
 --- @field on_response_complete? fun(data: agentic.UserConfig.ResponseCompleteData): nil
 --- @field on_session_update? fun(data: agentic.UserConfig.SessionUpdateData): nil
+--- @field on_file_edit? fun(data: agentic.UserConfig.FileEditData): nil
 
 --- Control various behaviors and features of the plugin
 --- @class agentic.UserConfig.Settings
@@ -465,6 +473,7 @@ local ConfigDefault = {
         on_prompt_submit = nil,
         on_response_complete = nil,
         on_session_update = nil,
+        on_file_edit = nil,
     },
 
     headers = {},

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -462,14 +462,21 @@ function SessionManager:_on_tool_call_update(tool_call_update)
 
             DiffPreview.cleanup_suggestion_buffer(tracker.file_path)
 
+            -- Skip the hook during restore replay: the provider replays
+            -- historical tool calls as "completed" but no write happened now.
             if
-                type(tracker.file_path) == "string"
+                not self._is_restoring_session
+                and type(tracker.file_path) == "string"
                 and tracker.file_path ~= ""
             then
                 local abs_path = FileSystem.to_absolute_path(tracker.file_path)
                 local raw_bufnr = vim.fn.bufnr(abs_path)
                 --- @type number|nil
-                local bufnr = raw_bufnr ~= -1 and raw_bufnr or nil
+                local bufnr = (
+                    raw_bufnr ~= -1 and vim.api.nvim_buf_is_loaded(raw_bufnr)
+                )
+                        and raw_bufnr
+                    or nil
                 --- @type agentic.UserConfig.FileEditData
                 local hook_data = {
                     filepath = abs_path,

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -27,7 +27,7 @@ local FILE_MUTATING_KINDS = {
 }
 
 --- Safely invoke a user-configured hook
---- @param hook_name "on_prompt_submit" | "on_response_complete" | "on_session_update"
+--- @param hook_name "on_prompt_submit" | "on_response_complete" | "on_session_update" | "on_file_edit"
 --- @param data table
 function P.invoke_hook(hook_name, data)
     local hook = Config.hooks and Config.hooks[hook_name]
@@ -459,6 +459,22 @@ function SessionManager:_on_tool_call_update(tool_call_update)
             vim.cmd.checktime()
 
             DiffPreview.cleanup_suggestion_buffer(tracker.file_path)
+
+            if
+                type(tracker.file_path) == "string"
+                and tracker.file_path ~= ""
+            then
+                local abs_path = FileSystem.to_absolute_path(tracker.file_path)
+                local raw_bufnr = vim.fn.bufnr(abs_path)
+                --- @type number|nil
+                local bufnr = raw_bufnr ~= -1 and raw_bufnr or nil
+                P.invoke_hook("on_file_edit", {
+                    filepath = abs_path,
+                    session_id = self.session_id,
+                    tab_page_id = self.tab_page_id,
+                    bufnr = bufnr,
+                })
+            end
         end
     end
 

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -386,6 +386,12 @@ function SessionManager:_on_session_update(update)
         )
     end
 
+    -- Skip the hook during restore replay: the provider re-emits historical
+    -- updates and users expect hooks to reflect live activity.
+    if self._is_restoring_session then
+        return
+    end
+
     -- This is being done after handling specific updates but one could argue
     -- there should be pre/post hooks for everything.
     --- @type agentic.UserConfig.SessionUpdateData

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -28,7 +28,7 @@ local FILE_MUTATING_KINDS = {
 
 --- Safely invoke a user-configured hook
 --- @param hook_name "on_prompt_submit" | "on_response_complete" | "on_session_update" | "on_file_edit"
---- @param data table
+--- @param data agentic.UserConfig.PromptSubmitData | agentic.UserConfig.ResponseCompleteData | agentic.UserConfig.SessionUpdateData | agentic.UserConfig.FileEditData
 function P.invoke_hook(hook_name, data)
     local hook = Config.hooks and Config.hooks[hook_name]
 
@@ -388,11 +388,13 @@ function SessionManager:_on_session_update(update)
 
     -- This is being done after handling specific updates but one could argue
     -- there should be pre/post hooks for everything.
-    P.invoke_hook("on_session_update", {
+    --- @type agentic.UserConfig.SessionUpdateData
+    local hook_data = {
         session_id = self.session_id,
         tab_page_id = self.tab_page_id,
         update = update,
-    })
+    }
+    P.invoke_hook("on_session_update", hook_data)
 end
 
 --- @param tool_call agentic.ui.MessageWriter.ToolCallBlock
@@ -468,12 +470,14 @@ function SessionManager:_on_tool_call_update(tool_call_update)
                 local raw_bufnr = vim.fn.bufnr(abs_path)
                 --- @type number|nil
                 local bufnr = raw_bufnr ~= -1 and raw_bufnr or nil
-                P.invoke_hook("on_file_edit", {
+                --- @type agentic.UserConfig.FileEditData
+                local hook_data = {
                     filepath = abs_path,
                     session_id = self.session_id,
                     tab_page_id = self.tab_page_id,
                     bufnr = bufnr,
-                })
+                }
+                P.invoke_hook("on_file_edit", hook_data)
             end
         end
     end
@@ -798,11 +802,13 @@ function SessionManager:_handle_input_submit(input_text)
 
     self.status_animation:start("thinking")
 
-    P.invoke_hook("on_prompt_submit", {
+    --- @type agentic.UserConfig.PromptSubmitData
+    local prompt_hook_data = {
         prompt = input_text,
         session_id = self.session_id,
         tab_page_id = self.tab_page_id,
-    })
+    }
+    P.invoke_hook("on_prompt_submit", prompt_hook_data)
 
     local session_id = self.session_id
     local tab_page_id = self.tab_page_id
@@ -845,12 +851,14 @@ function SessionManager:_handle_input_submit(input_text)
 
             self.status_animation:stop()
 
-            P.invoke_hook("on_response_complete", {
-                session_id = session_id,
+            --- @type agentic.UserConfig.ResponseCompleteData
+            local response_hook_data = {
+                session_id = session_id --[[@as string]],
                 tab_page_id = tab_page_id,
                 success = err == nil,
                 error = err,
-            })
+            }
+            P.invoke_hook("on_response_complete", response_hook_data)
         end)
     end)
 

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -902,6 +902,71 @@ describe("agentic.SessionManager", function()
         )
 
         it(
+            "does not invoke on_file_edit during session restore replay",
+            function()
+                local hook_spy = spy.new(function() end)
+                Config.hooks = Config.hooks or {}
+                Config.hooks.on_file_edit = function(data)
+                    hook_spy(data)
+                end
+
+                local session = make_session({
+                    ["tc-1"] = {
+                        kind = "edit",
+                        status = "in_progress",
+                        file_path = "/tmp/restore-replay.lua",
+                    },
+                })
+                session._is_restoring_session = true
+
+                SessionManager._on_tool_call_update(
+                    session,
+                    { tool_call_id = "tc-1", status = "completed" }
+                )
+
+                assert.spy(hook_spy).was.called(0)
+            end
+        )
+
+        it(
+            "invokes on_file_edit with nil bufnr when buffer exists but is not loaded",
+            function()
+                local hook_spy = spy.new(function() end)
+                Config.hooks = Config.hooks or {}
+                Config.hooks.on_file_edit = function(data)
+                    hook_spy(data)
+                end
+
+                local abs_path = vim.fn.fnamemodify(
+                    "./tests/fixtures/unloaded_hook.lua",
+                    ":p"
+                )
+                local test_bufnr = vim.fn.bufadd(abs_path)
+                assert.is_false(vim.api.nvim_buf_is_loaded(test_bufnr))
+
+                local session = make_session({
+                    ["tc-1"] = {
+                        kind = "edit",
+                        status = "in_progress",
+                        file_path = abs_path,
+                    },
+                })
+
+                SessionManager._on_tool_call_update(
+                    session,
+                    { tool_call_id = "tc-1", status = "completed" }
+                )
+
+                assert.spy(hook_spy).was.called(1)
+                local data = hook_spy.calls[1][1]
+                assert.equal(abs_path, data.filepath)
+                assert.is_nil(data.bufnr)
+
+                vim.api.nvim_buf_delete(test_bufnr, { force = true })
+            end
+        )
+
+        it(
             "does not invoke on_file_edit for non-file-mutating tool calls",
             function()
                 local hook_spy = spy.new(function() end)

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -695,15 +695,21 @@ describe("agentic.SessionManager", function()
     end)
 
     describe("on_tool_call_update: buffer reload", function()
+        local Config = require("agentic.config")
+        local DiffPreview = require("agentic.ui.diff_preview")
         --- @type TestStub
         local checktime_stub
         --- @type TestStub
         local schedule_stub
+        --- @type TestStub
+        local cleanup_suggestion_buffer_stub
 
         --- @param tool_call_blocks table<string, table>
         --- @return agentic.SessionManager
         local function make_session(tool_call_blocks)
             return {
+                session_id = "session-1",
+                tab_page_id = 42,
                 message_writer = {
                     update_tool_call_block = function() end,
                     tool_call_blocks = tool_call_blocks,
@@ -729,11 +735,16 @@ describe("agentic.SessionManager", function()
             schedule_stub:invokes(function(fn)
                 fn()
             end)
+            cleanup_suggestion_buffer_stub =
+                spy.stub(DiffPreview, "cleanup_suggestion_buffer")
         end)
 
         after_each(function()
             checktime_stub:revert()
             schedule_stub:revert()
+            cleanup_suggestion_buffer_stub:revert()
+            Config.hooks = Config.hooks or {}
+            Config.hooks.on_file_edit = nil
         end)
 
         it("calls checktime for each file-mutating kind", function()
@@ -797,6 +808,124 @@ describe("agentic.SessionManager", function()
             assert.spy(checktime_stub).was.called(0)
             debug_stub:revert()
         end)
+
+        it(
+            "invokes on_file_edit hook for file-mutating tool calls with absolute path and bufnr",
+            function()
+                local hook_spy = spy.new(function() end)
+                Config.hooks = Config.hooks or {}
+                Config.hooks.on_file_edit = function(data)
+                    hook_spy(data)
+                end
+
+                local test_bufnr = vim.api.nvim_create_buf(false, true)
+                local abs_path =
+                    vim.fn.fnamemodify("./tests/fixtures/edit_hook.lua", ":p")
+                vim.api.nvim_buf_set_name(test_bufnr, abs_path)
+
+                local session = make_session({
+                    ["tc-1"] = {
+                        kind = "edit",
+                        status = "in_progress",
+                        file_path = abs_path,
+                    },
+                })
+
+                SessionManager._on_tool_call_update(
+                    session,
+                    { tool_call_id = "tc-1", status = "completed" }
+                )
+
+                assert.spy(hook_spy).was.called(1)
+                local data = hook_spy.calls[1][1]
+                assert.equal(abs_path, data.filepath)
+                assert.equal("session-1", data.session_id)
+                assert.equal(42, data.tab_page_id)
+                assert.equal(test_bufnr, data.bufnr)
+
+                vim.api.nvim_buf_delete(test_bufnr, { force = true })
+            end
+        )
+
+        it(
+            "invokes on_file_edit with nil bufnr when file is not loaded",
+            function()
+                local hook_spy = spy.new(function() end)
+                Config.hooks = Config.hooks or {}
+                Config.hooks.on_file_edit = function(data)
+                    hook_spy(data)
+                end
+
+                local unloaded_path = "/tmp/agentic-unloaded-"
+                    .. tostring(vim.loop.hrtime())
+
+                local session = make_session({
+                    ["tc-1"] = {
+                        kind = "edit",
+                        status = "in_progress",
+                        file_path = unloaded_path,
+                    },
+                })
+
+                SessionManager._on_tool_call_update(
+                    session,
+                    { tool_call_id = "tc-1", status = "completed" }
+                )
+
+                assert.spy(hook_spy).was.called(1)
+                local data = hook_spy.calls[1][1]
+                assert.equal(unloaded_path, data.filepath)
+                assert.is_nil(data.bufnr)
+            end
+        )
+
+        it(
+            "does not invoke on_file_edit when tracker has no file_path",
+            function()
+                local hook_spy = spy.new(function() end)
+                Config.hooks = Config.hooks or {}
+                Config.hooks.on_file_edit = function(data)
+                    hook_spy(data)
+                end
+
+                local session = make_session({
+                    ["tc-1"] = { kind = "edit", status = "in_progress" },
+                })
+
+                SessionManager._on_tool_call_update(
+                    session,
+                    { tool_call_id = "tc-1", status = "completed" }
+                )
+
+                assert.spy(hook_spy).was.called(0)
+            end
+        )
+
+        it(
+            "does not invoke on_file_edit for non-file-mutating tool calls",
+            function()
+                local hook_spy = spy.new(function() end)
+                Config.hooks = Config.hooks or {}
+                Config.hooks.on_file_edit = function(data)
+                    hook_spy(data)
+                end
+
+                local session = make_session({
+                    ["tc-1"] = {
+                        kind = "read",
+                        status = "in_progress",
+                        file_path = "/tmp/foo.lua",
+                    },
+                })
+
+                SessionManager._on_tool_call_update(
+                    session,
+                    { tool_call_id = "tc-1", status = "completed" }
+                )
+
+                assert.spy(hook_spy).was.called(0)
+            end
+        )
     end)
 
     describe("_cancel_session resets is_generating", function()

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -635,6 +635,84 @@ describe("agentic.SessionManager", function()
         end)
     end)
 
+    describe("_on_session_update: on_session_update hook", function()
+        local Config = require("agentic.config")
+        --- @type TestStub
+        local schedule_stub
+
+        before_each(function()
+            schedule_stub = spy.stub(vim, "schedule")
+            schedule_stub:invokes(function(fn)
+                fn()
+            end)
+        end)
+
+        after_each(function()
+            schedule_stub:revert()
+            Config.hooks = Config.hooks or {}
+            Config.hooks.on_session_update = nil
+        end)
+
+        --- @return agentic.SessionManager
+        local function make_session()
+            return {
+                session_id = "session-1",
+                tab_page_id = 42,
+                _is_restoring_session = false,
+                todo_list = { render = function() end },
+                message_writer = {
+                    write_restoring_message = function() end,
+                    write_message_chunk = function() end,
+                },
+                chat_history = {
+                    add_message = function() end,
+                    append_agent_text = function() end,
+                },
+                status_animation = { start = function() end },
+                agent = { provider_config = { name = "Test" } },
+                _on_session_update = SessionManager._on_session_update,
+            } --[[@as agentic.SessionManager]]
+        end
+
+        it("fires for regular updates", function()
+            local hook_spy = spy.new(function() end)
+            Config.hooks = Config.hooks or {}
+            Config.hooks.on_session_update = function(data)
+                hook_spy(data)
+            end
+
+            local session = make_session()
+            session:_on_session_update({
+                sessionUpdate = "agent_message_chunk",
+                content = { type = "text", text = "hello" },
+            })
+
+            assert.spy(hook_spy).was.called(1)
+            local data = hook_spy.calls[1][1]
+            assert.equal("session-1", data.session_id)
+            assert.equal(42, data.tab_page_id)
+            assert.equal("agent_message_chunk", data.update.sessionUpdate)
+        end)
+
+        it("does not fire during session restore replay", function()
+            local hook_spy = spy.new(function() end)
+            Config.hooks = Config.hooks or {}
+            Config.hooks.on_session_update = function(data)
+                hook_spy(data)
+            end
+
+            local session = make_session()
+            session._is_restoring_session = true
+
+            session:_on_session_update({
+                sessionUpdate = "agent_message_chunk",
+                content = { type = "text", text = "replayed" },
+            })
+
+            assert.spy(hook_spy).was.called(0)
+        end)
+    end)
+
     describe("_on_session_update: user_message_chunk", function()
         --- @type TestSpy
         local write_message_spy


### PR DESCRIPTION
## Summary

- Adds `on_file_edit` hook fired after file-mutating tool calls complete, with `filepath`, `session_id`, `tab_page_id`, and `bufnr` (nil when file not loaded).
- Rebased and adapted from @qianchongyang's stale PR #163:
  - `tracker.argument` renamed to `tracker.file_path` (post-refactor PR #162).
  - Uses `self.tab_page_id` instead of `self.widget.tabpage` (per CodeRabbit).
  - Guards on `type(tracker.file_path) == \"string\"` and empty string (per CodeRabbit).
  - `bufnr` field uses LuaCATS `? number` optional syntax (per AGENTS.md style).
- Adds doc/README warning: mutating the file in this hook can cause the agent to re-read or retry edits.
- Fix #110
- Close #163 (credit to @qianchongyang)

## Test plan

- [x] `make validate` (format, luals, selene, test all pass)
- [x] 4 new `it()` blocks in `session_manager.test.lua`:
  - fires with absolute path + bufnr when file loaded
  - fires with nil bufnr when file not loaded
  - does not fire when tracker lacks `file_path`
  - does not fire for non-file-mutating tool calls
