### PR TITLE
fix(ui): prevent widget window options leaking to redirected buffers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,26 @@ Subsystem-specific traps live in nested `AGENTS.md`. These apply everywhere:
 - **FORBIDDEN: global keymaps** -> use `BufHelpers.keymap_set(bufnr, ...)`.
 - **FORBIDDEN: `vim.api.nvim_list_wins()` for tab-scoped lookups** -> use
   `vim.api.nvim_tabpage_list_wins(self.tab_page_id)`.
+- **FORBIDDEN: `:set`-style writes for window-local options** -> use
+  `vim.wo[winid][0].opt = val`, never `vim.wo[winid].opt = val` or
+  `nvim_set_option_value(opt, val, { win = winid })`. Per `:h local-options`,
+  window-local options are remembered per `(buffer, window)`. `:set` writes
+  imprint the value in any buffer that briefly cohabits the window and the
+  buffer carries it to its next host. `[0]` is the `:setlocal` sentinel
+  (only `[0]` is supported by `vim.wo`, see `:h vim.wo`); without it, panel
+  styling leaks to redirected buffers.
+  - Applies to ALL `vim.wo` writes, not just panels. No `vim.bo` equivalent
+    is needed: buffer options have no per-window memory.
+  - Reads (`local x = vim.wo[winid].opt`) are unaffected; `[0]` is
+    write-only.
+  - Regression: `lua/agentic/ui/buffer_guard.test.lua::"does not leak widget
+    window options to the editor window after redirect"`.
+- **AVOID: `nvim_set_option_value` / `nvim_get_option_value`** for buffer or
+  window options when an idiomatic accessor exists. Use `vim.bo[bufnr].opt`
+  for buffer options and `vim.wo[winid][0].opt` for window options. The
+  `nvim_*_option_value` API is reserved for cases that need a dynamic option
+  name or a non-default scope (e.g. `scope = "global"`). Reading is symmetric:
+  `vim.bo[bufnr].opt` / `vim.wo[winid].opt` (no `[0]` on reads).
 
 ## Code Style
 

--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -56,6 +56,14 @@ Widget windows are disposable.
   `tab_closing` check.
 - A hidden chat floating window keeps the chat buffer attached while the widget
   is hidden, so manual folds can be applied while closed. See ADR 001.
+  - Opened with `hide = true` + `focusable = false` + `noautocmd = true`. The
+    user cannot reach it: `<C-w>w`/`<C-w>p`, `:wincmd`, and `:buffer` skip it;
+    `nvim_list_wins()` returns it but interactive navigation does not visit it.
+    Only code holding `widget._hidden_chat_winid` can target it (via
+    `nvim_set_current_win`/`nvim_win_set_buf`). Treat it as an internal handle,
+    not a window the user might be sitting in. Do NOT add keymaps,
+    buffer-local autocmds expecting user focus, or any UX that assumes the user
+    can act inside it.
 
 ## Hard rules
 
@@ -87,6 +95,14 @@ or in the linked ADR — failures are not inlined here to avoid duplication.
 - Foreign buffers in widget windows are redirected via `BufferGuard`
   (`lua/agentic/ui/buffer_guard.lua`) to a non-widget window in the same
   tabpage.
+- Panel window options (everything in `WidgetLayout` `PANEL_WINDOW_OPTS` plus
+  `Fold.setup_window` fold opts) MUST be written via `vim.wo[winid][0].opt`
+  (`:setlocal`), not `vim.wo[winid].opt` or `nvim_set_option_value({win=...})`
+  (`:set`). Per `:h local-options`, window-local options are remembered per
+  `(buffer, window)`. With `:set`, panel values get recorded in any buffer
+  that briefly cohabits the widget window and follow that buffer to its next
+  host. Regression: `buffer_guard.test.lua::"does not leak widget window
+  options to the editor window after redirect"`.
 - Module-level state is forbidden for per-tab data. Namespace IDs are exempt —
   IDs are global, isolation comes from per-buffer `nvim_buf_clear_namespace`.
 

--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -95,14 +95,9 @@ or in the linked ADR — failures are not inlined here to avoid duplication.
 - Foreign buffers in widget windows are redirected via `BufferGuard`
   (`lua/agentic/ui/buffer_guard.lua`) to a non-widget window in the same
   tabpage.
