### PR TITLE
feat(ui): fold by screen rows; pretty-print JSON inside multi-line bodies

### DIFF
--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -808,7 +808,7 @@ Folding ~
     folding = {
       tool_calls = {
         enabled = true,  -- Master switch for tool call body folding
-        threshold = 10,  -- Fold when interior exceeds N lines. 0 = always.
+        threshold = 10,  -- Fold when interior wraps to more than N screen rows. 0 = always.
       },
     },
   }

--- a/docs/architectural-decisions/001-tool-call-folding.md
+++ b/docs/architectural-decisions/001-tool-call-folding.md
@@ -45,7 +45,15 @@ the two.
 A hidden chat float (`ChatWidget._hidden_chat_winid`) keeps exactly one window
 on the chat buffer at all times — visible chat window OR hidden float, never
 both, never neither — so the fold-state snapshot pipeline is uninterrupted
-across hide/show.
+across hide/show. The hidden float matches the visible chat window's width
+(`Config.windows.width`), `wrap`/`linebreak`, and statuscolumn so screen-row
+measurements (`nvim_win_text_height`) agree across hidden and visible states.
+
+`Fold.should_fold` decides folding by **screen rows**, not buffer lines.
+Counts wrapped rows via `nvim_win_text_height` against whichever window holds
+the chat buffer. A single very long line that wraps past the threshold folds
+even though it's one buffer line — relevant for huge tool outputs (Defuddle,
+`curl`-piped-to-`python`) that arrive as one mega-line.
 
 ## Consequences
 
@@ -94,11 +102,12 @@ Our case (live transitions on growing blocks) is the harder variant.
 
 ## Changelog
 
-| Date       | Commit  | Change                                             |
-| ---------- | ------- | -------------------------------------------------- |
-| 2026-04-18 | dc33d56 | Initial: foldexpr + threshold + foldtext.          |
-| 2026-04-29 | 28cb6ff | Migrate to manual + anchor pads + sync scroll.     |
-| 2026-04-29 | 28cb6ff | Add hidden chat float for fold-state preservation. |
+| Date       | Commit  | Change                                                                 |
+| ---------- | ------- | ---------------------------------------------------------------------- |
+| 2026-04-18 | dc33d56 | Initial: foldexpr + threshold + foldtext.                              |
+| 2026-04-29 | 28cb6ff | Migrate to manual + anchor pads + sync scroll.                         |
+| 2026-04-29 | 28cb6ff | Add hidden chat float for fold-state preservation.                     |
+| 2026-05-03 | -       | Switch fold decision to screen rows via `nvim_win_text_height`; sync hidden float dimensions/wrap with config. |
 
 ## Sources
 

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -164,7 +164,7 @@
 --- Tool call folding configuration
 --- @class agentic.UserConfig.Folding.ToolCalls
 --- @field enabled boolean Whether to fold tool call bodies.
---- @field threshold integer Fold when interior exceeds this many lines. 0 always folds. Negative values are clamped to 0.
+--- @field threshold integer Fold when the interior occupies more than this many wrapped screen rows. 0 always folds. Negative values are clamped to 0.
 
 --- Folding behavior in the chat buffer
 --- @class agentic.UserConfig.Folding

--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -193,8 +193,10 @@ change.
 
 - Fold survives window close + reopen —
   `tool_call_fold.test.lua::setup_window::"preserves fold ranges across window close + reopen"`.
-- Fold creation gated by interior > threshold —
-  `tool_call_fold.test.lua::should_fold::"folds when interior > threshold"`.
+- Fold creation gated by screen-row count > threshold —
+  `tool_call_fold.test.lua::should_fold::"folds when screen-row count exceeds threshold"`.
+- Fold counts wrapped rows, not buffer lines (one mega-line still folds) —
+  `tool_call_fold.test.lua::should_fold::"folds a single buffer line that wraps past the threshold"`.
 - Permission reanchor preserves keymaps + button position —
   `permission_manager.test.lua::reanchor permission prompt::"moves buttons to buffer bottom and preserves keymaps"`.
 - Permission reanchor does not double-blank across cycles —

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -434,8 +434,16 @@ function MessageWriter:write_tool_call_block(tool_call_block)
         self:_apply_header_highlight(start_row, tool_call_block.status)
         self:_apply_status_footer(end_row, tool_call_block.status)
 
