### PR TITLE
feat: Add support for restoring sessions by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ individual folds, or `zR`/`zM` to open/close all folds in the chat window.
 | `:lua require("agentic").new_session()`                      | Start new chat session, destroying and cleaning the current one   |
 | `:lua require("agentic").stop_generation()`                  | Stop current generation or tool execution (session stays active)  |
 | `:lua require("agentic").restore_session()`                  | Show provider's session picker to restore a previous session      |
+| `:lua require("agentic").restore_session_by_id(session_id)`  | Restore a session by its ID                                       |
 | `:lua require("agentic").switch_provider()`                  | Switch ACP provider mid-session (shows picker, preserves history) |
 | `:lua require("agentic").rotate_layout()`                    | Rotate window position through layouts (right → bottom → left)    |
 
@@ -593,6 +594,15 @@ require("agentic").add_files_to_context({
   focus_prompt = false,
 })
 ```
+
+`restore_session_by_id(session_id)` accepts a **session_id** argument with the
+ID of the session you want to restore.
+
+```lua
+-- Restore a session by ID
+require("agentic").restore_session_by_id("58e5cf8a-1277-4e43-bc29-10c1246a2c66")
+```
+
 
 ### Built-in Keybindings
 

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -438,6 +438,13 @@ agentic.restore_session()
   session. Sessions are interchangeable between Neovim and the
   terminal.
 
+                                             *agentic.restore_session_by_id()*
+agentic.restore_session_by_id({session_id})
+  Restore a previous session by it's ID.
+
+  Parameters: ~
+    {session_id}  (string)  Session ID to restore.
+
                                               *agentic.rotate_layout()*
 agentic.rotate_layout({layouts})
   Rotate through window positions (right -> bottom -> left).

--- a/lua/agentic/init.lua
+++ b/lua/agentic/init.lua
@@ -315,6 +315,14 @@ function Agentic.restore_session()
     end)
 end
 
+-- restore a session by it's ID.
+-- @param session_id string: the ID of the session to restore.
+function Agentic.restore_session_by_id(session_id)
+    SessionRegistry.get_session_for_tab_page(nil, function(session)
+        SessionRestore.restore_by_id(session, session_id)
+    end)
+end
+
 --- Used to make sure we don't set multiple signal handlers or autocmds, if the user calls setup multiple times
 local traps_set = false
 local cleanup_group = vim.api.nvim_create_augroup("AgenticCleanup", {

--- a/lua/agentic/session_restore.lua
+++ b/lua/agentic/session_restore.lua
@@ -98,4 +98,51 @@ function SessionRestore.show_picker(current_session)
     end)
 end
 
+--- Restore session by ID
+--- @param current_session agentic.SessionManager
+--- @param session_id string
+function SessionRestore.restore_by_id(current_session, session_id)
+    local cwd = vim.fn.getcwd()
+    current_session.agent:when_ready(function()
+        current_session.agent:list_sessions(cwd, function(result, err)
+            if err or not result then
+                Logger.notify(
+                    "Failed to list sessions: "
+                        .. (err and err.message or "unknown error"),
+                    vim.log.levels.WARN
+                )
+                return
+            end
+
+            local match = nil
+            for _, s in ipairs(result.sessions or {}) do
+                if s.sessionId == session_id then
+                    match = s
+                    break
+                end
+            end
+
+            if not match then
+                Logger.notify(
+                    "Session not found: " .. session_id,
+                    vim.log.levels.WARN
+                )
+                return
+            end
+
+            local title = match.title or "(no title)"
+            local date = match.updatedAt
+                    and match.updatedAt:sub(1, 16):gsub("T", " ")
+                or "unknown date"
+
+            vim.schedule(function()
+                with_conflict_check(current_session, function()
+                    current_session:load_acp_session(session_id, title, date)
+                    current_session.widget:show()
+                end)
+            end)
+        end)
+    end)
+end
+
 return SessionRestore


### PR DESCRIPTION
This allows users to programmatically restore specific sessions without needing to interact with the picker UI.

Fixes #194