### PR TITLE
docs(agents): convert ASCII diagrams to mermaid

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,10 @@ non-obvious. Citation format: `ADR NNN` (zero-padded, no brackets, no dash).
 - New "FORBIDDEN" / "MUST" rule about runtime behavior = new test that fails
   without the rule. Reference the test by name in the rule body. Pure-style
   rules (formatting, naming, docs) are exempt.
+- Fenced code blocks MUST have a language hint. Use `text` for free-form ASCII
+  (trees, byte layouts, pseudocode), `mermaid` for diagrams, and the actual
+  language otherwise (`lua`, `bash`, `markdown`, etc.). CodeRabbit /
+  markdownlint flag bare fences (MD040).
 
 ## CRITICAL: No Assumptions - Gather Context First
 
@@ -223,18 +227,17 @@ Subsystem-specific traps live in nested `AGENTS.md`. These apply everywhere:
   `nvim_set_option_value(opt, val, { win = winid })`. Per `:h local-options`,
   window-local options are remembered per `(buffer, window)`. `:set` writes
   imprint the value in any buffer that briefly cohabits the window and the
-  buffer carries it to its next host. `[0]` is the `:setlocal` sentinel
-  (only `[0]` is supported by `vim.wo`, see `:h vim.wo`); without it, panel
-  styling leaks to redirected buffers.
-  - Applies to ALL `vim.wo` writes, not just panels. No `vim.bo` equivalent
-    is needed: buffer options have no per-window memory.
-  - Reads (`local x = vim.wo[winid].opt`) are unaffected; `[0]` is
-    write-only.
-  - Regression: `lua/agentic/ui/buffer_guard.test.lua::"does not leak widget
-    window options to the editor window after redirect"`.
+  buffer carries it to its next host. `[0]` is the `:setlocal` sentinel (only
+  `[0]` is supported by `vim.wo`, see `:h vim.wo`); without it, panel styling
+  leaks to redirected buffers.
+  - Applies to ALL `vim.wo` writes, not just panels. No `vim.bo` equivalent is
+    needed: buffer options have no per-window memory.
+  - Reads (`local x = vim.wo[winid].opt`) are unaffected; `[0]` is write-only.
+  - Regression:
+    `lua/agentic/ui/buffer_guard.test.lua::"does not leak widget window options to the editor window after redirect"`.
 - **AVOID: `nvim_set_option_value` / `nvim_get_option_value`** for buffer or
-  window options when an idiomatic accessor exists. Use `vim.bo[bufnr].opt`
-  for buffer options and `vim.wo[winid][0].opt` for window options. The
+  window options when an idiomatic accessor exists. Use `vim.bo[bufnr].opt` for
+  buffer options and `vim.wo[winid][0].opt` for window options. The
   `nvim_*_option_value` API is reserved for cases that need a dynamic option
   name or a non-default scope (e.g. `scope = "global"`). Reading is symmetric:
   `vim.bo[bufnr].opt` / `vim.wo[winid].opt` (no `[0]` on reads).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,28 @@ SessionRegistry.get_session_for_tab_page(nil, function(session)
 end)
 ```
 
+```mermaid
+flowchart TD
+    Caller["public entry in init.lua"]
+    Entry["SessionRegistry.get_session_for_tab_page(tab_id_or_nil, cb?)"]
+    HasCb{"callback provided?"}
+    Resolve["resolve tabpage<br/>(nil -> current tab)"]
+    Provider{"ACP provider configured?"}
+    ReturnNil["return nil"]
+    Wrap["pcall(callback, session)"]
+    Touch["touch session/widget state safely"]
+    Notify["errors notified, not raised"]
+    Bare["bare-return form<br/>returns session or nil"]
+
+    Caller --> Entry --> HasCb
+    HasCb -->|yes| Resolve --> Wrap
+    Wrap --> Touch
+    Wrap --> Notify
+    HasCb -->|no, bare| Provider
+    Provider -->|yes| Bare
+    Provider -->|no| ReturnNil
+```
+
 Guarantees inside the callback:
 
 - Tabpage and session resolved against the requested tab.
@@ -168,10 +190,10 @@ Outside the callback:
 
 Cleanup path:
 
-```text
-TabClosed autocmd
-  -> SessionRegistry.destroy_session(tab_page_id)
-     -> SessionManager:destroy
+```mermaid
+flowchart LR
+    A[TabClosed autocmd] --> B["SessionRegistry.destroy_session(tab_page_id)"]
+    B --> C["SessionManager:destroy"]
 ```
 
 ### Logger