-        local interior = #lines - 4
-        if Fold.should_fold(interior, tool_call_block.diff ~= nil) then
+        local body_start = start_row + 2
+        local body_end = end_row - 2
+        if
+            Fold.should_fold(
+                bufnr,
+                body_start,
+                body_end,
+                tool_call_block.diff ~= nil
+            )
+        then
             Fold.close_range(bufnr, start_row + 2, end_row)
             tool_call_block.has_fold = true
         end
@@ -585,10 +593,14 @@ function MessageWriter:update_tool_call_block(tool_call_block)
             tracker.status
         )
 
-        local interior = #new_lines - 4
         if
             not tracker.has_fold
-            and Fold.should_fold(interior, tracker.diff ~= nil)
+            and Fold.should_fold(
+                bufnr,
+                start_row + 2,
+                new_end_row - 2,
+                tracker.diff ~= nil
+            )
         then
             Fold.close_range(bufnr, start_row + 2, new_end_row)
             tracker.has_fold = true

--- a/lua/agentic/ui/tool_call_fold.lua
+++ b/lua/agentic/ui/tool_call_fold.lua
@@ -12,15 +12,37 @@ function Fold.threshold()
     return math.max(0, cfg.threshold or 0)
 end
 
---- @param interior integer body lines (excludes header, pads, footer)
---- @param is_diff boolean diff blocks are never folded
+--- @param bufnr integer
+--- @param start_row integer 0-indexed inclusive
+--- @param end_row integer 0-indexed inclusive
+--- @param is_diff boolean
 --- @return boolean
-function Fold.should_fold(interior, is_diff)
+function Fold.should_fold(bufnr, start_row, end_row, is_diff)
     if is_diff then
         return false
     end
     local threshold = Fold.threshold()
-    return threshold ~= nil and interior > threshold
+    if threshold == nil then
+        return false
+    end
+    if start_row > end_row then
+        return false
+    end
+
+    local wins = vim.fn.win_findbuf(bufnr)
+    if #wins == 0 then
+        return false
+    end
+
+    local ok, result = pcall(vim.api.nvim_win_text_height, wins[1], {
+        start_row = start_row,
+        end_row = end_row,
+    })
+    if not ok or type(result) ~= "table" then
+        return false
+    end
+
+    return result.all > threshold
 end
 
 --- @return string

