### PR TITLE
feat(ui): render border pipes via statuscolumn for soft-wrap support

### DIFF
--- a/lua/agentic/acp/AGENTS.md
+++ b/lua/agentic/acp/AGENTS.md
@@ -106,8 +106,9 @@ Provider sends "tool_call"
   -> MessageWriter:write_tool_call_block(block)
      1. Renders header + body/diff lines to buffer
      2. Creates range extmark (NS_TOOL_BLOCKS) as position anchor
-     3. Creates decoration extmarks (borders, status icon)
-     4. Stores block in tool_call_blocks[id]
+     3. Updates ExtmarkBlock cache (statuscolumn border glyphs)
+     4. Applies status icon overlay extmark
+     5. Stores block in tool_call_blocks[id]
 ```
 
 **Phase 2 — `tool_call_update` (one or more)**
@@ -122,9 +123,10 @@ Provider sends "tool_call_update"
      2. Deep-merges via tbl_deep_extend("force", tracker, partial)
      3. Appends body (if both old and new exist and differ)
      4. Locates block position via range extmark
-     5. Diff already rendered: refresh decorations + status only
+     5. Diff already rendered: refresh status only
         (content frozen to prevent flicker)
      6. Diff is NEW: replace buffer lines, re-render everything
+     7. Updates ExtmarkBlock cache (statuscolumn border glyphs)
 ```
 
 **Phase 3 — final `tool_call_update` with terminal status**
@@ -140,13 +142,18 @@ Same as Phase 2, but status = "completed" | "failed"
 - **Updates are partial:** Only send what changed. MessageWriter merges onto the
   existing tracker via `tbl_deep_extend`.
 - **Diffs are immutable after first render:** Once a diff is written to the
-  buffer, content is frozen. Only status/decorations refresh on subsequent
-  updates.
+  buffer, content is frozen. Only status refreshes on subsequent updates.
 - **Body accumulates:** Multiple updates with different body content get
   concatenated with `---` dividers, not replaced.
 - **Extmarks as position anchors:** Range extmark in `NS_TOOL_BLOCKS`
   auto-adjusts when buffer content shifts. Single source of truth for block
   position.
+- **Borders via statuscolumn:** Border glyphs (╭─, │, ╰─) render via a
+  `statuscolumn` function on the chat window, not inline virtual text.
+  `ExtmarkBlock` maintains a per-buffer sorted cache of block ranges (read from
+  `NS_TOOL_BLOCKS` extmarks) and uses binary search per screen line. The
+  statuscolumn evaluates per screen line including soft-wrap continuations, so
+  borders repeat correctly on wrapped lines.
 
 ## Provider quirk handling
 

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -2,6 +2,7 @@ local Config = require("agentic.config")
 local BufHelpers = require("agentic.utils.buf_helpers")
 local BufferGuard = require("agentic.ui.buffer_guard")
 local DiffPreview = require("agentic.ui.diff_preview")
+local ExtmarkBlock = require("agentic.utils.extmark_block")
 local Logger = require("agentic.utils.logger")
 local WindowDecoration = require("agentic.ui.window_decoration")
 local WidgetLayout = require("agentic.ui.widget_layout")
@@ -206,6 +207,9 @@ function ChatWidget:clear()
                 )
             end
         end)
+        if name == "chat" then
+            ExtmarkBlock.clear_cache(bufnr)
+        end
     end
 end
 
@@ -236,6 +240,9 @@ function ChatWidget:destroy()
     self:_close_hidden_chat_window()
 
     for name, bufnr in pairs(self.buf_nrs) do
+        if name == "chat" then
+            ExtmarkBlock.clear_cache(bufnr)
+        end
         self.buf_nrs[name] = nil
         local ok = pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
         if not ok then

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -10,7 +10,6 @@ local Logger = require("agentic.utils.logger")
 local Theme = require("agentic.theme")
 
 local NS_TOOL_BLOCKS = vim.api.nvim_create_namespace("agentic_tool_blocks")