--- a/lua/agentic/acp/AGENTS.md
+++ b/lua/agentic/acp/AGENTS.md
@@ -132,7 +132,7 @@ chunks. JSON-RPC messages are newline-delimited, but a single chunk
 may split mid-message or carry several messages plus a partial
 trailer.
 
-```
+```text
 chunk 1:  ...{"jsonrpc":"2.0","i
                               ╰── partial, no newline yet
 chunk 2:  d":1,...}\n{"jsonrpc":"2.0","method
@@ -142,7 +142,7 @@ chunk 2:  d":1,...}\n{"jsonrpc":"2.0","method
 
 The buffering loop in `acp_transport.create_stdio_transport`:
 
-```
+```text
 chunks = chunks .. data
 lines  = split(chunks, "\n")
 chunks = lines[#lines]    -- keep partial trailer for next read

--- a/lua/agentic/acp/AGENTS.md
+++ b/lua/agentic/acp/AGENTS.md
@@ -56,25 +56,167 @@ acp_providers = {
 
 ## Event pipeline (top to bottom)
 
+```mermaid
+flowchart TD
+    Provider[Provider subprocess<br/>external CLI]
+    Transport[ACPTransport<br/>parses JSON, calls<br/>callbacks.on_message]
+    Client[ACPClient<br/>routes notification vs response<br/>__handle_tool_call,<br/>__handle_tool_call_update,<br/>__build_tool_call_message]
+    Session[SessionManager<br/>subscriber per session_id<br/>routes by sessionUpdate type<br/>see 'Session update routing']
+    Writer[MessageWriter<br/>writes to chat buffer<br/>tracks tool call state]
+    Perm[PermissionManager<br/>queues permission prompts<br/>manages keymaps]
+    History[ChatHistory<br/>accumulates messages<br/>for persistence]
+
+    Provider -->|stdio: newline-delimited JSON-RPC| Transport
+    Transport --> Client
+    Client --> Session
+    Session --> Writer
+    Session --> Perm
+    Session --> History
 ```
-Provider subprocess (external CLI)
-  | stdio: newline-delimited JSON-RPC
-  v
-ACPTransport      -- parses JSON, calls callbacks.on_message()
-  |
-  v
-ACPClient         -- routes by message type (notification vs response)
-  |  protected methods: __handle_tool_call,
-  |  __handle_tool_call_update, __build_tool_call_message
-  v
-SessionManager    -- registered as subscriber per session_id
-  |  routes by sessionUpdate type
-  |  (see "Session update routing" below)
-  v
-MessageWriter     -- writes to chat buffer, tracks tool call state
-PermissionManager -- queues permission prompts, manages keymaps
-ChatHistory       -- accumulates messages for persistence
+
+## ACPClient lifecycle (state machine)
+
+State lives on `ACPClient.state`. The transport's `on_state_change`
+callback drives `connecting -> connected -> error | disconnected`. The
+RPC responses to `initialize` and `authenticate` drive the rest.
+
+```mermaid
+stateDiagram-v2
+    [*] --> disconnected
+    disconnected --> connecting: _connect()
+    connecting --> connected: spawn ok, pipes open
+    connected --> initializing: send 'initialize'
+    initializing --> authenticating: auth_method set
+    initializing --> ready: no auth required
+    authenticating --> ready: auth response ok
+    disconnected --> connecting: reconnect (if enabled)
+
+    state "any state" as any
+    any --> disconnected: process exit
+    any --> error: transport error
+
+    note right of disconnected
+        on entry: _drain_pending_callbacks
+        rejects all pending RPC callbacks
+        with TRANSPORT_ERROR
+    end note
+    note right of error
+        on entry: _drain_pending_callbacks
+    end note
+    note right of ready
+        on entry: flush ready_listeners
+        (each via vim.schedule)
+    end note
 ```
+
+Invariants:
+
+- `_drain_pending_callbacks` runs on every transition to
+  `disconnected` or `error`. It rejects every pending RPC callback
+  with `TRANSPORT_ERROR`. Without it, `send_prompt`, `create_session`,
+  and the rest of `_send_request`-based calls hang forever when the
+  provider dies.
+- Reconnect (when `provider_config.reconnect` is true) loops back to
+  `connecting`. `reconnect_count` on the client gates max attempts;
+  the transport's `on_reconnect` callback reinvokes `_connect`.
+- `_on_ready` fan-out: callers registered via `when_ready` before the
+  client reaches `ready` are flushed (each via `vim.schedule`) at the
+  moment of transition. After `ready`, new `when_ready` callers fire
+  immediately (still via `vim.schedule`), so the callback contract is
+  the same in both cases.
+
+## Stdio transport line framing
+
+The stdio transport reads from the provider's stdout in arbitrary
+chunks. JSON-RPC messages are newline-delimited, but a single chunk
+may split mid-message or carry several messages plus a partial
+trailer.
+
+```
+chunk 1:  ...{"jsonrpc":"2.0","i
+                              ╰── partial, no newline yet
+chunk 2:  d":1,...}\n{"jsonrpc":"2.0","method
+          ╰─────────╯         ╰─────────────╯
+          completes prior     partial again
+```
+
+The buffering loop in `acp_transport.create_stdio_transport`:
+
+```
+chunks = chunks .. data
+lines  = split(chunks, "\n")
+chunks = lines[#lines]    -- keep partial trailer for next read
+for i = 1, #lines - 1 do
+    dispatch(decode(trim(lines[i])))
+end
+```
+
+Invariants:
+
+- `chunks` always holds the unterminated tail across reads.
+- A single read can dispatch zero or more complete messages.
+- Empty/whitespace-only lines are skipped, not dispatched.
+- JSON-decode failures `Logger.notify` and continue; they do not
+  corrupt the buffer.
+
+Why preserved: large payloads (tool-call diffs, big agent message
+chunks) routinely exceed a single pipe-read. Dropping the
+partial-tail buffer turns every multi-chunk message into a JSON parse
+error that surfaces as silent message loss.
+
+## Sync vs async dispatch
+
+`ACPClient:_handle_message` runs inside the libuv stdout callback,
+i.e. in fast event context. The two dispatch branches differ in where
+the user-supplied callback ultimately runs:
+
+```mermaid
+flowchart TD
+    Entry["_handle_message<br/>(fast context)"]
+    Branch{has id + result/error?}
+    RPC["RPC response<br/>self.callbacks[id](...)<br/><b>SYNC, fast context</b>"]
+    Notif["notification<br/>_handle_notification"]
+    Update["__handle_session_update"]
+    Sub["__with_subscriber"]
+    Sched["vim.schedule(cb)<br/><b>ASYNC, main loop</b>"]
+
+    Entry --> Branch
+    Branch -->|yes| RPC
+    Branch -->|no, has method| Notif
+    Notif --> Update
+    Update --> Sub
+    Sub --> Sched
+```
+
+Implications for callers:
+
+- RPC callbacks passed to `_send_request` (used by `create_session`,
+  `send_prompt`, `set_mode`, `set_model`, `set_config_option`,
+  `load_session`, `list_sessions`, `authenticate`, `initialize`) fire
+  in fast context. Buffer writes, most `vim.api.*` calls, and
+  `Logger.notify` from those callbacks crash with a fast-context
+  error. Wrap their bodies in `vim.schedule`.
+  `session_manager._handle_input_submit` already does this for the
+  `send_prompt` response.
+- Session-update notifications already cross the `vim.schedule`
+  boundary inside `ACPClient`, so subscribers (`SessionManager:_on_*`)
+  run on the main loop. No extra `vim.schedule` needed there.
+- `vim.schedule` preserves FIFO order: subscribers see notifications
+  in the order the provider sent them, even when one libuv read
+  delivers many messages at once. No batching, no reordering. If the
+  UI ever appears to "batch" updates after a delay, the buffering is
+  upstream (provider stdout), not here.
+
+Why preserved:
+
+- Wrapping the RPC branch in `vim.schedule` too would defer the
+  `initialize` handler that flips state to `ready` and drains
+  `ready_listeners`. Deferring it lets notifications that arrive in
+  the same libuv read observe `state == "initializing"` and behave
+  inconsistently.
+- Running the notification branch synchronously would put UI writes
+  (`MessageWriter:write_message_chunk` calls `nvim_buf_set_text`)
+  into fast context and crash.
 
 ## Session update routing
 
@@ -98,42 +240,56 @@ Tool calls go through **3 phases**. `MessageWriter` tracks each via
 
 **Phase 1 — `tool_call` (initial)**
 
-```
-Provider sends "tool_call"
-  -> ACPClient builds ToolCallBlock via __build_tool_call_message
-     { tool_call_id, kind, argument, status, body?, diff? }
-  -> subscriber.on_tool_call(block)
-  -> MessageWriter:write_tool_call_block(block)
-     1. Renders header + body/diff lines to buffer
-     2. Creates range extmark (NS_TOOL_BLOCKS) as position anchor
-     3. Statuscolumn reads the range extmark for borders; status footer
-        extmark renders the status icon
-     4. Stores block in tool_call_blocks[id]
+```mermaid
+flowchart TD
+    P["Provider sends 'tool_call'"]
+    B["ACPClient.__build_tool_call_message<br/>builds ToolCallBlock<br/>{ tool_call_id, kind, argument,<br/>status, body?, diff? }"]
+    S["subscriber.on_tool_call(block)"]
+    W["MessageWriter:write_tool_call_block(block)"]
+    W1["1. Render header + body/diff lines"]
+    W2["2. Create range extmark<br/>(NS_TOOL_BLOCKS) as anchor"]
+    W3["3. Statuscolumn reads extmark for borders<br/>status footer extmark renders icon"]
+    W4["4. Store block in tool_call_blocks[id]"]
+
+    P --> B --> S --> W
+    W --> W1 --> W2 --> W3 --> W4
 ```
 
 **Phase 2 — `tool_call_update` (one or more)**
 
-```
-Provider sends "tool_call_update"
-  -> ACPClient builds ToolCallBase via __build_tool_call_message
-     (only CHANGED fields needed — MessageWriter merges)
-  -> subscriber.on_tool_call_update(partial)
-  -> MessageWriter:update_tool_call_block(partial)
-     1. Looks up tracker = tool_call_blocks[id]
-     2. Deep-merges via tbl_deep_extend("force", tracker, partial)
-     3. Appends body (if both old and new exist and differ)
-     4. Locates block position via range extmark
-     5. Diff already rendered: refresh header + status only
-        (content frozen to prevent flicker)
-     6. Diff is NEW: replace buffer lines, re-render everything
+```mermaid
+flowchart TD
+    P["Provider sends 'tool_call_update'"]
+    B["ACPClient.__build_tool_call_message<br/>builds ToolCallBase<br/>(only CHANGED fields — MessageWriter merges)"]
+    S["subscriber.on_tool_call_update(partial)"]
+    W["MessageWriter:update_tool_call_block(partial)"]
+    W1["1. tracker = tool_call_blocks[id]"]
+    W2["2. tbl_deep_extend('force', tracker, partial)"]
+    W3["3. Append body if old/new exist and differ"]
+    W4["4. Locate block via range extmark"]
+    Diff{"diff already rendered?"}
+    W5a["5a. Refresh header + status only<br/>(content frozen, no flicker)"]
+    W5b["5b. Replace buffer lines, re-render all"]
+
+    P --> B --> S --> W
+    W --> W1 --> W2 --> W3 --> W4 --> Diff
+    Diff -->|yes| W5a
+    Diff -->|no, diff is new| W5b
 ```
 
 **Phase 3 — final `tool_call_update` with terminal status**
 
-```
-Same as Phase 2, but status = "completed" | "failed"
-  -> Visual status icon updates to final state
-  -> If "failed": PermissionManager removes pending request
+```mermaid
+flowchart TD
+    P["Same as Phase 2, but status = 'completed' | 'failed'"]
+    I["Visual status icon updates to final state"]
+    F{"status == 'failed'?"}
+    R["PermissionManager removes pending request"]
+    N["no-op"]
+
+    P --> I --> F
+    F -->|yes| R
+    F -->|no| N
 ```
 
 ## Key design rules
@@ -165,17 +321,26 @@ To handle a new provider quirk, add the fallback logic in
 
 ## Permission flow (interleaved with tool calls)
 
-```
-Provider sends "session/request_permission"
-  -> SessionManager: opens diff preview (if the request carries a diff)
-  -> PermissionManager:add_request(request, callback)
-     -> Queues request (sequential — one prompt at a time)
-     -> Renders permission buttons in chat buffer
-     -> Sets up buffer-local keymaps (1,2,3,4)
-  -> User presses key
-     -> Sends result back to provider via callback
-     -> Clears diff preview
-     -> Dequeues next permission if any
+```mermaid
+flowchart TD
+    P["Provider sends 'session/request_permission'"]
+    SM["SessionManager<br/>opens diff preview if request carries a diff"]
+    PM["PermissionManager:add_request(request, callback)"]
+    Q["Queue request (sequential, one prompt at a time)"]
+    R["Render permission buttons in chat buffer"]
+    K["Set up buffer-local keymaps (1, 2, 3, 4)"]
+    U["User presses key"]
+    CB["Send result back to provider via callback"]
+    Clear["Clear diff preview"]
+    Next{"more queued?"}
+    Deq["Dequeue + render next"]
+    Done["idle"]
+
+    P --> SM --> PM
+    PM --> Q --> R --> K --> U
+    U --> CB --> Clear --> Next
+    Next -->|yes| Deq --> R
+    Next -->|no| Done
 ```
 
 ## Protected methods in ACPClient

--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -36,6 +36,38 @@ SessionManager (per tab)
 
 Widget windows are disposable.
 
+```mermaid
+stateDiagram-v2
+    [*] --> hidden
+    hidden --> visible: show()<br/>create fresh windows<br/>reapply window-local opts
+    visible --> hidden: hide()<br/>close + destroy widget windows<br/>buffers persist
+
+    state "destroy()" as destroy
+    visible --> destroy
+    hidden --> destroy
+
+    state tab_check <<choice>>
+    destroy --> tab_check
+    tab_check --> hide_then_delete: tab still in nvim_list_tabpages()
+    tab_check --> delete_only: tab_closing<br/>(TabClosed in progress)
+
+    hide_then_delete --> [*]: buffers deleted
+    delete_only --> [*]: buffers deleted<br/>(skip nvim_win_close, segfaults on 0.11.x)
+
+    note right of visible
+        hide() preconditions:
+        - ensure non-widget fallback window
+          (open_editor_window if none) -> E444 otherwise
+        - wrap close in _avoid_auto_close_cmd
+          (sets _closing) -> recursive close otherwise
+    end note
+    note right of hidden
+        hidden chat float keeps chat buffer
+        attached so manual folds apply while
+        closed (ADR 001). Internal handle only.
+    end note
+```
+
 - `hide` closes and destroys every widget window.
 - Buffers persist.
 - `show` creates fresh windows on every call and reapplies every window-local
@@ -197,6 +229,23 @@ Special write paths bypass `_maybe_write_sender_header`'s normal flow:
     write path itself: it is set true around `_reanchor_permission_prompt`'s own
     `set_lines` so the post-mutation callback no-ops instead of re-entering.
     Removing the flag re-enters and stack-overflows.
+
+    ```mermaid
+    sequenceDiagram
+        participant Caller
+        participant PM as PermissionManager
+        participant Buf as chat buffer
+        participant CB as post-mutation cb
+
+        Caller->>PM: _reanchor_permission_prompt()
+        PM->>PM: _reanchoring = true
+        PM->>Buf: set_lines (move buttons)
+        Buf-->>CB: fires post-mutation hook
+        CB->>PM: check _reanchoring
+        Note over CB,PM: true -> no-op<br/>(without flag: re-enters,<br/>stack overflow)
+        PM->>PM: _reanchoring = false
+        PM-->>Caller: done
+    ```
 
 ## Test invariants
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -63,7 +63,7 @@ docs), say so explicitly in the PR description.
 
 **Example structure:**
 
-```
+```text
 lua/agentic/
   ├── init.lua
   ├── init.test.lua


### PR DESCRIPTION
- Convert ASCII art in `AGENTS.md` files to mermaid diagrams.
- Rationale: mermaid renders inline in Snacks.nvim and GitHub UI; agents
  and humans parse the same source.
- Prose kept as ground truth. Diagrams added/replaced only where the
  shape is a graph (state machines, flowcharts, fan-out, sequences).
- ASCII kept for byte-layout illustrations and pseudocode (not graphs).