### PR TITLE
ci: cache rg/fd binaries with weekly rotation

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -127,7 +127,7 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/BurntSushi/ripgrep/releases/latest \
-            | jq -r '.assets[] | select(.name | endswith("x86_64-unknown-linux-musl.tar.gz")) | .browser_download_url')
+            | jq -r '[.assets[] | select(.name | endswith("x86_64-unknown-linux-musl.tar.gz")) | .browser_download_url] | .[0]')
           curl -sfL "$url" | tar -xz -C .local/bin --strip-components=1 --wildcards '*/rg'
           chmod +x .local/bin/rg
 
@@ -148,7 +148,7 @@ jobs:
             -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/sharkdp/fd/releases/latest \
-            | jq -r '.assets[] | select(.name | endswith("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
+            | jq -r '[.assets[] | select(.name | endswith("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url] | .[0]')
           curl -sfL "$url" | tar -xz -C .local/bin --strip-components=1 --wildcards '*/fd'
           chmod +x .local/bin/fd
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -28,6 +28,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   LUALS_VERSION: 3.16.2
   STYLUA_VERSION: 2.3.1
@@ -104,25 +107,50 @@ jobs:
         id: week
         run: echo "week=$(date +%Y-%W)" >> "$GITHUB_OUTPUT"
 
-      - name: Install system dependencies
-        run: |
-          # Install newer versions of rg and fd for unit tests
-          curl -sL "$(curl -s https://api.github.com/repos/BurntSushi/ripgrep/releases/latest \
-            | grep "browser_download_url.*x86_64-unknown-linux-musl.tar.gz" \
-            | cut -d '"' -f 4 | head -n1)" \
-            | tar -xz -C /usr/local/bin --strip-components=1 --wildcards '*/rg'
-          chmod +x /usr/local/bin/rg
-
-          echo "[DEBUG] RG version: $(rg --version) from '$(which rg)' \n"
-
-          curl -sL "$(curl -s https://api.github.com/repos/sharkdp/fd/releases/latest | grep "browser_download_url.*fd-.*-x86_64-unknown-linux-gnu\.tar\.gz" | cut -d '"' -f 4)" \
-            | tar -xz -C /usr/local/bin --strip-components=1 --wildcards '*/fd'
-          chmod +x /usr/local/bin/fd
-
-          echo "[DEBUG] FD version: $(fd --version) from '$(which fd)' \n"
-
       - name: Setup directories
         run: mkdir -p .local/nvim .local/bin
+
+      - name: Cache ripgrep
+        id: cache-rg
+        uses: actions/cache@v4
+        with:
+          path: .local/bin/rg
+          # Weekly rotation - tracks `latest` upstream
+          key: rg-${{ runner.os }}-${{ steps.week.outputs.week }}
+
+      - name: Install ripgrep
+        if: steps.cache-rg.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          url=$(curl -sfL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/BurntSushi/ripgrep/releases/latest \
+            | jq -r '.assets[] | select(.name | endswith("x86_64-unknown-linux-musl.tar.gz")) | .browser_download_url')
+          curl -sfL "$url" | tar -xz -C .local/bin --strip-components=1 --wildcards '*/rg'
+          chmod +x .local/bin/rg
+
+      - name: Cache fd
+        id: cache-fd
+        uses: actions/cache@v4
+        with:
+          path: .local/bin/fd
+          # Weekly rotation - tracks `latest` upstream
+          key: fd-${{ runner.os }}-${{ steps.week.outputs.week }}
+
+      - name: Install fd
+        if: steps.cache-fd.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          url=$(curl -sfL \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/sharkdp/fd/releases/latest \
+            | jq -r '.assets[] | select(.name | endswith("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
+          curl -sfL "$url" | tar -xz -C .local/bin --strip-components=1 --wildcards '*/fd'
+          chmod +x .local/bin/fd
 
       - name: Cache Neovim
         id: cache-neovim


### PR DESCRIPTION
## Summary

- Adds `actions/cache@v4` for `.local/bin/rg` and `.local/bin/fd` with weekly-rotating keys (matches the nightly Neovim cache pattern at lines 161 of `pr-check.yml`)
- Authenticates the `api.github.com/.../releases/latest` calls with `GITHUB_TOKEN` so we get the per-repo 1000/hr rate limit instead of the shared 60/hr per-IP unauthenticated limit (this was causing the v0.11.5 `tar: gzip: stdin: not in gzip format` failure on PR #207 when the unauth IP limit was hit and the API returned a JSON error in place of the asset URL)
- Replaces `grep | cut | head` URL extraction with `jq` for cleaner JSON parsing and proper failure modes (`curl -sfL` now exits non-zero on HTTP errors instead of piping garbage into `tar`)
- Adds `permissions: contents: read` at the workflow level for defense-in-depth

## Behavior

| Scenario | What happens |
|---|---|
| Same week, cache exists | rg/fd restored from cache. **Zero API calls.** |
| New week (Monday) | Cache miss → 1 authenticated API call per tool per matrix job → fresh download → cache repopulated for the week |
| API rate limit (1000/hr per repo, ~impossible to hit) | `curl -sfL` fails non-zero → step fails loudly with the actual error |

Stable Neovim versions still cache indefinitely; nightly Neovim weekly rotation is unchanged.

## Test plan

- [ ] CI runs green on this PR (validates the new cache+install steps work on a cold cache)
- [ ] Re-running CI hits the cache (`Cache ripgrep` / `Cache fd` steps report `cache-hit: true`, install steps skip)
- [ ] Workflow YAML parses (the workflow itself runs)