-local NS_DECORATIONS = vim.api.nvim_create_namespace("agentic_tool_decorations")
 local NS_PERMISSION_BUTTONS =
     vim.api.nvim_create_namespace("agentic_permission_buttons")
 local NS_DIFF_HIGHLIGHTS =
@@ -35,7 +34,6 @@ local NS_THINKING = vim.api.nvim_create_namespace("agentic_thinking")
 --- @field argument? string
 --- @field file_path? string
 --- @field extmark_id? integer Range extmark spanning the block
---- @field decoration_extmark_ids? integer[] IDs of decoration extmarks from ExtmarkBlock
 --- @field status? agentic.acp.ToolCallStatus
 --- @field body? string[]
 --- @field diff? agentic.ui.MessageWriter.ToolCallDiff
@@ -425,15 +423,6 @@ function MessageWriter:write_tool_call_block(tool_call_block)
             highlight_ranges
         )
 
-        tool_call_block.decoration_extmark_ids =
-            ExtmarkBlock.render_block(bufnr, NS_DECORATIONS, {
-                header_line = start_row,
-                body_start = start_row + 1,
-                body_end = end_row - 1,
-                footer_line = end_row,
-                hl_group = Theme.HL_GROUPS.CODE_BLOCK_FENCE,
-            })
-
         tool_call_block.extmark_id =
             vim.api.nvim_buf_set_extmark(bufnr, NS_TOOL_BLOCKS, start_row, 0, {
                 id = tool_call_block.extmark_id,
@@ -445,6 +434,8 @@ function MessageWriter:write_tool_call_block(tool_call_block)
 
         self:_apply_header_highlight(start_row, tool_call_block.status)
         self:_apply_status_footer(end_row, tool_call_block.status)
+
+        ExtmarkBlock.update_cache(bufnr, NS_TOOL_BLOCKS)
 
         local interior = #lines - 4
         if Fold.should_fold(interior, tool_call_block.diff ~= nil) then
@@ -544,9 +535,15 @@ function MessageWriter:update_tool_call_block(tool_call_block)
                 return false
             end
 
-            self:_clear_decoration_extmarks(tracker.decoration_extmark_ids)
-            tracker.decoration_extmark_ids =
-                self:_render_decorations(start_row, old_end_row)
+            -- Re-write header line so updated kind/argument are visible
+            local header = self:_build_header_line(tracker)
+            vim.api.nvim_buf_set_lines(
+                bufnr,
+                start_row,
+                start_row + 1,
+                false,
+                { header }
+            )
 
             self:_clear_status_namespace(start_row, old_end_row)
             self:_apply_status_highlights_if_present(
@@ -558,7 +555,6 @@ function MessageWriter:update_tool_call_block(tool_call_block)
             return false
         end
 
-        self:_clear_decoration_extmarks(tracker.decoration_extmark_ids)
         self:_clear_status_namespace(start_row, old_end_row)
 
         local new_lines, highlight_ranges = self:_prepare_block_lines(tracker)
@@ -596,14 +592,13 @@ function MessageWriter:update_tool_call_block(tool_call_block)
             right_gravity = false,
         })
 
-        tracker.decoration_extmark_ids =
-            self:_render_decorations(start_row, new_end_row)
-
         self:_apply_status_highlights_if_present(
             start_row,
             new_end_row,
             tracker.status
         )
+
+        ExtmarkBlock.update_cache(bufnr, NS_TOOL_BLOCKS)
 
         local interior = #new_lines - 4
         if
@@ -1112,7 +1107,7 @@ function MessageWriter:_apply_status_footer(footer_line, status)
 
     vim.api.nvim_buf_set_extmark(self.bufnr, NS_STATUS, footer_line, 0, {
         virt_text = {
-            { string.format(" %s %s ", icon, status), hl_group },
+            { string.format(" %s %s", icon, status), hl_group },
         },
         virt_text_pos = "overlay",
     })
@@ -1144,30 +1139,6 @@ function MessageWriter:_set_thinking_extmark(start_line, end_line, id)
             hl_eol = true,
         }
     )