-- Panel window options (everything in `WidgetLayout` `PANEL_WINDOW_OPTS` plus
-  `Fold.setup_window` fold opts) MUST be written via `vim.wo[winid][0].opt`
-  (`:setlocal`), not `vim.wo[winid].opt` or `nvim_set_option_value({win=...})`
-  (`:set`). Per `:h local-options`, window-local options are remembered per
-  `(buffer, window)`. With `:set`, panel values get recorded in any buffer
-  that briefly cohabits the widget window and follow that buffer to its next
-  host. Regression: `buffer_guard.test.lua::"does not leak widget window
-  options to the editor window after redirect"`.
+- Panel + fold window options (`WidgetLayout.PANEL_WINDOW_OPTS`,
+  `Fold.setup_window`) MUST be written via `vim.wo[winid][0]`. See the
+  general `:set`-style ban in root `AGENTS.md` "Common traps".
 - Module-level state is forbidden for per-tab data. Namespace IDs are exempt —
   IDs are global, isolation comes from per-buffer `nvim_buf_clear_namespace`.
 

--- a/lua/agentic/ui/buffer_guard.lua
+++ b/lua/agentic/ui/buffer_guard.lua
@@ -72,12 +72,11 @@ local function on_buf_enter(cb)
     -- it via :edit (same buffer ID, now with a file path).
     -- nofile buffers are exempt: they legitimately hold display names
     -- set via nvim_buf_set_name (e.g. "󰦨 Prompt") without being
-    -- repurposed. Window-local options (wrap, number, cursorline, etc.)
-    -- belong to the window, not the buffer — verified via
-    -- :h local-options and headless testing. A buffer briefly
-    -- displayed in a widget window does NOT carry widget
-    -- window options when moved to another window. So we
-    -- simply move the buffer as-is.
+    -- repurposed. Per :h local-options, window-local options are
+    -- remembered per (buffer, window). Widget windows therefore set
+    -- panel options via vim.wo[winid][0] (`:setlocal`) so foreign
+    -- buffers that briefly cohabit do NOT inherit panel styling and
+    -- do NOT carry it to their next host window.
     local buf_name = vim.api.nvim_buf_get_name(cur_buf)
     local buftype = vim.bo[cur_buf].buftype
     if buf_name ~= "" and buftype ~= "nofile" then

--- a/lua/agentic/ui/buffer_guard.lua
+++ b/lua/agentic/ui/buffer_guard.lua
@@ -72,11 +72,7 @@ local function on_buf_enter(cb)
     -- it via :edit (same buffer ID, now with a file path).
     -- nofile buffers are exempt: they legitimately hold display names
     -- set via nvim_buf_set_name (e.g. "󰦨 Prompt") without being
-    -- repurposed. Per :h local-options, window-local options are
-    -- remembered per (buffer, window). Widget windows therefore set
-    -- panel options via vim.wo[winid][0] (`:setlocal`) so foreign
-    -- buffers that briefly cohabit do NOT inherit panel styling and
-    -- do NOT carry it to their next host window.
+    -- repurposed.
     local buf_name = vim.api.nvim_buf_get_name(cur_buf)
     local buftype = vim.bo[cur_buf].buftype
     if buf_name ~= "" and buftype ~= "nofile" then

--- a/lua/agentic/ui/buffer_guard.test.lua
+++ b/lua/agentic/ui/buffer_guard.test.lua
@@ -1,6 +1,7 @@
 -- lua/agentic/ui/buffer_guard.test.lua
 local assert = require("tests.helpers.assert")
 local BufferGuard = require("agentic.ui.buffer_guard")
+local WidgetLayout = require("agentic.ui.widget_layout")
 
 --- Helper: create a minimal widget-like setup in a fresh tab
 --- @return table state { tab, bufs, wins, augroup, cleanup }
@@ -210,6 +211,124 @@ describe("BufferGuard", function()
             vim.cmd("tabclose!")
         end)
     end)
