### PR TITLE
feat(ui): pretty-print single-line JSON in tool call output

### DIFF
--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -5,6 +5,7 @@ local DiffHighlighter = require("agentic.utils.diff_highlighter")
 local DiffPreview = require("agentic.ui.diff_preview")
 local ExtmarkBlock = require("agentic.utils.extmark_block")
 local Fold = require("agentic.ui.tool_call_fold")
+local JsonFormat = require("agentic.utils.json_format")
 local Logger = require("agentic.utils.logger")
 local Theme = require("agentic.theme")
 
@@ -394,6 +395,10 @@ end
 
 --- @param tool_call_block agentic.ui.MessageWriter.ToolCallBlock
 function MessageWriter:write_tool_call_block(tool_call_block)
+    if tool_call_block.body then
+        tool_call_block.body = JsonFormat.format_lines(tool_call_block.body)
+    end
+
     self:_clear_thinking_state()
     self:_capture_scroll(self.bufnr)
     self:_maybe_write_sender_header("tool_call")
@@ -464,6 +469,10 @@ function MessageWriter:update_tool_call_block(tool_call_block)
         )
 
         return
+    end
+
+    if tool_call_block.body then
+        tool_call_block.body = JsonFormat.format_lines(tool_call_block.body)
     end
 
     self:_capture_scroll(self.bufnr)

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -503,6 +503,32 @@ describe("agentic.ui.MessageWriter", function()
             assert.truthy(get_all_content():match("read"))
         end)
 