--- a/lua/agentic/ui/tool_call_fold.test.lua
+++ b/lua/agentic/ui/tool_call_fold.test.lua
@@ -56,23 +56,81 @@ describe("agentic.ui.ToolCallFold", function()
     end)
 
     describe("should_fold", function()
-        it("folds when interior > threshold", function()
-            assert.is_true(Fold.should_fold(6, false))
+        --- @param lines string[]
+        local function fill(lines)
+            vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+        end
+
+        it("folds when screen-row count exceeds threshold", function()
+            local six = {}
+            for i = 1, 6 do
+                six[i] = "L" .. i
+            end
+            fill(six)
+            assert.is_true(Fold.should_fold(bufnr, 0, 5, false))
         end)
 
-        it("does not fold when interior == threshold", function()
-            assert.is_false(Fold.should_fold(5, false))
+        it("tips over to fold at the screen-row threshold boundary", function()
+            local five = {}
+            for i = 1, 5 do
+                five[i] = "L" .. i
+            end
+            fill(five)
+            assert.is_false(Fold.should_fold(bufnr, 0, 4, false))
+
+            fill({ "L1", "L2", "L3", "L4", "L5", "L6" })
+            assert.is_true(Fold.should_fold(bufnr, 0, 5, false))
         end)
+
+        it(
+            "folds a single buffer line that wraps past the threshold",
+            function()
+                fill({ string.rep("x", 240) })
+                assert.is_true(Fold.should_fold(bufnr, 0, 0, false))
+            end
+        )
+
+        it(
+            "does not fold a short single line, but does fold once it wraps far enough",
+            function()
+                fill({ "short" })
+                assert.is_false(Fold.should_fold(bufnr, 0, 0, false))
+
+                fill({ string.rep("x", 240) })
+                assert.is_true(Fold.should_fold(bufnr, 0, 0, false))
+            end
+        )
 
         it("never folds diff blocks regardless of size", function()
-            assert.is_false(Fold.should_fold(100, true))
+            fill({ string.rep("x", 1000) })
+            assert.is_false(Fold.should_fold(bufnr, 0, 0, true))
         end)
 
-        it("returns false when folding is disabled", function()
-            Config.folding = {
-                tool_calls = { enabled = false, threshold = 5 },
-            }
-            assert.is_false(Fold.should_fold(100, false))
+        it(
+            "returns false when folding is disabled, even for huge content",
+            function()
+                fill({ string.rep("x", 1000) })
+                -- sanity: with folding ON this content would fold
+                assert.is_true(Fold.should_fold(bufnr, 0, 0, false))
+
+                Config.folding = {
+                    tool_calls = { enabled = false, threshold = 5 },
+                }
+                assert.is_false(Fold.should_fold(bufnr, 0, 0, false))
+            end
+        )
+
+        it("returns false when no window is attached to the buffer", function()
+            local hidden_buf = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_buf_set_lines(
+                hidden_buf,
+                0,
+                -1,
+                false,
+                { string.rep("x", 1000) }
+            )
+            assert.is_false(Fold.should_fold(hidden_buf, 0, 0, false))
+            vim.api.nvim_buf_delete(hidden_buf, { force = true })
         end)
     end)
 

--- a/lua/agentic/ui/widget_layout.lua
+++ b/lua/agentic/ui/widget_layout.lua
@@ -99,6 +99,28 @@ local PANEL_WINDOW_OPTS = {
     winhighlight = "EndOfBuffer:",
 }
 
+--- @param winid integer
+--- @param bufnr integer
+--- @param window_name agentic.ui.ChatWidget.PanelNames
+--- @param win_opts table<string, any>
+local function apply_panel_window_opts(winid, bufnr, window_name, win_opts)
+    -- Mark this window so BufferGuard knows which buffer belongs here
+    vim.w[winid].agentic_bufnr = bufnr
+
+    local window_config = Config.windows[window_name] or {}
+    local config_win_opts = window_config.win_opts or {}
+
+    local merged_win_opts = vim.tbl_deep_extend("force", {
+        wrap = true,
+        linebreak = true,
+        winfixheight = true,
+    }, PANEL_WINDOW_OPTS, win_opts or {}, config_win_opts)
+
+    for name, value in pairs(merged_win_opts) do
+        vim.api.nvim_set_option_value(name, value, { win = winid })
+    end
+end
+
 --- @param bufnr integer
 --- @param enter boolean
 --- @param opts vim.api.keyset.win_config
@@ -117,21 +139,7 @@ local function open_win(bufnr, enter, opts, window_name, win_opts)
 
     local winid = vim.api.nvim_open_win(bufnr, enter, config)
 
-    -- Mark this window so BufferGuard knows which buffer belongs here
-    vim.w[winid].agentic_bufnr = bufnr
-
-    local window_config = Config.windows[window_name] or {}
-    local config_win_opts = window_config.win_opts or {}
-
-    local merged_win_opts = vim.tbl_deep_extend("force", {
-        wrap = true,
-        linebreak = true,
-        winfixheight = true,
-    }, PANEL_WINDOW_OPTS, win_opts or {}, config_win_opts)
-
-    for name, value in pairs(merged_win_opts) do
-        vim.api.nvim_set_option_value(name, value, { win = winid })
-    end
+    apply_panel_window_opts(winid, bufnr, window_name, win_opts)
 
     return winid
 end
@@ -299,11 +307,14 @@ end
 --- @param bufnr integer Chat buffer
 --- @return integer|nil winid nil on failure (graceful degradation)
 function WidgetLayout.open_hidden_chat_window(bufnr)
+    -- Width must match the visible chat so nvim_win_text_height agrees. ADR 001.
+    local width = WidgetLayout.calculate_width(Config.windows.width)
+
     local ok, winid = pcall(vim.api.nvim_open_win, bufnr, false, {
         relative = "editor",
         row = 0,
         col = 0,
-        width = 80,
+        width = width,
         height = 20,
         hide = true,
         focusable = false,
@@ -317,11 +328,9 @@ function WidgetLayout.open_hidden_chat_window(bufnr)
 
     vim.wo[winid].winbar = ""
 
-    vim.w[winid].agentic_bufnr = bufnr
-
-    for name, value in pairs(PANEL_WINDOW_OPTS) do
-        vim.api.nvim_set_option_value(name, value, { win = winid })
-    end
+    apply_panel_window_opts(winid, bufnr, "chat", {
+        statuscolumn = ToolBlockBorder.STATUSCOLUMN_EXPR,
+    })
 
     Fold.setup_window(winid, bufnr)
 

--- a/lua/agentic/utils/json_format.lua
+++ b/lua/agentic/utils/json_format.lua
@@ -172,25 +172,35 @@ function M.format_line(line)
     return pretty(decoded)
 end
 
---- Format a body (array of buffer lines). Only formats when the body
---- is a single line that parses as JSON. Multi-line bodies and short
---- lines pass through untouched.
----
 --- Idempotent: re-running on already-formatted bodies returns the same
 --- shape because the pretty-printer is deterministic.
 --- @param lines string[]
 --- @return string[] formatted
 function M.format_lines(lines)
-    if type(lines) ~= "table" or #lines ~= 1 then
+    if type(lines) ~= "table" or #lines == 0 then
         return lines
     end
 
-    local formatted = M.format_line(lines[1])
-    if formatted == lines[1] then
+    local out = {}
+    local changed = false
+
+    for _, line in ipairs(lines) do
+        local formatted = M.format_line(line)
+        if formatted == line then
+            table.insert(out, line)
+        else
+            changed = true
+            for _, sub in ipairs(vim.split(formatted, "\n")) do
+                table.insert(out, sub)
+            end
+        end
+    end
+
+    if not changed then
         return lines
     end
 
-    return vim.split(formatted, "\n")
+    return out
 end
 
 return M

--- a/lua/agentic/utils/json_format.test.lua
+++ b/lua/agentic/utils/json_format.test.lua
@@ -88,5 +88,33 @@ describe("JsonFormat", function()
             local input = { "I'm going to fetch this" }
             assert.same(input, JsonFormat.format_lines(input))
         end)
+
+        it(
+            "pretty-prints a JSON line wrapped in a markdown code fence",
+            function()
+                local long_value = string.rep("v", 100)
+                local json_text = '{"key":"' .. long_value .. '","x":1}'
+                local input = { "```console", json_text, "```" }
+
+                local result = JsonFormat.format_lines(input)
+
+                assert.is_true(#result > 3)
+                assert.equal("```console", result[1])
+                assert.equal("```", result[#result])
+                assert.equal("{", result[2])
+            end
+        )
+
+        it("pretty-prints a JSON line that follows a prose line", function()
+            local long_value = string.rep("v", 100)
+            local json_text = '{"key":"' .. long_value .. '","x":1}'
+            local input = { "Here is the response:", json_text }
+
+            local result = JsonFormat.format_lines(input)
+
+            assert.is_true(#result > 2)
+            assert.equal("Here is the response:", result[1])
+            assert.equal("{", result[2])
+        end)
     end)
 end)

--- a/lua/agentic/utils/json_format.test.lua
+++ b/lua/agentic/utils/json_format.test.lua
@@ -116,5 +116,15 @@ describe("JsonFormat", function()
             assert.equal("Here is the response:", result[1])
             assert.equal("{", result[2])
         end)
+
+        it("is idempotent on already-formatted bodies", function()
+            local long_value = string.rep("v", 100)
+            local input = { '{"key":"' .. long_value .. '","x":1}' }
+
+            local once = JsonFormat.format_lines(input)
+            local twice = JsonFormat.format_lines(once)
+
+            assert.same(once, twice)
+        end)
     end)
 end)


### PR DESCRIPTION
## Summary

- `JsonFormat.format_lines` walks every line and pretty-prints any line that parses as JSON. Previously bailed on multi-line input, so JSON wrapped in a markdown code fence (e.g. `gh api ... | head` rendered inside ` ```console `) stayed unreadable.
- `Fold.should_fold` decides folding by **wrapped screen rows** via `nvim_win_text_height` instead of buffer-line count. Single mega-lines (Defuddle output, `curl | python` one-liners) now fold when they wrap past the threshold. Signature: `(bufnr, start_row, end_row, is_diff)`.
- `open_hidden_chat_window` reuses the same panel-window-options merge as the visible chat (extracted helper `apply_panel_window_opts`), pulls width from `Config.windows.width`, and inherits `wrap`/`linebreak`/`statuscolumn` so screen-row counts match across hidden and visible states.
- Threshold semantics changed from buffer lines to screen rows. vimdoc/LuaCATS doc updated. ADR 001 updated.