+
+    it(
+        "does not leak widget window options to the editor window after redirect",
+        function()
+            -- Widget windows hold panel-styled options (no number column,
+            -- no signcolumn, custom winhighlight, etc.). When a foreign
+            -- buffer briefly cohabits a widget window before being
+            -- redirected, those window-local options must not follow the
+            -- buffer to its target window.
+            --
+            -- Forces non-default global options so a leak from PANEL
+            -- defaults is observable as a divergence on the editor window.
+            local saved = {
+                number = vim.o.number,
+                signcolumn = vim.o.signcolumn,
+                cursorline = vim.o.cursorline,
+                list = vim.o.list,
+            }
+            vim.o.number = true
+            vim.o.signcolumn = "yes"
+            vim.o.cursorline = true
+            vim.o.list = true
+
+            vim.cmd("tabnew")
+            local tab_page_id = vim.api.nvim_get_current_tabpage()
+
+            local win_nrs = {}
+            local buf_nrs = {
+                chat = vim.api.nvim_create_buf(false, true),
+                input = vim.api.nvim_create_buf(false, true),
+                code = vim.api.nvim_create_buf(false, true),
+                files = vim.api.nvim_create_buf(false, true),
+                diagnostics = vim.api.nvim_create_buf(false, true),
+                todos = vim.api.nvim_create_buf(false, true),
+            }
+
+            -- Editor window in this tab is the one created by :tabnew
+            local editor_win = vim.api.nvim_get_current_win()
+
+            WidgetLayout.open({
+                tab_page_id = tab_page_id,
+                buf_nrs = buf_nrs,
+                win_nrs = win_nrs,
+                position = "right",
+                focus_prompt = false,
+            })
+
+            -- Snapshot editor window options BEFORE any cohabit cycle
+            local editor_before = {
+                number = vim.wo[editor_win].number,
+                signcolumn = vim.wo[editor_win].signcolumn,
+                cursorline = vim.wo[editor_win].cursorline,
+                list = vim.wo[editor_win].list,
+                winhighlight = vim.wo[editor_win].winhighlight,
+                statuscolumn = vim.wo[editor_win].statuscolumn,
+                fillchars = vim.wo[editor_win].fillchars,
+                scrolloff = vim.wo[editor_win].scrolloff,
+                foldcolumn = vim.wo[editor_win].foldcolumn,
+            }
+
+            local augroup = BufferGuard.attach({
+                tab_page_id = tab_page_id,
+                find_target_window = function()
+                    if vim.api.nvim_win_is_valid(editor_win) then
+                        return editor_win
+                    end
+                    return nil
+                end,
+            })
+
+            -- Force a foreign buffer into the chat widget window. This
+            -- triggers BufEnter inside the widget and, in turn, a
+            -- redirect to the editor window via BufferGuard.
+            vim.api.nvim_set_current_win(win_nrs.chat)
+            local foreign = vim.api.nvim_create_buf(true, false)
+            vim.api.nvim_buf_set_name(foreign, vim.fn.tempname() .. "_leak.txt")
+            vim.api.nvim_win_set_buf(win_nrs.chat, foreign)
+
+            -- Editor window should now hold the foreign buffer with its
+            -- ORIGINAL options intact, not panel-styled.
+            assert.equal(foreign, vim.api.nvim_win_get_buf(editor_win))
+            assert.equal(editor_before.number, vim.wo[editor_win].number)
+            assert.equal(
+                editor_before.signcolumn,
+                vim.wo[editor_win].signcolumn
+            )
+            assert.equal(
+                editor_before.cursorline,
+                vim.wo[editor_win].cursorline
+            )
+            assert.equal(editor_before.list, vim.wo[editor_win].list)
+            assert.equal(
+                editor_before.winhighlight,
+                vim.wo[editor_win].winhighlight
+            )
+            assert.equal(
+                editor_before.statuscolumn,
+                vim.wo[editor_win].statuscolumn
+            )
+            assert.equal(editor_before.fillchars, vim.wo[editor_win].fillchars)
+            assert.equal(editor_before.scrolloff, vim.wo[editor_win].scrolloff)
+            assert.equal(
+                editor_before.foldcolumn,
+                vim.wo[editor_win].foldcolumn
+            )
+
+            BufferGuard.detach(augroup)
+            WidgetLayout.close(win_nrs)
+            pcall(function()
+                vim.cmd("tabclose!")
+            end)
+
+            vim.o.number = saved.number
+            vim.o.signcolumn = saved.signcolumn
+            vim.o.cursorline = saved.cursorline
+            vim.o.list = saved.list
+        end
+    )
 end)
 
 -- Child process tests for cursor-follow behavior.

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -499,7 +499,7 @@ function ChatWidget:_create_new_buf(opts)
     }, opts)
 
     for key, value in pairs(config) do