+        it("formats unformatted single-line JSON body on replay", function()
+            writer:set_provider_name("Claude")
+
+            local long_value = string.rep("v", 100)
+            local json_text = '{"key":"' .. long_value .. '","x":42}'
+
+            --- @type agentic.ui.ChatHistory.Message[]
+            local messages = {
+                {
+                    type = "tool_call",
+                    tool_call_id = "tc-json",
+                    kind = "fetch",
+                    argument = "MCP",
+                    status = "completed",
+                    body = { json_text },
+                    provider_name = "Claude",
+                },
+            }
+
+            writer:replay_history_messages(messages)
+
+            local tracker = writer.tool_call_blocks["tc-json"]
+            assert.is_not_nil(tracker)
+            assert.is_true(#tracker.body > 1)
+        end)
+
         it(
             "replay thought extmark covers content lines, not trailing blank",
             function()
@@ -677,6 +703,68 @@ describe("agentic.ui.MessageWriter", function()
             local ns = vim.api.nvim_create_namespace("agentic_thinking")
             local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, {})
             assert.equal(2, #extmarks)
+        end)
+    end)
+
+    describe("tool call body JSON formatting", function()
+        it("formats single-line JSON body when writing the block", function()
+            local long_value = string.rep("v", 100)
+            local json_text = '{"key":"' .. long_value .. '","x":42}'
+
+            local block =
+                make_tool_call_block("json-1", "completed", { json_text })
+            writer:write_tool_call_block(block)
+
+            local tracker = writer.tool_call_blocks["json-1"]
+            assert.is_not_nil(tracker)
+            assert.is_true(#tracker.body > 1)
+        end)
+
+        it(
+            "leaves placeholder text untouched and formats only JSON segments on update",
+            function()
+                local placeholder = "I'm going to fetch this"
+                local long_value = string.rep("v", 100)
+                local json_text = '{"key":"' .. long_value .. '","x":42}'
+
+                local block = make_tool_call_block(
+                    "json-stream",
+                    "in_progress",
+                    { placeholder }
+                )
+                writer:write_tool_call_block(block)
+
+                writer:update_tool_call_block({
+                    tool_call_id = "json-stream",
+                    status = "completed",
+                    body = { json_text },
+                })
+
+                local tracker = writer.tool_call_blocks["json-stream"]
+                assert.is_not_nil(tracker)
+                assert.equal(placeholder, tracker.body[1])
+
+                local separator_idx
+                for i, line in ipairs(tracker.body) do
+                    if line == "---" then
+                        separator_idx = i
+                        break
+                    end
+                end
+                assert.is_not_nil(separator_idx)
+                assert.is_true(#tracker.body - separator_idx > 1)
+            end
+        )
+
+        it("leaves malformed JSON unchanged", function()
+            local malformed = "{" .. string.rep("not valid json ", 10) .. "}"
+
+            local block =
+                make_tool_call_block("json-bad", "completed", { malformed })
+            writer:write_tool_call_block(block)
+
+            local tracker = writer.tool_call_blocks["json-bad"]
+            assert.same({ malformed }, tracker.body)
         end)
     end)
 

--- a/lua/agentic/utils/json_format.lua
+++ b/lua/agentic/utils/json_format.lua
@@ -1,0 +1,196 @@
+--- Pretty-print single-line JSON bodies in tool call output so they
+--- read as multi-line blocks in the chat buffer and become foldable.
+--- @class agentic.utils.JsonFormat
+local M = {}
+
+local INDENT = "  "
+local MIN_LENGTH = 80
+
+--- Decide whether a single-line string is worth pretty-printing. Cheap
+--- structural check before paying for `vim.json.decode`.
+--- @param line string
+--- @return boolean
+local function looks_like_json(line)
+    if #line < MIN_LENGTH then
+        return false
+    end
+
+    local trimmed = line:match("^%s*(.-)%s*$")
+    if not trimmed or trimmed == "" then
+        return false
+    end
+
+    local first = trimmed:sub(1, 1)
+    local last = trimmed:sub(-1)
+
+    if first == "{" and last == "}" then
+        return true
+    end
+
+    if first == "[" and last == "]" then
+        return true
+    end
+
+    return false
+end
+
+--- Distinguish array-shaped tables from object-shaped tables. Lua has
+--- one table type, so we look at the keys: contiguous integer keys
+--- starting at 1 means array; anything else means object. Empty tables
+--- are treated as arrays (matches `vim.json.decode("[]")` returning `{}`).
+--- @param value table
+--- @return boolean
+local function is_array(value)
+    local count = 0
+    for _ in pairs(value) do
+        count = count + 1
+    end
+
+    if count == 0 then
+        return true
+    end
+
+    for i = 1, count do
+        if value[i] == nil then
+            return false
+        end
+    end
+
+    return true
+end
+
+--- @param value any
+--- @param depth integer
+--- @param parts string[]
+local function encode(value, depth, parts)
+    local t = type(value)
+
+    if t == "nil" or value == vim.NIL then
+        table.insert(parts, "null")
+        return
+    end
+
+    if t == "boolean" then
+        table.insert(parts, value and "true" or "false")
+        return
+    end
+
+    if t == "number" then
+        table.insert(parts, tostring(value))
+        return
+    end
+
+    if t == "string" then
+        table.insert(parts, vim.json.encode(value))
+        return
+    end
+
+    if t ~= "table" then
+        table.insert(parts, vim.json.encode(value))
+        return
+    end
+
+    local indent = string.rep(INDENT, depth)
+    local inner = string.rep(INDENT, depth + 1)
+
+    if is_array(value) then
+        if #value == 0 then
+            table.insert(parts, "[]")
+            return
+        end
+
+        table.insert(parts, "[\n")
+        for i, item in ipairs(value) do
+            table.insert(parts, inner)
+            encode(item, depth + 1, parts)
+            if i < #value then
+                table.insert(parts, ",")
+            end
+            table.insert(parts, "\n")
+        end
+        table.insert(parts, indent)
+        table.insert(parts, "]")
+        return
+    end
+
+    local keys = {}
+    for k in pairs(value) do
+        table.insert(keys, k)
+    end
+    table.sort(keys, function(a, b)
+        return tostring(a) < tostring(b)
+    end)
+
+    if #keys == 0 then
+        table.insert(parts, "{}")
+        return
+    end
+
+    table.insert(parts, "{\n")
+    for i, k in ipairs(keys) do
+        table.insert(parts, inner)
+        table.insert(parts, vim.json.encode(tostring(k)))
+        table.insert(parts, ": ")
+        encode(value[k], depth + 1, parts)
+        if i < #keys then
+            table.insert(parts, ",")
+        end
+        table.insert(parts, "\n")
+    end
+    table.insert(parts, indent)
+    table.insert(parts, "}")
+end
+
+--- Pretty-print a Lua value back to JSON with 2-space indentation.
+--- @param value any
+--- @return string
+local function pretty(value)
+    local parts = {}
+    encode(value, 0, parts)
+    return table.concat(parts)
+end
+
+--- Try to format a single string as pretty-printed JSON. Returns the
+--- original string unchanged when it doesn't look like JSON or fails to
+--- parse (truncated/streaming JSON, non-standard formats).
+--- @param line string
+--- @return string formatted
+function M.format_line(line)
+    if not looks_like_json(line) then
+        return line
+    end
+
+    local ok, decoded = pcall(
+        vim.json.decode,
+        line,
+        { luanil = { object = true, array = true } }
+    )
+    if not ok or type(decoded) ~= "table" then
+        return line
+    end
+
+    return pretty(decoded)
+end
+
+--- Format a body (array of buffer lines). Only formats when the body
+--- is a single line that parses as JSON. Multi-line bodies and short
+--- lines pass through untouched.
+---
+--- Idempotent: re-running on already-formatted bodies returns the same
+--- shape because the pretty-printer is deterministic.
+--- @param lines string[]
+--- @return string[] formatted
+function M.format_lines(lines)
+    if type(lines) ~= "table" or #lines ~= 1 then
+        return lines
+    end
+
+    local formatted = M.format_line(lines[1])
+    if formatted == lines[1] then
+        return lines
+    end
+
+    return vim.split(formatted, "\n")
+end
+
+return M

--- a/lua/agentic/utils/json_format.test.lua
+++ b/lua/agentic/utils/json_format.test.lua
@@ -1,0 +1,92 @@
+local assert = require("tests.helpers.assert")
+
+describe("JsonFormat", function()
+    --- @type agentic.utils.JsonFormat
+    local JsonFormat
+
+    before_each(function()
+        package.loaded["agentic.utils.json_format"] = nil
+        JsonFormat = require("agentic.utils.json_format")
+    end)
+
+    describe("format_line", function()
+        it("returns short strings unchanged", function()
+            local input = '{"a":1}'
+            assert.equal(input, JsonFormat.format_line(input))
+        end)
+
+        it("returns non-JSON looking strings unchanged", function()
+            local input = string.rep("x", 200)
+            assert.equal(input, JsonFormat.format_line(input))
+        end)
+
+        it("returns plain prose unchanged", function()
+            local input = "I'm going to fetch this and then look up the value "
+                .. string.rep("text ", 30)
+            assert.equal(input, JsonFormat.format_line(input))
+        end)
+
+        it("returns invalid JSON unchanged", function()
+            local input = "{" .. string.rep("not valid json ", 10) .. "}"
+            assert.equal(input, JsonFormat.format_line(input))
+        end)
+
+        it("pretty-prints a long JSON object", function()
+            local long_value = string.rep("v", 100)
+            local input = '{"key":"' .. long_value .. '","other":42}'
+            local result = JsonFormat.format_line(input)
+
+            assert.is_true(result:find("\n") ~= nil)
+            assert.is_true(result:sub(1, 1) == "{")
+            assert.is_true(result:sub(-1) == "}")
+
+            local ok, decoded = pcall(vim.json.decode, result)
+            assert.is_true(ok)
+            assert.equal(long_value, decoded.key)
+            assert.equal(42, decoded.other)
+        end)
+
+        it("pretty-prints a long JSON array", function()
+            local input = "["
+                .. string.rep('"' .. string.rep("a", 20) .. '",', 10)
+            input = input:sub(1, -2) .. "]"
+
+            local result = JsonFormat.format_line(input)
+            assert.is_true(result:find("\n") ~= nil)
+            assert.is_true(result:sub(1, 1) == "[")
+            assert.is_true(result:sub(-1) == "]")
+        end)
+
+        it("is idempotent on already-formatted JSON", function()
+            local long_value = string.rep("v", 100)
+            local input = '{"key":"' .. long_value .. '"}'
+            local once = JsonFormat.format_line(input)
+            local twice = JsonFormat.format_line(once)
+            assert.equal(once, twice)
+        end)
+    end)
+
+    describe("format_lines", function()
+        it("returns multi-line input unchanged", function()
+            local input = { "line one", "line two" }
+            assert.same(input, JsonFormat.format_lines(input))
+        end)
+
+        it("returns empty input unchanged", function()
+            local input = {}
+            assert.same(input, JsonFormat.format_lines(input))
+        end)
+
+        it("formats a single-line JSON body into many lines", function()
+            local long_value = string.rep("v", 100)
+            local input = { '{"key":"' .. long_value .. '","x":1}' }
+            local result = JsonFormat.format_lines(input)
+            assert.is_true(#result > 1)
+        end)
+
+        it("returns single non-JSON line unchanged", function()
+            local input = { "I'm going to fetch this" }
+            assert.same(input, JsonFormat.format_lines(input))
+        end)
+    end)
+end)


### PR DESCRIPTION
## Summary

Tool call bodies that arrive as a single multi-hundred-character JSON line (Jira responses, MCP results, etc.) now render as multi-line, foldable blocks in the chat buffer.

- New `agentic.utils.json_format` module detects single-line JSON via a cheap structural check followed by `pcall(vim.json.decode)`, then pretty-prints with 2-space indent and sorted keys.
- Formatting hook lives at the entry of `MessageWriter:write_tool_call_block` and `MessageWriter:update_tool_call_block`. Covers live ACP stream, ACP-replay restore, and history-replay (provider switch / on-disk restore).
- ACP layer untouched. `__build_tool_call_message` stays a pure data extractor.
- Idempotent, deterministic output. Re-formatting an already-formatted body is a no-op.
- Falls back to the original string on parse failure (truncated/streaming JSON, non-standard formats).
- Solves the foldability gap from #210 incidentally. `Fold.should_fold` counts buffer lines, and a formatted JSON body now has many.

## Test plan

- [x] `make validate` passes (format / luals / selene / test all 0)
- [x] 11 new tests in `json_format.test.lua` covering detection, formatting, idempotence, malformed input, multi-line passthrough
- [x] 3 new tests in `message_writer.test.lua` covering single-line JSON formatting on initial write, placeholder + JSON merge with separator on update, malformed-JSON passthrough
- [x] Manual: trigger a Jira / MCP tool call that returns long JSON and verify the body wraps, folds, and the existing fold behavior from #210 still works