-end
-
---- @param ids integer[]|nil
-function MessageWriter:_clear_decoration_extmarks(ids)
-    if not ids then
-        return
-    end
-
-    for _, id in ipairs(ids) do
-        pcall(vim.api.nvim_buf_del_extmark, self.bufnr, NS_DECORATIONS, id)
-    end
-end
-
---- @param start_row integer
---- @param end_row integer
---- @return integer[] decoration_extmark_ids
-function MessageWriter:_render_decorations(start_row, end_row)
-    return ExtmarkBlock.render_block(self.bufnr, NS_DECORATIONS, {
-        header_line = start_row,
-        body_start = start_row + 1,
-        body_end = end_row - 1,
-        footer_line = end_row,
-        hl_group = Theme.HL_GROUPS.CODE_BLOCK_FENCE,
-    })
 end
 
 --- @param start_row integer

--- a/lua/agentic/ui/widget_layout.lua
+++ b/lua/agentic/ui/widget_layout.lua
@@ -119,6 +119,17 @@ local function open_win(bufnr, enter, opts, window_name, win_opts)
         winfixheight = true,
     }, PANEL_WINDOW_OPTS, win_opts or {}, config_win_opts)
 
+    if window_name == "chat" then
+        merged_win_opts.statuscolumn =
+            "%{%v:lua.require'agentic.utils.extmark_block'.statuscolumn()%}"
+        local whl = merged_win_opts.winhighlight or ""
+        if whl ~= "" then
+            whl = whl .. ","
+        end
+        merged_win_opts.winhighlight = whl
+            .. "SignColumn:Normal,FoldColumn:Normal,LineNr:Normal,StatusColumn:Normal"
+    end
+
     for name, value in pairs(merged_win_opts) do
         vim.api.nvim_set_option_value(name, value, { win = winid })
     end

--- a/lua/agentic/utils/extmark_block.lua
+++ b/lua/agentic/utils/extmark_block.lua
@@ -10,6 +10,7 @@ local ExtmarkBlock = {}
 
 --- Per-buffer cache of block ranges for statuscolumn rendering.
 --- Maps bufnr -> sorted array of {start_row, end_row}.
+--- @protected
 --- @type table<integer, {start_row: integer, end_row: integer}[]>
 ExtmarkBlock._block_cache = {}
 
@@ -26,9 +27,6 @@ function ExtmarkBlock.update_cache(bufnr, ns_id)
             end_row = m[4].end_row,
         }
     end
-    table.sort(ranges, function(a, b)
-        return a.start_row < b.start_row
-    end)
     ExtmarkBlock._block_cache[bufnr] = ranges
 end
 
@@ -68,11 +66,11 @@ local BLANK = "  "
 --- Compute the glyph for a given line within a set of block ranges.
 --- @param ranges {start_row: integer, end_row: integer}[]
 --- @param lnum integer 0-indexed buffer line
---- @param virtnum integer 0 = first screen line, >0 = continuation
+--- @param virtnum integer 0 = first screen line, >0 = continuation, <0 = virt_lines
 --- @return string
 function ExtmarkBlock.glyph(ranges, lnum, virtnum)
     local r = find_block(ranges, lnum)
-    if not r then
+    if not r or virtnum < 0 then
         return BLANK
     end
 