-        vim.api.nvim_set_option_value(key, value, { buf = bufnr })
+        vim.bo[bufnr][key] = value
     end
 
     return bufnr

--- a/lua/agentic/ui/floating_message.lua
+++ b/lua/agentic/ui/floating_message.lua
@@ -46,8 +46,8 @@ function M.show(opts)
         footer_pos = "right",
     })
 
-    vim.wo[win].wrap = true
-    vim.wo[win].linebreak = true
+    vim.wo[win][0].wrap = true
+    vim.wo[win][0].linebreak = true
 
     BufHelpers.keymap_set(buf, "n", "q", function()
         vim.cmd.close()

--- a/lua/agentic/ui/tool_call_fold.lua
+++ b/lua/agentic/ui/tool_call_fold.lua
@@ -62,14 +62,17 @@ function Fold.setup_window(winid, _bufnr)
     if Fold.threshold() == nil then
         return
     end
+    -- Use vim.wo[winid][0] (`:setlocal`) to keep these options scoped
+    -- to (winid, current buffer) only. See widget_layout.apply_panel_window_opts
+    -- for the leak this avoids.
     if vim.wo[winid].foldmethod ~= "manual" then
-        vim.wo[winid].foldmethod = "manual"
+        vim.wo[winid][0].foldmethod = "manual"
     end
     if vim.wo[winid].foldlevel ~= 0 then
-        vim.wo[winid].foldlevel = 0
+        vim.wo[winid][0].foldlevel = 0
     end
-    vim.wo[winid].foldenable = true
-    vim.wo[winid].foldtext = FOLDTEXT_EXPR
+    vim.wo[winid][0].foldenable = true
+    vim.wo[winid][0].foldtext = FOLDTEXT_EXPR
 end
 
 --- @param bufnr integer

--- a/lua/agentic/ui/tool_call_fold.lua
+++ b/lua/agentic/ui/tool_call_fold.lua
@@ -62,9 +62,6 @@ function Fold.setup_window(winid, _bufnr)
     if Fold.threshold() == nil then
         return
     end
-    -- Use vim.wo[winid][0] (`:setlocal`) to keep these options scoped
-    -- to (winid, current buffer) only. See widget_layout.apply_panel_window_opts
-    -- for the leak this avoids.
     if vim.wo[winid].foldmethod ~= "manual" then
         vim.wo[winid][0].foldmethod = "manual"
     end

--- a/lua/agentic/ui/widget_layout.lua
+++ b/lua/agentic/ui/widget_layout.lua
@@ -116,14 +116,6 @@ local function apply_panel_window_opts(winid, bufnr, window_name, win_opts)
         winfixheight = true,
     }, PANEL_WINDOW_OPTS, win_opts or {}, config_win_opts)
 
-    -- Use vim.wo[winid][0] (`:setlocal` semantics) so panel options
-    -- are stored against (winid, widget_buf) only. With `:set`-style
-    -- writes (e.g. nvim_set_option_value scope-defaulted, or
-    -- vim.wo[winid] without [0]), Neovim records the panel values in
-    -- the per-buffer option memory of any buffer that briefly cohabits
-    -- this window, leaking them to the buffer's next host window.
-    -- Regression: buffer_guard.test.lua "does not leak widget window
-    -- options to the editor window after redirect".
     for name, value in pairs(merged_win_opts) do
         vim.wo[winid][0][name] = value
     end

--- a/lua/agentic/ui/widget_layout.lua
+++ b/lua/agentic/ui/widget_layout.lua
@@ -116,8 +116,16 @@ local function apply_panel_window_opts(winid, bufnr, window_name, win_opts)
         winfixheight = true,
     }, PANEL_WINDOW_OPTS, win_opts or {}, config_win_opts)
 
