### PR TITLE
fix(utils): gate keymap `buf` opt on nvim-0.12.1

### DIFF
--- a/lua/agentic/utils/buf_helpers.lua
+++ b/lua/agentic/utils/buf_helpers.lua
@@ -65,11 +65,12 @@ end
 --- @param opts vim.keymap.set.Opts|nil
 function BufHelpers.keymap_set(bufnr, mode, lhs, rhs, opts)
     opts = opts or {}
-    -- Neovim 0.12 renamed `buffer` to `buf` in vim.keymap.set opts
-    -- (see :h vim.keymap.set and :h deprecated — "buffer" renamed to "buf").
-    -- `buffer` will be removed in 0.15, so use `buf` on 0.12+ and `buffer` on older.
+    -- `buffer` was renamed to `buf` in neovim#38360, shipped in 0.12.0 final.
+    -- Gate on 0.12.1 to skip 0.12.0-dev nightlies built before the rename
+    -- (they answer `has('nvim-0.12') == 1` but reject `buf`).
+    -- `buffer` is removed in 0.15.
     --- @diagnostic disable: inject-field
-    if vim.fn.has("nvim-0.12") == 1 then
+    if vim.fn.has("nvim-0.12.1") == 1 then
         opts.buf = bufnr
     else
         opts.buffer = bufnr

--- a/lua/agentic/utils/buf_helpers.test.lua
+++ b/lua/agentic/utils/buf_helpers.test.lua
@@ -99,6 +99,57 @@ describe("BufHelpers", function()
         )
     end)
 
+    describe("keymap_set", function()
+        --- @type TestStub
+        local keymap_set_stub
+        --- @type TestStub
+        local has_stub
+
+        before_each(function()
+            keymap_set_stub = spy.stub(vim.keymap, "set")
+            has_stub = spy.stub(vim.fn, "has")
+        end)
+
+        after_each(function()
+            keymap_set_stub:revert()
+            has_stub:revert()
+        end)
+
+        -- Regression: 0.12.0-dev nightlies built before neovim#38360 (the
+        -- `buffer` -> `buf` rename) report `has('nvim-0.12') == 1` but
+        -- reject `buf` with `invalid key: buf`. Gate on 0.12.1, the first
+        -- stable that ships `buf`.
+        it("uses `buffer` opt on Neovim < 0.12.1", function()
+            has_stub:invokes(function(feature)
+                return feature == "nvim-0.12.1" and 0 or 1
+            end)
+            local bufnr = vim.api.nvim_create_buf(false, true)
+
+            BufHelpers.keymap_set(bufnr, "n", "x", function() end)
+
+            local opts = keymap_set_stub.calls[1][4]
+            assert.equal(bufnr, opts.buffer)
+            assert.is_nil(opts.buf)
+
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end)
+
+        it("uses `buf` opt on Neovim >= 0.12.1", function()
+            has_stub:invokes(function(feature)
+                return feature == "nvim-0.12.1" and 1 or 0
+            end)
+            local bufnr = vim.api.nvim_create_buf(false, true)
+
+            BufHelpers.keymap_set(bufnr, "n", "x", function() end)
+
+            local opts = keymap_set_stub.calls[1][4]
+            assert.equal(bufnr, opts.buf)
+            assert.is_nil(opts.buffer)
+
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end)
+    end)
+
     describe("is_buffer_empty", function()
         it("should return true for buffer with single empty line", function()
             local bufnr = vim.api.nvim_create_buf(false, true)


### PR DESCRIPTION
## Summary

- `vim.fn.has('nvim-0.12') == 1` matches any 0.12.0-dev nightly, including builds before neovim#38360 (the `buffer` -> `buf` rename in `vim.keymap.set`). Those nightlies reject `buf` with `invalid key: buf`, crashing `BufHelpers.keymap_set` and cascading into a `status_animation` nil deref during session setup.
- Tighten the gate to `nvim-0.12.1`, the first stable shipping `buf`. Pre-0.12.1 keeps using `buffer` (still valid through 0.15).
- Adds regression tests for both branches via `vim.fn.has` stubbing.
- close #213

## Test plan

- [x] `make validate` (format, luals, selene, test all 0)
- [x] New tests confirmed RED on the old gate before fix, GREEN on the new gate