### PR TITLE
fix(ui): render markdown diffs with proper fences and highlighting

### DIFF
--- a/lua/agentic/theme.lua
+++ b/lua/agentic/theme.lua
@@ -50,7 +50,8 @@ local lang_map = {
     sh = "bash",
     typescriptreact = "tsx",
     javascriptreact = "jsx",
-    markdown = "md",
+    -- tree-sitter markdown parser does not register "md" as alias, fences with "md" are not highlighted
+    md = "markdown",
 }
 
 local status_hl = {

--- a/lua/agentic/theme.test.lua
+++ b/lua/agentic/theme.test.lua
@@ -1,0 +1,24 @@
+local assert = require("tests.helpers.assert")
+
+describe("agentic.theme", function()
+    local Theme = require("agentic.theme")
+
+    describe("get_language_from_path", function()
+        it("maps .md to 'markdown' (tree-sitter has no 'md' alias)", function()
+            assert.equal("markdown", Theme.get_language_from_path("README.md"))
+        end)
+
+        it("returns extension as-is when not in lang_map", function()
+            assert.equal("lua", Theme.get_language_from_path("init.lua"))
+        end)
+
+        it("applies lang_map aliases", function()
+            assert.equal("python", Theme.get_language_from_path("a.py"))
+            assert.equal("bash", Theme.get_language_from_path("a.sh"))
+        end)
+
+        it("returns empty string for path without extension", function()
+            assert.equal("", Theme.get_language_from_path("Makefile"))
+        end)
+    end)
+end)

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -664,12 +664,7 @@ function MessageWriter:_prepare_block_lines(tool_call_block)
         })
 
         local lang = Theme.get_language_from_path(diff_path)
-
-        -- Hack to avoid triple backtick conflicts in markdown files
-        local has_fences = lang ~= "md" and lang ~= "markdown"
-        if has_fences then
-            table.insert(lines, "```" .. lang)
-        end
+        table.insert(lines, "`````" .. lang)
 
         for _, block in ipairs(diff_blocks) do
             local old_count = #block.old_lines
@@ -748,10 +743,7 @@ function MessageWriter:_prepare_block_lines(tool_call_block)
             end
         end
 
-        -- Close code fences, if not markdown, to avoid conflicts
-        if has_fences then
-            table.insert(lines, "```")
-        end
+        table.insert(lines, "`````")
     else
         if tool_call_block.body then
             vim.list_extend(lines, tool_call_block.body)

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -310,6 +310,50 @@ describe("agentic.ui.MessageWriter", function()
             assert.is_true(#new_ranges > 0)
             assert.equal("inserted", new_ranges[1].new_line)
         end)
+
+        it(
+            "wraps markdown-file diffs in a 5-backtick fence so inner ``` survives",
+            function()
+                read_stub:returns({ "old line" })
+
+                local Theme = require("agentic.theme")
+                local lang = Theme.get_language_from_path("README.md")
+                local open_fence = string.rep("`", 5) .. lang
+                local close_fence = string.rep("`", 5)
+
+                --- @type agentic.ui.MessageWriter.ToolCallBlock
+                local block = {
+                    tool_call_id = "test-md-fence",
+                    status = "pending",
+                    kind = "edit",
+                    argument = "README.md",
+                    file_path = "README.md",
+                    diff = {
+                        old = { "old line" },
+                        new = { "new line", "```", "still new" },
+                    },
+                }
+
+                local lines = writer:_prepare_block_lines(block)
+
+                local open_idx, close_idx, inner_idx
+                for i, line in ipairs(lines) do
+                    if line == open_fence then
+                        open_idx = i
+                    elseif line == close_fence and not close_idx then
+                        close_idx = i
+                    elseif line == "```" then
+                        inner_idx = i
+                    end
+                end
+
+                assert.is_not_nil(open_idx)
+                assert.is_not_nil(close_idx)
+                assert.is_not_nil(inner_idx)
+                assert.is_true(open_idx < inner_idx)
+                assert.is_true(inner_idx < close_idx)
+            end
+        )
     end)
 
     describe("sender header tracking", function()


### PR DESCRIPTION
## Summary

- Switch diff blocks to 5-backtick fences so markdown-file diffs no longer drop fencing. Per CommonMark, a 5-backtick opener is only closed by a line with 5+ backticks, so inner triple-backtick lines in markdown content pass through cleanly.
- Drop the markdown-specific no-fence hack in `MessageWriter:_prepare_block_lines`.
- Fix `Theme.get_language_from_path` so `.md` resolves to `markdown` instead of `md`. The tree-sitter `markdown` parser does not register `md` as an alias, so fences tagged `md` were not highlighted in the chat buffer.

## Risk accepted

A diff whose content contains a line with 5+ backticks would close the outer fence prematurely. Vanishingly rare in practice.