--- a/lua/agentic/utils/extmark_block.lua
+++ b/lua/agentic/utils/extmark_block.lua
@@ -8,62 +8,92 @@ local GLYPHS = {
 --- @class agentic.utils.ExtmarkBlock
 local ExtmarkBlock = {}
 
---- @class agentic.utils.ExtmarkBlock.RenderBlockOpts
---- @field header_line integer 0-indexed line number for header
---- @field body_start? integer 0-indexed start line for body (optional)
---- @field body_end? integer 0-indexed end line for body (optional)
---- @field footer_line? integer 0-indexed line number for footer (optional)
---- @field hl_group string Highlight group name
+--- Per-buffer cache of block ranges for statuscolumn rendering.
+--- Maps bufnr -> sorted array of {start_row, end_row}.
+--- @type table<integer, {start_row: integer, end_row: integer}[]>
+ExtmarkBlock._block_cache = {}
 
---- Renders a complete block with header, optional body, and optional footer
+--- Update the block cache for a buffer by reading NS_TOOL_BLOCKS extmarks.
 --- @param bufnr integer
---- @param ns_id integer
---- @param opts agentic.utils.ExtmarkBlock.RenderBlockOpts
---- @return integer[]
-function ExtmarkBlock.render_block(bufnr, ns_id, opts)
-    local decoration_ids = {}
+--- @param ns_id integer The NS_TOOL_BLOCKS namespace
+function ExtmarkBlock.update_cache(bufnr, ns_id)
+    local marks =
+        vim.api.nvim_buf_get_extmarks(bufnr, ns_id, 0, -1, { details = true })
+    local ranges = {}
+    for _, m in ipairs(marks) do
+        ranges[#ranges + 1] = {
+            start_row = m[2],
+            end_row = m[4].end_row,
+        }
+    end
+    table.sort(ranges, function(a, b)
+        return a.start_row < b.start_row
+    end)
+    ExtmarkBlock._block_cache[bufnr] = ranges
+end
 
-    table.insert(
-        decoration_ids,
-        vim.api.nvim_buf_set_extmark(bufnr, ns_id, opts.header_line, 0, {
-            virt_text = {
-                { GLYPHS.TOP_LEFT .. GLYPHS.HORIZONTAL .. " ", opts.hl_group },
-            },
-            virt_text_pos = "inline",
-            hl_mode = "combine",
-        })
-    )
+--- Clear cache for a buffer.
+--- @param bufnr integer
+function ExtmarkBlock.clear_cache(bufnr)
+    ExtmarkBlock._block_cache[bufnr] = nil
+end
 
-    -- Add body pipe padding if body exists
-    if opts.body_start and opts.body_end then
-        for line_num = opts.body_start, opts.body_end do
-            table.insert(
-                decoration_ids,
-                vim.api.nvim_buf_set_extmark(bufnr, ns_id, line_num, 0, {
-                    virt_text = { { GLYPHS.VERTICAL .. " ", opts.hl_group } },
-                    virt_text_pos = "inline",
-                    hl_mode = "combine",
-                })
-            )
+--- Find the block range containing a 0-indexed line number using binary search.
+--- @param ranges {start_row: integer, end_row: integer}[]
+--- @param lnum integer 0-indexed line number
+--- @return {start_row: integer, end_row: integer}|nil
+local function find_block(ranges, lnum)
+    local lo, hi = 1, #ranges
+    while lo <= hi do
+        local mid = math.floor((lo + hi) / 2)
+        local r = ranges[mid]
+        if lnum < r.start_row then
+            hi = mid - 1
+        elseif lnum > r.end_row then
+            lo = mid + 1
+        else
+            return r
         end
     end
+    return nil
+end
 
-    if opts.footer_line then
-        table.insert(
-            decoration_ids,
-            vim.api.nvim_buf_set_extmark(bufnr, ns_id, opts.footer_line, 0, {
-                virt_text = {
-                    {
-                        GLYPHS.BOTTOM_LEFT .. GLYPHS.HORIZONTAL .. " ",
-                        opts.hl_group,
-                    },
-                },
-                virt_text_pos = "inline",
-                hl_mode = "combine",
-            })
-        )
+local HL = "%#AgenticCodeBlockFence#"
+local RESET = "%*"
+local PIPE = HL .. GLYPHS.VERTICAL .. " " .. RESET
+local CORNER_TOP = HL .. GLYPHS.TOP_LEFT .. GLYPHS.HORIZONTAL .. RESET
+local CORNER_BOTTOM = HL .. GLYPHS.BOTTOM_LEFT .. GLYPHS.HORIZONTAL .. RESET
+local BLANK = "  "
+
+--- Compute the glyph for a given line within a set of block ranges.
+--- @param ranges {start_row: integer, end_row: integer}[]
+--- @param lnum integer 0-indexed buffer line
+--- @param virtnum integer 0 = first screen line, >0 = continuation
+--- @return string
+function ExtmarkBlock.glyph(ranges, lnum, virtnum)
+    local r = find_block(ranges, lnum)
+    if not r then
+        return BLANK
     end
-    return decoration_ids
+
+    if lnum == r.start_row and virtnum == 0 then
+        return CORNER_TOP
+    elseif lnum == r.end_row and virtnum == 0 then
+        return CORNER_BOTTOM
+    else
+        return PIPE
+    end
+end
+
+--- Statuscolumn function. Returns the glyph string for the current screen line.
+--- @return string
+function ExtmarkBlock.statuscolumn()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local ranges = ExtmarkBlock._block_cache[bufnr]
+    if not ranges or #ranges == 0 then
+        return BLANK
+    end
+    return ExtmarkBlock.glyph(ranges, vim.v.lnum - 1, vim.v.virtnum)
 end
 
 return ExtmarkBlock

--- a/lua/agentic/utils/extmark_block.test.lua
+++ b/lua/agentic/utils/extmark_block.test.lua
@@ -1,5 +1,7 @@
 local assert = require("tests.helpers.assert")
 
+--- @diagnostic disable: invisible
+
 describe("extmark_block", function()
     local ExtmarkBlock = require("agentic.utils.extmark_block")
 
@@ -76,6 +78,12 @@ describe("extmark_block", function()
                 assert.equal(pipe, glyph(ranges, 12, 1))
                 assert.equal(pipe, glyph(ranges, 12, 2))
             end)
+
+            it("returns blank for virt_lines (virtnum < 0)", function()
+                assert.equal(blank, glyph(ranges, 12, -1))
+                assert.equal(blank, glyph(ranges, 10, -1))
+                assert.equal(blank, glyph(ranges, 15, -1))
+            end)
         end)
 
         describe("multiple blocks", function()
@@ -108,7 +116,7 @@ describe("extmark_block", function()
     end)
 
     describe("update_cache", function()
-        it("populates sorted ranges from extmarks", function()
+        it("populates ranges from extmarks", function()
             local buf = vim.api.nvim_create_buf(false, true)
             vim.api.nvim_buf_set_lines(
                 buf,

--- a/lua/agentic/utils/extmark_block.test.lua
+++ b/lua/agentic/utils/extmark_block.test.lua
@@ -1,0 +1,147 @@
+local assert = require("tests.helpers.assert")
+
+describe("extmark_block", function()
+    local ExtmarkBlock = require("agentic.utils.extmark_block")
+
+    local hl = "%#AgenticCodeBlockFence#"
+    local reset = "%*"
+    local pipe = hl .. "│ " .. reset
+    local corner_top = hl .. "╭─" .. reset
+    local corner_bottom = hl .. "╰─" .. reset
+    local blank = "  "
+
+    local function glyph(ranges, lnum, virtnum)
+        return ExtmarkBlock.glyph(ranges, lnum, virtnum or 0)
+    end
+
+    after_each(function()
+        ExtmarkBlock._block_cache = {}
+    end)
+
+    describe("glyph", function()
+        describe("outside any block", function()
+            it("returns blank for empty ranges", function()
+                assert.equal(blank, glyph({}, 1))
+            end)
+
+            it("returns blank for line before block", function()
+                local ranges = {
+                    { start_row = 10, end_row = 20 },
+                }
+                assert.equal(blank, glyph(ranges, 5))
+            end)
+
+            it("returns blank for line after block", function()
+                local ranges = {
+                    { start_row = 10, end_row = 20 },
+                }
+                assert.equal(blank, glyph(ranges, 25))
+            end)
+
+            it("returns blank between blocks", function()
+                local ranges = {
+                    { start_row = 5, end_row = 10 },
+                    { start_row = 20, end_row = 25 },
+                }
+                assert.equal(blank, glyph(ranges, 15))
+            end)
+        end)
+
+        describe("block glyphs", function()
+            local ranges = {
+                { start_row = 10, end_row = 15 },
+            }
+
+            it("returns corner_top on start row", function()
+                assert.equal(corner_top, glyph(ranges, 10))
+            end)
+
+            it("returns pipe on start row continuation", function()
+                assert.equal(pipe, glyph(ranges, 10, 1))
+            end)
+
+            it("returns pipe on body row", function()
+                assert.equal(pipe, glyph(ranges, 12))
+            end)
+
+            it("returns corner_bottom on end row", function()
+                assert.equal(corner_bottom, glyph(ranges, 15))
+            end)
+
+            it("returns pipe on end row continuation", function()
+                assert.equal(pipe, glyph(ranges, 15, 1))
+            end)
+
+            it("returns pipe on soft-wrapped continuation", function()
+                assert.equal(pipe, glyph(ranges, 12, 1))
+                assert.equal(pipe, glyph(ranges, 12, 2))
+            end)
+        end)
+
+        describe("multiple blocks", function()
+            local ranges = {
+                { start_row = 5, end_row = 10 },
+                { start_row = 20, end_row = 25 },
+            }
+
+            it("finds first block", function()
+                assert.equal(pipe, glyph(ranges, 7))
+            end)
+
+            it("finds second block", function()
+                assert.equal(corner_top, glyph(ranges, 20))
+            end)
+
+            it("returns blank between blocks", function()
+                assert.equal(blank, glyph(ranges, 15))
+            end)
+        end)
+
+        describe("single-line block", function()
+            it("returns corner_top (start == end, virtnum 0)", function()
+                local ranges = {
+                    { start_row = 5, end_row = 5 },
+                }
+                assert.equal(corner_top, glyph(ranges, 5))
+            end)
+        end)
+    end)
+
+    describe("update_cache", function()
+        it("populates sorted ranges from extmarks", function()
+            local buf = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_buf_set_lines(
+                buf,
+                0,
+                -1,
+                false,
+                { "a", "b", "c", "d", "e", "f", "g", "h", "i", "j" }
+            )
+            local ns = vim.api.nvim_create_namespace("test_update_cache")
+            vim.api.nvim_buf_set_extmark(buf, ns, 5, 0, { end_row = 8 })
+            vim.api.nvim_buf_set_extmark(buf, ns, 0, 0, { end_row = 2 })
+
+            ExtmarkBlock.update_cache(buf, ns)
+            local cache = ExtmarkBlock._block_cache[buf]
+
+            assert.equal(2, #cache)
+            assert.equal(0, cache[1].start_row)
+            assert.equal(2, cache[1].end_row)
+            assert.equal(5, cache[2].start_row)
+            assert.equal(8, cache[2].end_row)
+
+            vim.api.nvim_buf_delete(buf, { force = true })
+        end)
+    end)
+
+    describe("clear_cache", function()
+        it("removes cache for buffer", function()
+            local bufnr = vim.api.nvim_get_current_buf()
+            ExtmarkBlock._block_cache[bufnr] = {
+                { start_row = 0, end_row = 5 },
+            }
+            ExtmarkBlock.clear_cache(bufnr)
+            assert.is_nil(ExtmarkBlock._block_cache[bufnr])
+        end)
+    end)
+end)


### PR DESCRIPTION
## Problem

Tool call blocks use border glyphs (╭─, │, ╰─) to visually delimit their content. The previous implementation used inline virtual text extmarks at column 0 of each line. Inline virtual text only renders on the first screen line of a buffer line — soft-wrap continuation lines get no glyph, breaking the visual border.

## Alternatives considered

**Inline virtual text (previous approach):** Renders once per buffer line. Soft-wrapped continuations have no border. This is the problem being fixed.

**virt_text_repeat_linebreak:** Neovim supports a
`virt_text_repeat_linebreak` option on extmarks that repeats the glyph on soft-wrap continuations. Two problems: (1) it only works with `overlay` and `virt_text_win_col` positioning, not `inline` — this means buffer content needs 2-char padding prepended so the overlay has something to cover, plus `breakindent = true` so continuations inherit the indent; (2) the repeated glyph is always identical to the first line's, so header lines repeat `╭─` and footer lines repeat `╰─` on continuations instead of showing `│`. A neovim/neovim#35341 proposal to allow different continuation text was rejected. The workaround (uniform `│` on all lines, corners via virt_lines) loses the boxed aesthetic. See carlos-algms/agentic.nvim#196 for the full exploration.

**Sign column:** Signs are buffer-scoped (no window option override), but they share the inline virt text limitation — signs don't repeat on soft-wrap continuation lines. They also conflict with other plugins that place signs on the same line (gitsigns, diagnostics), and managing sign lifecycle (place, update, remove per line) is more bookkeeping than a stateless function.

**statuscolumn + winhighlight:** An intermediate approach explored on this branch: set `signcolumn=yes:1` to guarantee gutter width, then use `winhighlight=SignColumn:Normal` to make the gutter background seamless across colorschemes (addressing the maintainer's concern in #196 about statuscolumn having a different background color). Dropped because `signcolumn=yes:1` added extra gutter width in some setups, and `style=minimal` (already set at window creation) makes native gutter columns unnecessary — the statuscolumn auto-allocates its own width from its content.

**statuscolumn (chosen approach):** Neovim's statuscolumn is evaluated per screen line, including soft-wrap continuations. A single window option override (`statuscolumn`) is the only user setting touched — `style=minimal` (already set at window creation) handles the rest. The statuscolumn function can return different glyphs per screen line (╭─ for header, │ for body/continuations, ╰─ for footer), and renders in the gutter outside the text area. Window-local, so no interference with Snacks.nvim or other statuscolumn plugins on other windows.

## Implementation

Replace extmark-based border rendering with a statuscolumn function on the chat window. ExtmarkBlock maintains a per-buffer sorted cache of block ranges (read from NS_TOOL_BLOCKS range extmarks) and uses binary search to resolve each screen line to a glyph in O(log n).

Glyph strings are pre-computed module-level constants — no per-call allocation. The cache is updated after each tool call write/update and cleared on ChatWidget:clear() and ChatWidget:destroy().

The only window option override is `statuscolumn`. `style=minimal` (set at nvim_open_win time) already disables number, relativenumber, signcolumn, and foldcolumn. The statuscolumn auto-allocates its own gutter width from the 2-cell glyph content.

Ref: https://github.com/carlos-algms/agentic.nvim/issues/196

<img width="1620" height="398" alt="image" src="https://github.com/user-attachments/assets/666e07f7-8119-4e3c-b669-49226976dd8a" />

With soft-wrapping:

<img width="940" height="560" alt="image" src="https://github.com/user-attachments/assets/0c5a7565-186d-4c7c-a0ee-13c18728ff4c" />

tested with manually setting these before opening agentic:

```
:lua vim.api.nvim_set_hl(0, "SignColumn", {bg="#ff0000"}) vim.api.nvim_set_hl(0, "LineNr", {bg="#00ff00"}) vim.api.nvim_set_hl(0, "FoldColumn", {bg="#0000ff"}) vim.api.nvim_set_hl(0, "StatusColumn", {bg="#ffff00"})
```


Committed-By-Agent: claude