+    -- Use vim.wo[winid][0] (`:setlocal` semantics) so panel options
+    -- are stored against (winid, widget_buf) only. With `:set`-style
+    -- writes (e.g. nvim_set_option_value scope-defaulted, or
+    -- vim.wo[winid] without [0]), Neovim records the panel values in
+    -- the per-buffer option memory of any buffer that briefly cohabits
+    -- this window, leaking them to the buffer's next host window.
+    -- Regression: buffer_guard.test.lua "does not leak widget window
+    -- options to the editor window after redirect".
     for name, value in pairs(merged_win_opts) do
-        vim.api.nvim_set_option_value(name, value, { win = winid })
+        vim.wo[winid][0][name] = value
     end
 end
 
@@ -326,7 +334,7 @@ function WidgetLayout.open_hidden_chat_window(bufnr)
         return nil
     end
 
-    vim.wo[winid].winbar = ""
+    vim.wo[winid][0].winbar = ""
 
     apply_panel_window_opts(winid, bufnr, "chat", {
         statuscolumn = ToolBlockBorder.STATUSCOLUMN_EXPR,

--- a/lua/agentic/ui/window_decoration.lua
+++ b/lua/agentic/ui/window_decoration.lua
@@ -174,7 +174,7 @@ local function set_winbar(winid, text)
 
     -- Handle empty string case - disable winbar completely
     if text == "" then
-        vim.api.nvim_set_option_value("winbar", nil, { win = winid })
+        vim.wo[winid][0].winbar = ""
         return
     end
 
@@ -192,7 +192,7 @@ local function set_winbar(winid, text)
 
     winbar_text = "%#Normal#" .. winbar_text
 
-    vim.api.nvim_set_option_value("winbar", winbar_text, { win = winid })
+    vim.wo[winid][0].winbar = winbar_text
 end
 
 --- Sets the buffer name based on header text and tab count

--- a/lua/agentic/utils/buf_helpers.lua
+++ b/lua/agentic/utils/buf_helpers.lua
@@ -15,16 +15,11 @@ function BufHelpers.with_modifiable(bufnr, callback)
         return false
     end
 
-    local original_modifiable =
-        vim.api.nvim_get_option_value("modifiable", { buf = bufnr })
-    vim.api.nvim_set_option_value("modifiable", true, { buf = bufnr })
+    local original_modifiable = vim.bo[bufnr].modifiable
+    vim.bo[bufnr].modifiable = true
     local ok, response = pcall(callback, bufnr)
 
-    vim.api.nvim_set_option_value(
-        "modifiable",
-        original_modifiable,
-        { buf = bufnr }
-    )
+    vim.bo[bufnr].modifiable = original_modifiable
 
     if not ok then
         Logger.notify(


### PR DESCRIPTION
## Summary

- Panel + fold window options leaked to the editor window when `BufferGuard` redirected a foreign buffer out of a widget window. Root cause: `nvim_set_option_value({win=...})` and `vim.wo[winid].opt` use `:set` semantics, which record window-local values in the per-`(buffer, window)` option memory. Foreign buffers that briefly cohabited the widget window carried the panel styling to their next host.
- Fix: write all panel + fold options via `vim.wo[winid][0].opt` (`:setlocal`). Verified end-to-end via headless tests covering `:edit`, `:buffer`, `nvim_win_set_buf`, and `<C-w>w`.
- Drive-by: convert remaining `nvim_set_option_value` / bare `vim.wo[id]` writes to idiomatic `vim.wo[id][0]` / `vim.bo[id]` in `floating_message`, `window_decoration`, `chat_widget._create_new_buf`, `buf_helpers.with_modifiable`.
- Docs: corrected stale comment in `buffer_guard.lua`, added hard rule + regression-test pointer in `lua/agentic/ui/AGENTS.md`, documented the hidden chat float as un-interactable.

## Test plan

- [x] `make validate` (format, luals, selene, test) all green
- [x] New regression test `buffer_guard.test.lua::"does not leak widget window options to the editor window after redirect"` fails on current code, passes after fix
- [x] Mark count: 8/8 in `buffer_guard.test.lua`
- [x] Headless verification: `<C-w>w`, `:edit <file>`, `:buffer <id>`, `nvim_win_set_buf` all leave editor window options at defaults; widget window keeps panel options across cohabit cycles; manual fold survives cycles