### PR TITLE
feat: Inline buttons layout for permission requests anchored to each tool call

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,6 +11,7 @@
       "Bash(make format:*)",
       "Bash(make luacheck:*)",
       "Bash(make luals:*)",
+      "Bash(make selene *)",
       "Bash(make test-file:*)",
       "Bash(make test:*)",
       "Bash(make validate:*)",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,13 @@ status animation, permission manager, file list, code selection.
   global autocommands.
 
 - **Keymaps must be buffer-local.** Use
-  `BufHelpers.keymap_set(bufnr, "n", "key", fn)`. NEVER use global keymaps.
+  `BufHelpers.keymap_set(bufnr, "n", "key", fn)` and
+  `BufHelpers.keymap_del(bufnr, "n", "key")`. NEVER use global keymaps.
+  NEVER call `vim.keymap.set` / `vim.keymap.del` directly with
+  `{ buffer = bufnr }`: the option was renamed to `buf` in Neovim 0.12.1
+  (`neovim#38360`) and removed
+  in 0.15; the wrappers gate on `has('nvim-0.12.1')`. Regression tests:
+  `lua/agentic/utils/buf_helpers.test.lua::"uses `buffer`/`buf` opt on Neovim"`.
 
 ## Public API and call chain
 
@@ -219,7 +225,10 @@ Subsystem-specific traps live in nested `AGENTS.md`. These apply everywhere:
   example.
 - **FORBIDDEN: module-level mutable state for per-tab data** -> store on per-tab
   instances. See "Multi-Tabpage Architecture" below.
-- **FORBIDDEN: global keymaps** -> use `BufHelpers.keymap_set(bufnr, ...)`.
+- **FORBIDDEN: global keymaps, and direct `vim.keymap.set`/`vim.keymap.del`
+  with `{ buffer = bufnr }`** -> use `BufHelpers.keymap_set` /
+  `BufHelpers.keymap_del`. See "Keymaps must be buffer-local" above for the
+  `buffer` -> `buf` rename rationale and regression tests.
 - **FORBIDDEN: `vim.api.nvim_list_wins()` for tab-scoped lookups** -> use
   `vim.api.nvim_tabpage_list_wins(self.tab_page_id)`.
 - **FORBIDDEN: `:set`-style writes for window-local options** -> use

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ status animation, permission manager, file list, code selection.
   `{ buffer = bufnr }`: the option was renamed to `buf` in Neovim 0.12.1
   (`neovim#38360`) and removed
   in 0.15; the wrappers gate on `has('nvim-0.12.1')`. Regression tests:
-  `lua/agentic/utils/buf_helpers.test.lua::"uses `buffer`/`buf` opt on Neovim"`.
+  ``lua/agentic/utils/buf_helpers.test.lua::"uses `buffer`/`buf` opt on Neovim"``.
 
 ## Public API and call chain
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ test-file:
 
 # Lua Language Server headless diagnosis report
 luals:
-	@VIMRUNTIME=$${VIMRUNTIME:-$$($(NVIM) --headless -i NONE -n -c 'echo $$VIMRUNTIME' -c q 2>/dev/null)}; \
+	@VIMRUNTIME=$${VIMRUNTIME:-$$($(NVIM) --headless -i NONE -n -u NONE -c 'lua io.stdout:write(vim.env.VIMRUNTIME or "")' -c q 2>/dev/null)}; \
 	if [ -z "$$VIMRUNTIME" ]; then \
 		echo "Error: Could not determine VIMRUNTIME. Check that '$(NVIM)' is on PATH and runnable" >&2; \
 		exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ LOGDIR  ?= .luals-log
 .PHONY: luals selene selene-file format-check format format-file check test validate install-hooks
 
 test:
-	$(NVIM) --headless -u tests/init.lua -c "lua require('tests.runner').run()"
+	$(NVIM) --headless -i NONE -n -u tests/init.lua -c "lua require('tests.runner').run()"
 
 test-file:
-	$(NVIM) --headless -u tests/init.lua -c "lua require('tests.runner').run_file('$(FILE)')"
+	$(NVIM) --headless -i NONE -n -u tests/init.lua -c "lua require('tests.runner').run_file('$(FILE)')"
 
 # Lua Language Server headless diagnosis report
 luals:
-	@VIMRUNTIME=$$($(NVIM) --headless -c 'echo $$VIMRUNTIME' -c q 2>&1); \
+	@VIMRUNTIME=$${VIMRUNTIME:-$$($(NVIM) --headless -i NONE -n -c 'echo $$VIMRUNTIME' -c q 2>/dev/null)}; \
 	if [ -z "$$VIMRUNTIME" ]; then \
 		echo "Error: Could not determine VIMRUNTIME. Check that '$(NVIM)' is on PATH and runnable" >&2; \
 		exit 1; \

--- a/README.md
+++ b/README.md
@@ -634,6 +634,18 @@ your setup:
         next_hunk = "]c",
         prev_hunk = "[c",
       },
+
+      -- Keybindings to cycle focus between pending permission blocks.
+      -- Once a block is focused, per-block keys work on its row N:
+      --   h / <Left>  : focus previous button
+      --   l / <Right> : focus next button
+      --   <CR>        : submit focused button
+      --   1..4        : submit option N directly
+      -- Per-block keys only fire when the cursor is on the focused row.
+      permission = {
+        cycle_next = "<C-n>",
+        cycle_prev = "<C-p>",
+      },
     },
   },
 }
@@ -892,6 +904,9 @@ colorscheme.
 | `AgenticStatusPending`   | Pending tool call status indicator       | `bg=#5f4d8f`                        |
 | `AgenticStatusCompleted` | Completed tool call status indicator     | `bg=#2d5a3d`                        |
 | `AgenticStatusFailed`    | Failed tool call status indicator        | `bg=#7a2d2d`                        |
+| `AgenticPermissionButtonAllow`    | Focused allow button (after `h`/`l` focus)         | `bg=#2d5a3d, bold=true`             |
+| `AgenticPermissionButtonReject`   | Focused reject button (after `h`/`l` focus)        | `bg=#7a2d2d, bold=true`             |
+| `AgenticPermissionButtonInactive` | All non-focused permission buttons                 | `bg=#3a3a3a`                        |
 | `AgenticCodeBlockFence`  | The left border decoration on tool calls | Links to `Directory`                |
 | `AgenticTitle`           | Window titles in sidebar                 | `bg=#2787b0, fg=#000000, bold=true` |
 | `AgenticThinking`        | Thinking block text in chat buffer       | Links to `Comment`                  |

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -534,6 +534,10 @@ Override default keybindings via the `keymaps` config option:
   }
 <
 
+The per-block permission keys (`h`, `l`, `<Left>`, `<Right>`, `<CR>`,
+`1`..`4`) are fixed and not configurable. Only `cycle_next` / `cycle_prev`
+can be remapped via `keymaps.permission`.
+
 Keymap configuration formats:
   - String: `close = "q"` (normal mode by default)
   - Array: `submit = { "<CR>", "<C-s>" }` (multiple bindings)

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -485,6 +485,12 @@ These keybindings are automatically set in Agentic buffers:
   d                      n/v     Remove file/selection/diagnostic
   ]c                     n       Next diff hunk
   [c                     n       Previous diff hunk
+  <C-n>                  n       Cycle to next pending permission block
+  <C-p>                  n       Cycle to previous pending permission block
+  h / <Left>             n       Focus previous permission button (on row)
+  l / <Right>            n       Focus next permission button (on row)
+  <CR>                   n       Submit focused permission button (on row)
+  1..4                   n       Submit permission option directly (on row)
 
                                         *agentic-keymaps-customizing*
 Customizing keymaps ~
@@ -519,6 +525,10 @@ Override default keybindings via the `keymaps` config option:
       diff_preview = {
         next_hunk = "]c",
         prev_hunk = "[c",
+      },
+      permission = {
+        cycle_next = "<C-n>",
+        cycle_prev = "<C-p>",
       },
     },
   }
@@ -673,6 +683,9 @@ loads, that definition is preserved.
   `AgenticStatusPending`     Pending tool call status   bg=#5f4d8f
   `AgenticStatusCompleted`   Completed tool status      bg=#2d5a3d
   `AgenticStatusFailed`      Failed tool status         bg=#7a2d2d
+  `AgenticPermissionButtonAllow`     Focused allow button   bg=#2d5a3d bold
+  `AgenticPermissionButtonReject`    Focused reject button  bg=#7a2d2d bold
+  `AgenticPermissionButtonInactive`  Non-focused buttons    bg=#3a3a3a
   `AgenticCodeBlockFence`    Tool call left border      Links to Directory
   `AgenticTitle`             Window titles              bg=#2787b0 fg=#000000
   `AgenticThinking`          Thinking block text        Links to Comment

--- a/docs/architectural-decisions/003-inline-permission-buttons.md
+++ b/docs/architectural-decisions/003-inline-permission-buttons.md
@@ -40,7 +40,7 @@ flowchart TD
     Add["add_request(req, cb)"]
     Map["pending[tool_call_id] = req<br/>append to _order"]
     First{first pending?}
-    Focus["_set_focus(id)<br/>install per-block keymaps<br/>jump cursor + zz"]
+    Focus["_set_focus(id)<br/>install per-block keymaps<br/>jump cursor + zb"]
     Paint["repaint_status_row<br/>(non-focused state)"]
     Cycle["cycle_next / cycle_prev<br/>(default <C-n> / <C-p>)"]
     Btn["h / l / <Left> / <Right>"]
@@ -115,7 +115,9 @@ On every block-focus transition, `_jump_cursor_to(tool_call_id)`:
 1. Resolves the block's `end_row` via its range extmark.
 2. Resolves the first button's start column via
    `MessageWriter:_get_first_button_col(id)`.
-3. Sets cursor to `(end_row + 1, first_button_col)` and `zz` centers.
+3. Sets cursor to `(end_row + 1, first_button_col)` and `zb` anchors row
+   N at the window bottom (matches chat auto-scroll convention, see
+   ADR 001).
 
 Single-pending case: `cycle_next` lands on the same `focused_id`. Instead of
 no-op'ing in `_set_focus` (early return on same id), `_cycle_focus` detects

--- a/docs/architectural-decisions/003-inline-permission-buttons.md
+++ b/docs/architectural-decisions/003-inline-permission-buttons.md
@@ -1,7 +1,7 @@
 # 003. Inline permission buttons
 
 - Status: accepted
-- Last updated: 2026-05-14
+- Last updated: 2026-05-15
 - Related: `lua/agentic/ui/permission_manager.lua`,
   `lua/agentic/ui/message_writer.lua`, `lua/agentic/ui/AGENTS.md`,
   `lua/agentic/acp/AGENTS.md`
@@ -75,7 +75,8 @@ flowchart TD
 
 - **Block-level** (`Config.keymaps.permission.cycle_next` /
   `cycle_prev`, default `<C-n>` / `<C-p>`): cycles `focused_id` across pending
-  blocks. Permanent buffer-local keymaps; no-op when `pending` empty.
+  blocks. Buffer-local keymaps are installed only while permissions are
+  pending.
 - **Button-level** (`h` / `l` / `<Left>` / `<Right>`): cycles
   `focused_button_index` within the focused block. `<CR>` submits. Digits
   `1`..`4` submit option N directly.

--- a/docs/architectural-decisions/003-inline-permission-buttons.md
+++ b/docs/architectural-decisions/003-inline-permission-buttons.md
@@ -84,7 +84,7 @@ flowchart TD
 
 ### Row-gated per-block keymaps
 
-Per-block keymaps (`h`, `l`, `<Left>`, `<Right>`, `<CR>`, `1`..`4`) use
+Motion / submit keymaps (`h`, `l`, `<Left>`, `<Right>`, `<CR>`) use
 `expr = true`. On row N of the focused block they fire the action and return
 `""`. Off-row they return the original key, which is replayed with `noremap`
 and falls through to default Neovim behavior (cursor motion, counts,
@@ -92,6 +92,17 @@ read-only-buffer `<CR>`).
 
 This avoids buffer-wide hijacking of `h`/`l` while a permission is pending,
 without the complexity of an autocmd-driven install/uninstall lifecycle.
+
+Digit keys `1`..`4` are NOT row-gated: they fire from anywhere in the chat
+buffer. Direct dispatch is the whole point of inline permissions; gating them
+to row N forces the user to scroll to the block before pressing the digit,
+which defeats the feature. Digits `1`..`9` already have no useful unprefixed
+meaning in the chat buffer (counts only matter as prefixes to motions, which
+work normally since `0` is unbound and prefix-mode swallows digits before any
+mapping triggers).
+
+Regression test:
+`lua/agentic/ui/permission_manager.test.lua::"digit keymaps fire from anywhere in the chat buffer (off-row included)"`.
 
 ### Static label map
 
@@ -203,3 +214,4 @@ No change to ADR 001's manual-fold contract or anchor-pad invariants.
 | 2026-05-13 | -       | Two-level focus added: `h` / `l` / `<CR>` for buttons; digits kept; static label map; bg-only highlights, brackets removed.  |
 | 2026-05-13 | -       | Row-gated `expr=true` keymaps; cursor positions on first button column.                                                      |
 | 2026-05-13 | -       | `<C-n>` / `<C-p>` replace `]p` / `[p`; `Config.keymaps.permission.cycle_next` / `cycle_prev` made configurable.               |
+| 2026-05-13 | -       | Digits `1`..`4` ungated (fire from anywhere in the chat buffer); only motion / submit keys (`h`/`l`/`<Left>`/`<Right>`/`<CR>`) remain row-gated. |

--- a/docs/architectural-decisions/003-inline-permission-buttons.md
+++ b/docs/architectural-decisions/003-inline-permission-buttons.md
@@ -1,7 +1,7 @@
 # 003. Inline permission buttons
 
 - Status: accepted
-- Last updated: 2026-05-13
+- Last updated: 2026-05-14
 - Related: `lua/agentic/ui/permission_manager.lua`,
   `lua/agentic/ui/message_writer.lua`, `lua/agentic/ui/AGENTS.md`,
   `lua/agentic/acp/AGENTS.md`
@@ -135,6 +135,14 @@ no-op'ing in `_set_focus` (early return on same id), `_cycle_focus` detects
 this and calls `_jump_cursor_to` directly, so the user can recall the focused
 row even with one pending block.
 
+### Auto-scroll suppression
+
+`MessageWriter:_check_auto_scroll` stops following new output when the cursor
+row contains a permission-button extmark in `NS_STATUS`. The check uses
+rendered state, not `PermissionManager` focus state, so `MessageWriter` stays
+decoupled from permission ownership and row shifts remain correct after block
+rewrites.
+
 ### Highlight groups
 
 Three HL groups, defined with backgrounds (button-fill look, not text-color):
@@ -175,6 +183,9 @@ No change to ADR 001's manual-fold contract or anchor-pad invariants.
   line from the tracker; called by both update paths
   (`update_tool_call_block`, body refresh) and `PermissionManager` state
   changes.
+- Auto-scroll suppression is driven by `NS_STATUS` permission-button extmarks
+  on the cursor row. No focus-row callback from `PermissionManager` to
+  `MessageWriter` is needed.
 - `<CR>` consumed on row N of focused block. Read-only buffer default
   (next-line) was rarely useful there.
 - Sticky-reading regression on focus jump: user reading farther up the
@@ -215,3 +226,4 @@ No change to ADR 001's manual-fold contract or anchor-pad invariants.
 | 2026-05-13 | -       | Row-gated `expr=true` keymaps; cursor positions on first button column.                                                      |
 | 2026-05-13 | -       | `<C-n>` / `<C-p>` replace `]p` / `[p`; `Config.keymaps.permission.cycle_next` / `cycle_prev` made configurable.               |
 | 2026-05-13 | -       | Digits `1`..`4` ungated (fire from anywhere in the chat buffer); only motion / submit keys (`h`/`l`/`<Left>`/`<Right>`/`<CR>`) remain row-gated. |
+| 2026-05-14 | -       | Auto-scroll suppresses follow mode on `NS_STATUS` permission-button rows; no `PermissionManager` focus-row callback.          |

--- a/docs/architectural-decisions/003-inline-permission-buttons.md
+++ b/docs/architectural-decisions/003-inline-permission-buttons.md
@@ -125,7 +125,7 @@ On every block-focus transition, `_jump_cursor_to(tool_call_id)`:
 
 1. Resolves the block's `end_row` via its range extmark.
 2. Resolves the first button's start column via
-   `MessageWriter:_get_first_button_col(id)`.
+   `MessageWriter:get_button_col(id, 1)`.
 3. Sets cursor to `(end_row + 1, first_button_col)` and `zb` anchors row
    N at the window bottom (matches chat auto-scroll convention, see
    ADR 001).

--- a/docs/architectural-decisions/003-inline-permission-buttons.md
+++ b/docs/architectural-decisions/003-inline-permission-buttons.md
@@ -1,0 +1,203 @@
+# 003. Inline permission buttons
+
+- Status: accepted
+- Last updated: 2026-05-13
+- Related: `lua/agentic/ui/permission_manager.lua`,
+  `lua/agentic/ui/message_writer.lua`, `lua/agentic/ui/AGENTS.md`,
+  `lua/agentic/acp/AGENTS.md`
+
+## Context
+
+The previous permission UI was a single prompt rendered at the chat-buffer
+bottom by `MessageWriter:display_permission_buttons`. `PermissionManager`
+queued requests sequentially: one prompt at a time, dequeue on resolve.
+
+Two problems:
+
+1. **Visual disconnect.** Multiple pending tool calls collapsed into a single
+   bottom prompt. The header truncated to fit (`kind(arg)` cut to buffer
+   width). Users could not tie the prompt to its originating block, especially
+   when the chat had scrolled past the tool call.
+2. **Reanchor recursion.** Every chat mutation moved the prompt to the new
+   bottom (`_reanchor_permission_prompt`). The write itself fired the
+   post-mutation hook, so a `_reanchoring` flag was required to break the
+   self-trigger loop. Worked, but cost a recursion guard and a stack-overflow
+   trap documented in the UI AGENTS file.
+
+ACP allows multiple concurrent `session/request_permission` calls; each
+carries its own `respond_tx` oneshot. The sequential queue was a UI choice
+masking protocol capability — out-of-order resolution was already supported by
+the wire format.
+
+## Current decision
+
+One prompt per pending block, rendered as REAL TEXT on row N (the trailing
+slot of the tool-call layout — see `lua/agentic/ui/AGENTS.md` "Tool-call block
+layout") of each block.
+
+```mermaid
+flowchart TD
+    Add["add_request(req, cb)"]
+    Map["pending[tool_call_id] = req<br/>append to _order"]
+    First{first pending?}
+    Focus["_set_focus(id)<br/>install per-block keymaps<br/>jump cursor + zz"]
+    Paint["repaint_status_row<br/>(non-focused state)"]
+    Cycle["cycle_next / cycle_prev<br/>(default <C-n> / <C-p>)"]
+    Btn["h / l / <Left> / <Right>"]
+    Sub["<CR> or digit 1..4"]
+    Res["resolve(id, option_id)"]
+    Drain{pending empty?}
+    NextHead["_set_focus(next head)"]
+    Clear["clear focus + remove keymaps"]
+
+    Add --> Map --> First
+    First -->|yes| Focus
+    First -->|no| Paint
+    Focus --> Btn
+    Focus --> Sub
+    Cycle --> Focus
+    Btn --> Sub
+    Sub --> Res --> Drain
+    Drain -->|no| NextHead --> Btn
+    Drain -->|yes| Clear
+```
+
+### Concurrency model
+
+- `PermissionManager.pending: table<string, PermissionRequest>` keyed by
+  `tool_call_id`. Insertion-ordered `_order: string[]` for navigation.
+- New arrivals appended; do not steal focus.
+- `resolve(id, option_id)` removes from map + `_order`, fires callback. If the
+  resolved id was focused, focus snaps to next head (oldest remaining).
+- Head-tracking: focus always points at the oldest pending block.
+
+### Two-level focus
+
+- **Block-level** (`Config.keymaps.permission.cycle_next` /
+  `cycle_prev`, default `<C-n>` / `<C-p>`): cycles `focused_id` across pending
+  blocks. Permanent buffer-local keymaps; no-op when `pending` empty.
+- **Button-level** (`h` / `l` / `<Left>` / `<Right>`): cycles
+  `focused_button_index` within the focused block. `<CR>` submits. Digits
+  `1`..`4` submit option N directly.
+- Button-level keymaps are installed only while a block is focused; lifecycle
+  tied to `_set_focus`.
+
+### Row-gated per-block keymaps
+
+Per-block keymaps (`h`, `l`, `<Left>`, `<Right>`, `<CR>`, `1`..`4`) use
+`expr = true`. On row N of the focused block they fire the action and return
+`""`. Off-row they return the original key, which is replayed with `noremap`
+and falls through to default Neovim behavior (cursor motion, counts,
+read-only-buffer `<CR>`).
+
+This avoids buffer-wide hijacking of `h`/`l` while a permission is pending,
+without the complexity of an autocmd-driven install/uninstall lifecycle.
+
+### Static label map
+
+Button labels are keyed by `PermissionOptionKind`:
+
+```text
+allow_once    -> Allow
+allow_always  -> Allow Always
+reject_once   -> Reject
+reject_always -> Reject Always
+```
+
+Agent-supplied `option.name` is discarded. Different providers send different
+strings for the same kind; rendering provider text would jitter the layout
+and confuse users switching providers mid-session.
+
+### Cursor placement
+
+On every block-focus transition, `_jump_cursor_to(tool_call_id)`:
+
+1. Resolves the block's `end_row` via its range extmark.
+2. Resolves the first button's start column via
+   `MessageWriter:_get_first_button_col(id)`.
+3. Sets cursor to `(end_row + 1, first_button_col)` and `zz` centers.
+
+Single-pending case: `cycle_next` lands on the same `focused_id`. Instead of
+no-op'ing in `_set_focus` (early return on same id), `_cycle_focus` detects
+this and calls `_jump_cursor_to` directly, so the user can recall the focused
+row even with one pending block.
+
+### Highlight groups
+
+Three HL groups, defined with backgrounds (button-fill look, not text-color):
+
+```text
+AgenticPermissionButtonAllow    bg = #2d5a3d (status_completed_bg), bold
+AgenticPermissionButtonReject   bg = #7a2d2d (status_failed_bg),    bold
+AgenticPermissionButtonInactive bg = #3a3a3a
+```
+
+Greens / reds reuse the existing status-pill palette
+(`COLORS.status_completed_bg` / `COLORS.status_failed_bg`) for visual
+consistency with the `pending` / `completed` / `failed` pills.
+
+Button text is `" 1 ✓ Allow "` (leading + trailing space inside the
+highlighted span). No bracket wrappers — the bg fill alone reads as a button.
+
+### Fold interaction
+
+Row N stays OUTSIDE the manual fold range. `Fold.close_range` is called with
+`(start_row + 2, end_row)` (1-indexed inclusive), which folds 0-indexed
+`top_pad..bottom_pad`. Row N (trailing / status) at 0-indexed `end_row` is
+not in the fold. Buttons always visible regardless of fold state.
+
+No change to ADR 001's manual-fold contract or anchor-pad invariants.
+
+## Consequences
+
+- `MessageWriter:_with_modifiable_and_notify_permission_reanchor`,
+  `set_permission_reanchor_callback`, `_on_permission_reanchor`,
+  `display_permission_buttons`, `remove_permission_buttons`,
+  `_apply_status_footer` deleted. Six call sites migrated to plain
+  `BufHelpers.with_modifiable`.
+- `PermissionManager.queue` (array) + `current_request` (single ref) replaced
+  by `pending` map. `_reanchoring` recursion guard gone.
+- `tracker.permission: PermissionState` is the single source of truth for
+  what row N renders. `MessageWriter:repaint_status_row(id)` rebuilds the
+  line from the tracker; called by both update paths
+  (`update_tool_call_block`, body refresh) and `PermissionManager` state
+  changes.
+- `<CR>` consumed on row N of focused block. Read-only buffer default
+  (next-line) was rarely useful there.
+- Sticky-reading regression on focus jump: user reading farther up the
+  chat gets yanked to row N on every focus transition. Accepted; the
+  alternative (silent focus change) loses the visual anchor.
+- Tall edit-kind diffs may scroll row N offscreen at initial render.
+  `<C-n>` recovers focus + cursor.
+- ADR 001 (manual folds) and ADR 002 (statuscolumn fences) unchanged.
+
+## Rejected / superseded alternatives
+
+| Option                                                              | Reason rejected                                                                                                                            |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Sequential queue at chat bottom (previous behavior)                 | Visual disconnect on multi-block, truncated header, reanchor recursion guard.                                                              |
+| Keep bottom prompt + add inline alongside                           | Two UIs, double bookkeeping, ambiguous focus model.                                                                                        |
+| Click / mouse buttons                                               | Pure keyboard fits Vim; mouse handling adds OS-dependent quirks.                                                                           |
+| Single focus level (block OR button)                                | Block-only loses fast direct dispatch via digits; button-only forces manual scrolling to find the right block.                             |
+| Always-on `h` / `l` buffer-local keymaps                            | Hijacks normal cursor navigation while a permission is pending.                                                                            |
+| Autocmd `CursorMoved` install / uninstall keymaps                   | Complex lifecycle (install/uninstall on every move); `expr=true` fall-through is a one-line equivalent.                                    |
+| Snap cursor back to row N (popup-style)                             | Prevents chat scrolling while a prompt is active.                                                                                          |
+| Render agent-supplied `option.name`                                 | Provider inconsistency (Claude / Gemini / Codex send different text for same kind); layout jitter on provider switch.                      |
+| Bracket wrappers `[ Allow ]`                                        | Visual noise next to bg fill; user feedback during iteration.                                                                              |
+| `link = "DiagnosticOk" / "DiagnosticError" / "Comment"` (fg-only)   | Reads as colored text, not buttons. User asked for bg fill.                                                                                |
+| Light-bg / dark-fg button palette                                   | User chose existing dark green / red palette (`status_completed_bg`, `status_failed_bg`) for plugin-wide consistency.                      |
+| `]p` / `[p` block cycle keys                                        | Both right-hand pinky, two-key sequence, awkward; user requested ergonomic alternatives.                                                   |
+| `]p` / `[p` no-op when target equals current focus (single pending) | Cursor recall use case: user wants `<C-n>` to jump back to row N even with one pending. Fixed by explicit `_jump_cursor_to` in that branch. |
+| Customizable digits / `h` / `l` / `<Left>` / `<Right>` / `<CR>`     | YAGNI; only `cycle_next` / `cycle_prev` are config'd. Per-block keys are conventions.                                                      |
+| Original plan's `Fold.close_range(..., end_row - 1)`                | Off-by-one in plan; existing 1-indexed `end_row` already excludes row N from the fold. Changing would shrink the fold past `bottom_pad`.   |
+| Fold range INCLUDES row N                                           | Buttons hidden when block folded — opposite of the goal.                                                                                   |
+| Sticky cursor (no jump on focus change)                             | Loses visual anchor; user might press a digit thinking the wrong block is focused.                                                         |
+
+## Changelog
+
+| Date       | Commit  | Change                                                                                                                       |
+| ---------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-13 | initial | Initial implementation per `docs/superpowers/inline-permission-buttons.md`. Concurrent map, head-tracking focus, row N text. |
+| 2026-05-13 | -       | Two-level focus added: `h` / `l` / `<CR>` for buttons; digits kept; static label map; bg-only highlights, brackets removed.  |
+| 2026-05-13 | -       | Row-gated `expr=true` keymaps; cursor positions on first button column.                                                      |
+| 2026-05-13 | -       | `<C-n>` / `<C-p>` replace `]p` / `[p`; `Config.keymaps.permission.cycle_next` / `cycle_prev` made configurable.               |

--- a/lua/agentic/acp/AGENTS.md
+++ b/lua/agentic/acp/AGENTS.md
@@ -63,7 +63,7 @@ flowchart TD
     Client[ACPClient<br/>routes notification vs response<br/>__handle_tool_call,<br/>__handle_tool_call_update,<br/>__build_tool_call_message]
     Session[SessionManager<br/>subscriber per session_id<br/>routes by sessionUpdate type<br/>see 'Session update routing']
     Writer[MessageWriter<br/>writes to chat buffer<br/>tracks tool call state]
-    Perm[PermissionManager<br/>queues permission prompts<br/>manages keymaps]
+    Perm[PermissionManager<br/>renders inline buttons on row N<br/>concurrent pending map keyed by tool_call_id]
     History[ChatHistory<br/>accumulates messages<br/>for persistence]
 
     Provider -->|stdio: newline-delimited JSON-RPC| Transport
@@ -230,7 +230,7 @@ determines routing:
 | `"agent_message_chunk"` | `MessageWriter:write_message_chunk()`      |
 | `"agent_thought_chunk"` | `MessageWriter:write_message_chunk()`      |
 | `"plan"`                | `TodoList.render()`                        |
-| `"request_permission"`  | `PermissionManager` (queued, sequential)   |
+| `"request_permission"`  | `PermissionManager` (concurrent map)       |
 | others                  | `subscriber.on_session_update()` (generic) |
 
 ## Tool call lifecycle
@@ -326,22 +326,39 @@ flowchart TD
     P["Provider sends 'session/request_permission'"]
     SM["SessionManager<br/>opens diff preview if request carries a diff"]
     PM["PermissionManager:add_request(request, callback)"]
-    Q["Queue request (sequential, one prompt at a time)"]
-    R["Render permission buttons in chat buffer"]
-    K["Set up buffer-local keymaps (1, 2, 3, 4)"]
-    U["User presses key"]
-    CB["Send result back to provider via callback"]
+    Store["Store in pending[tool_call_id]<br/>append to insertion order"]
+    F{"first pending?"}
+    Focus["_set_focus -> install digit keymaps,<br/>jump cursor, paint focused row N"]
+    Paint["paint non-focused row N (buttons inactive)"]
+    U["User presses 1/2/3/4 (digit)"]
+    Cyc["User presses cycle_next / cycle_prev<br/>(default <C-n> / <C-p>)"]
+    Cycle["_cycle_focus -> repaint old + new row N"]
+    Res["resolve(focused_id, option_id)"]
+    CB["callback(option_id), provider notified"]
     Clear["Clear diff preview"]
-    Next{"more queued?"}
-    Deq["Dequeue + render next"]
+    Next{"more pending?"}
+    Adv["_set_focus(next head)"]
     Done["idle"]
 
-    P --> SM --> PM
-    PM --> Q --> R --> K --> U
-    U --> CB --> Clear --> Next
-    Next -->|yes| Deq --> R
+    P --> SM --> PM --> Store --> F
+    F -->|yes| Focus
+    F -->|no| Paint
+    Focus --> U
+    Paint --> U
+    U --> Res --> CB --> Clear --> Next
+    Next -->|yes| Adv --> U
     Next -->|no| Done
+    Cyc --> Cycle --> U
 ```
+
+Multiple permission requests can be pending concurrently (one per tool call).
+Focus tracks the queue head (oldest pending); new arrivals do not steal focus.
+Digit keys `1`..`4` dispatch the focused block's option;
+`Config.keymaps.permission.cycle_next` / `cycle_prev` (default `<C-n>` /
+`<C-p>`) cycle focus between pending blocks. `h` / `l` / `<Left>` / `<Right>`
+cycle the focused button within the block; `<CR>` submits it. All per-block
+keys fire only when the cursor is on the focused block's row N (off-row keys
+fall through to normal behavior).
 
 ## Protected methods in ACPClient
 

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -62,10 +62,15 @@
 
 --- @alias agentic.UserConfig.KeymapValue string | string[] | (string | agentic.UserConfig.KeymapEntry)[]
 
+--- @class agentic.UserConfig.Keymaps.Permission
+--- @field cycle_next agentic.UserConfig.KeymapValue Focus next pending permission block
+--- @field cycle_prev agentic.UserConfig.KeymapValue Focus previous pending permission block
+
 --- @class agentic.UserConfig.Keymaps
 --- @field widget table<string, agentic.UserConfig.KeymapValue>
 --- @field prompt table<string, agentic.UserConfig.KeymapValue>
 --- @field diff_preview table<string, string>
+--- @field permission agentic.UserConfig.Keymaps.Permission
 
 --- Window options passed to nvim_set_option_value
 --- Overrides default options (wrap, linebreak, winfixheight)
@@ -408,6 +413,11 @@ local ConfigDefault = {
         diff_preview = {
             next_hunk = "]c",
             prev_hunk = "[c",
+        },
+
+        permission = {
+            cycle_next = "<C-n>",
+            cycle_prev = "<C-p>",
         },
     },
 

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -497,10 +497,7 @@ function SessionManager:_on_tool_call_update(tool_call_update)
         end
     end
 
-    if
-        not self.permission_manager.current_request
-        and #self.permission_manager.queue == 0
-    then
+    if not self.permission_manager:has_pending() then
         self.status_animation:start("generating")
     end
 end
@@ -984,10 +981,7 @@ function SessionManager:_build_handlers()
                     is_rejection
                 )
 
-                if
-                    not self.permission_manager.current_request
-                    and #self.permission_manager.queue == 0
-                then
+                if not self.permission_manager:has_pending() then
                     self.status_animation:start("generating")
                 end
             end

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -453,10 +453,10 @@ function SessionManager:_on_tool_call_update(tool_call_update)
     local is_rejection = tool_call_update.status == "failed"
     self:_clear_diff_in_buffer(tool_call_update.tool_call_id, is_rejection)
 
-    -- Remove the permission request when the tool call reaches a terminal
-    -- status. `failed` covers user rejection or agent-side error; `completed`
-    -- covers cases where the agent finishes the tool without (or alongside)
-    -- user resolution. Both should clear the inline buttons.
+    -- Remove the permission request when the tool call reaches a terminal status.
+    -- `failed` covers user rejection or agent-side error;
+    -- `completed` covers cases where the agent finishes the tool without (or alongside) user resolution.
+    -- Both should clear the inline buttons.
     if
         tool_call_update.status == "failed"
         or tool_call_update.status == "completed"

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -453,8 +453,14 @@ function SessionManager:_on_tool_call_update(tool_call_update)
     local is_rejection = tool_call_update.status == "failed"
     self:_clear_diff_in_buffer(tool_call_update.tool_call_id, is_rejection)
 
-    -- Remove the permission request if the tool call failed before user granted it
-    if tool_call_update.status == "failed" then
+    -- Remove the permission request when the tool call reaches a terminal
+    -- status. `failed` covers user rejection or agent-side error; `completed`
+    -- covers cases where the agent finishes the tool without (or alongside)
+    -- user resolution. Both should clear the inline buttons.
+    if
+        tool_call_update.status == "failed"
+        or tool_call_update.status == "completed"
+    then
         self.permission_manager:remove_request_by_tool_call_id(
             tool_call_update.tool_call_id
         )

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -850,6 +850,58 @@ describe("agentic.SessionManager", function()
             end
         end)
 
+        it(
+            "removes pending permission on failed and completed tool-call updates",
+            function()
+                for _, status in ipairs({ "failed", "completed" }) do
+                    local remove_calls = {}
+                    local session = make_session({
+                        ["tc-" .. status] = {
+                            kind = "edit",
+                            status = "in_progress",
+                        },
+                    })
+                    session.permission_manager.remove_request_by_tool_call_id = function(
+                        _self,
+                        id
+                    )
+                        table.insert(remove_calls, id)
+                    end
+
+                    SessionManager._on_tool_call_update(session, {
+                        tool_call_id = "tc-" .. status,
+                        status = status,
+                    })
+
+                    assert.equal(1, #remove_calls)
+                    assert.equal("tc-" .. status, remove_calls[1])
+                end
+            end
+        )
+
+        it(
+            "does not remove pending permission on non-terminal updates",
+            function()
+                local remove_calls = {}
+                local session = make_session({
+                    ["tc-prog"] = { kind = "edit", status = "pending" },
+                })
+                session.permission_manager.remove_request_by_tool_call_id = function(
+                    _self,
+                    id
+                )
+                    table.insert(remove_calls, id)
+                end
+
+                SessionManager._on_tool_call_update(session, {
+                    tool_call_id = "tc-prog",
+                    status = "in_progress",
+                })
+
+                assert.equal(0, #remove_calls)
+            end
+        )
+
         it("does not call checktime for failed tool calls", function()
             local session = make_session({
                 ["tc-1"] = { kind = "edit", status = "in_progress" },

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -793,8 +793,10 @@ describe("agentic.SessionManager", function()
                     tool_call_blocks = tool_call_blocks,
                 },
                 permission_manager = {
-                    current_request = nil,
-                    queue = {},
+                    pending = {},
+                    has_pending = function()
+                        return false
+                    end,
                     remove_request_by_tool_call_id = function() end,
                 },
                 status_animation = { start = function() end },

--- a/lua/agentic/theme.lua
+++ b/lua/agentic/theme.lua
@@ -16,6 +16,10 @@ Theme.HL_GROUPS = {
     CODE_BLOCK_FENCE = "AgenticCodeBlockFence",
     WIN_BAR_TITLE = "AgenticTitle",
 
+    PERMISSION_BUTTON_ALLOW = "AgenticPermissionButtonAllow",
+    PERMISSION_BUTTON_REJECT = "AgenticPermissionButtonReject",
+    PERMISSION_BUTTON_INACTIVE = "AgenticPermissionButtonInactive",
+
     SPINNER_GENERATING = "AgenticSpinnerGenerating",
     SPINNER_THINKING = "AgenticSpinnerThinking",
     SPINNER_SEARCHING = "AgenticSpinnerSearching",
@@ -29,6 +33,7 @@ local COLORS = {
     status_pending_bg = "#5f4d8f",
     status_completed_bg = "#2d5a3d",
     status_failed_bg = "#7a2d2d",
+    permission_button_inactive_bg = "#3a3a3a",
 
     title_bg = "#2787b0",
     title_fg = "#000000",
@@ -82,6 +87,11 @@ function Theme.setup()
         { Theme.HL_GROUPS.STATUS_COMPLETED, { bg = COLORS.status_completed_bg } },
         { Theme.HL_GROUPS.STATUS_FAILED, { bg = COLORS.status_failed_bg } },
         { Theme.HL_GROUPS.CODE_BLOCK_FENCE, { link = "Directory" } },
+
+        -- Permission button highlights (bg-based, button-like fill)
+        { Theme.HL_GROUPS.PERMISSION_BUTTON_ALLOW, { bg = COLORS.status_completed_bg, bold = true } },
+        { Theme.HL_GROUPS.PERMISSION_BUTTON_REJECT, { bg = COLORS.status_failed_bg, bold = true } },
+        { Theme.HL_GROUPS.PERMISSION_BUTTON_INACTIVE, { bg = COLORS.permission_button_inactive_bg } },
 
         -- Title highlight
         { Theme.HL_GROUPS.WIN_BAR_TITLE, { bg = COLORS.title_bg, fg = COLORS.title_fg, bold = true } },

--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -118,6 +118,9 @@ or in the linked ADR — failures are not inlined here to avoid duplication.
     than `Config.auto_scroll.threshold` lines from the bottom. This is
     intentional sticky-reading behavior, not a bug — the user stopped following
     the stream and we preserve their position.
+  - `_check_auto_scroll` also returns false when the cursor row has
+    permission-button extmarks in `NS_STATUS`. This avoids a
+    `PermissionManager` back-reference in `MessageWriter`.
 - Tool-call body updates replace only the body between stable anchor pads; the
   whole block range is never replaced.
 - Manual folds only. Never `foldexpr`. Before proposing a `foldexpr` workaround
@@ -254,7 +257,7 @@ change.
   `permission_manager.test.lua::concurrent pending map::*`.
 - Sender header dedup on consecutive same-sender writes —
   `message_writer.test.lua::sender header tracking`.
-- Auto-scroll threshold preserves user reading position —
+- Auto-scroll threshold preserves reading position and permission-row cursor —
   `message_writer.test.lua::_check_auto_scroll`.
 - Thinking-state cleared on non-thought writes —
   `message_writer.test.lua::thinking block highlighting::"clears thinking state on reset_sender_tracking, write_tool_call_block, and write_message"`.

--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -29,8 +29,9 @@ SessionManager (per tab)
         ├── DiffHighlighter     line/word hl on chat buffer
         │                       (lives in agentic.utils, not ui)
         ├── ToolBlockBorder     ╭ │ ╰ fence glyphs via statuscolumn — ADR 002
-        └── PermissionManager   renders inline button strip on row N of pending
-                                blocks; rebinds digit keymaps on focus transition
+        └── PermissionManager   pending map + focus state; rebinds per-block
+                                keymaps on focus transition. Row N rendering
+                                owned by MessageWriter (repaint_status_row)
 ```
 
 ## Lifecycle

--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -29,7 +29,8 @@ SessionManager (per tab)
         ├── DiffHighlighter     line/word hl on chat buffer
         │                       (lives in agentic.utils, not ui)
         ├── ToolBlockBorder     ╭ │ ╰ fence glyphs via statuscolumn — ADR 002
-        └── PermissionManager   queues + reanchors permission prompts
+        └── PermissionManager   renders inline button strip on row N of pending
+                                blocks; rebinds digit keymaps on focus transition
 ```
 
 ## Lifecycle
@@ -122,8 +123,11 @@ or in the linked ADR — failures are not inlined here to avoid duplication.
   (self-assign cache invalidation, `BufEnter` reapply, etc.), read the
   rejected-alternatives table in ADR 001 — every obvious workaround has been
   tried and documented.
-- Permission prompts reanchor after every chat mutation and reuse the existing
-  trailing `""` as separator.
+- Permission buttons live on row N (status line) of each pending block; row N
+  is outside the fold range, and digit keymaps are bound only while a block is
+  focused. Buttons are rendered as real text via
+  `MessageWriter:_render_status_row`; status word + button labels are
+  highlighted via extmark column ranges in `NS_STATUS`.
 - Foreign buffers in widget windows are redirected via `BufferGuard`
   (`lua/agentic/ui/buffer_guard.lua`) to a non-widget window in the same
   tabpage.
@@ -141,7 +145,8 @@ row 0    header           rewritten on every update, NOT folded
 row 1    "" top_pad       fold start anchor
 row 2..  body             replaced on every update
 row N-1  "" bottom_pad    fold end anchor
-row N    "" trailing      footer, status virt_text
+row N    status + buttons real text, outside fold, written by
+                          MessageWriter:_render_status_row
 ```
 
 Pads are unconditional. Header is rewritten unconditionally because providers
@@ -192,10 +197,6 @@ Special write paths bypass `_maybe_write_sender_header`'s normal flow:
     `WidgetLayout.close`, check
     `nvim_tabpage_is_valid(nvim_win_get_tabpage(winid))` per window before
     `nvim_win_close` — not just once at the start of the loop.
-- Adding a blank line before a reanchored prompt
-  - The reanchor leaves a trailing `""`; the next display reuses it.
-    `MessageWriter:display_permission_buttons` owns the detection — skip the
-    check there and reanchor cycles produce double blanks.
 - `vim.notify` directly
   - Fast-context errors. Use `Logger.notify`.
 - Module-level mutable state for per-tab data
@@ -216,36 +217,13 @@ Special write paths bypass `_maybe_write_sender_header`'s normal flow:
   - `vim.t` returns copies; nested edits do not persist. Read via
     `WindowDecoration.get_headers_state`, mutate, write back via
     `set_headers_state`.
-- Mutating chat content without
-  `_with_modifiable_and_notify_permission_reanchor`
-  - Skips `_notify_permission_reanchor`; permission prompts stop reanchoring.
-  - For non-chat buffers (input, diagnostics, etc.) `BufHelpers.with_modifiable`
-    is correct — those buffers have no permission-reanchor contract. Use the
-    wrapper only when mutating `self.bufnr` (the chat buffer).
-  - Exception: `display_permission_buttons` / `remove_permission_buttons` are
-    the reanchor write path itself and use `BufHelpers.with_modifiable` directly
-    under the `PermissionManager._reanchoring` guard.
-  - `PermissionManager._reanchoring` is the recursion guard for the reanchor
-    write path itself: it is set true around `_reanchor_permission_prompt`'s own
-    `set_lines` so the post-mutation callback no-ops instead of re-entering.
-    Removing the flag re-enters and stack-overflows.
-
-    ```mermaid
-    sequenceDiagram
-        participant Caller
-        participant PM as PermissionManager
-        participant Buf as chat buffer
-        participant CB as post-mutation cb
-
-        Caller->>PM: _reanchor_permission_prompt()
-        PM->>PM: _reanchoring = true
-        PM->>Buf: set_lines (move buttons)
-        Buf-->>CB: fires post-mutation hook
-        CB->>PM: check _reanchoring
-        Note over CB,PM: true -> no-op<br/>(without flag: re-enters,<br/>stack overflow)
-        PM->>PM: _reanchoring = false
-        PM-->>Caller: done
-    ```
+- Overwriting row N while a permission request is pending
+  - `MessageWriter:update_tool_call_block` ends up calling
+    `repaint_status_row(tracker.tool_call_id)`. The repaint reads
+    `tracker.permission` (the state stored by `PermissionManager`), so updates
+    that arrive while buttons are visible re-render the buttons rather than
+    wipe them. If you bypass `repaint_status_row` and write to row N directly,
+    buttons disappear until the next focus event triggers a repaint.
 
 ## Test invariants
 
@@ -258,10 +236,21 @@ change.
   `tool_call_fold.test.lua::should_fold::"folds when screen-row count exceeds threshold"`.
 - Fold counts wrapped rows, not buffer lines (one mega-line still folds) —
   `tool_call_fold.test.lua::should_fold::"folds a single buffer line that wraps past the threshold"`.
-- Permission reanchor preserves keymaps + button position —
-  `permission_manager.test.lua::reanchor permission prompt::"moves buttons to buffer bottom and preserves keymaps"`.
-- Permission reanchor does not double-blank across cycles —
-  `permission_manager.test.lua::empty line accumulation during reanchor`.
+- Row N is real text rendered per state —
+  `message_writer.test.lua::status row::"writes the status word as real text at row N for non-pending blocks"`,
+  `..::"renders inline buttons for pending non-focused permission state"`,
+  `..::"renders inline buttons with digit prefixes when focused"`.
+- Focus transition triggers exactly 2 status-row repaints (old + new) —
+  `permission_manager.test.lua::bracket cycle::"focus transition triggers exactly 2 status-row repaints"`.
+- Digit keymap dispatches the focused block's option —
+  `permission_manager.test.lua::digit keymap lifecycle::"digit 1 resolves the focused block's option 1"`,
+  `..::"rebinds digit keymaps with new mapping after focus transition"`.
+- Bracket cycle wraps and no-ops when pending is empty —
+  `permission_manager.test.lua::bracket cycle::"forward cycle wraps to first"`,
+  `..::"backward cycle wraps to last"`,
+  `..::"cycle is a no-op when pending is empty"`.
+- Concurrent map preserves insertion order and supports out-of-order resolve —
+  `permission_manager.test.lua::concurrent pending map::*`.
 - Sender header dedup on consecutive same-sender writes —
   `message_writer.test.lua::sender header tracking`.
 - Auto-scroll threshold preserves user reading position —

--- a/lua/agentic/ui/file_picker.lua
+++ b/lua/agentic/ui/file_picker.lua
@@ -231,6 +231,7 @@ FilePicker.GLOB_EXCLUDE_PATTERNS = {
     "^%.%.$",
     "%.git/",
     "^%.git$", -- Exclude .git (both directory and file used in worktrees)
+    "%.worktrees/",
     "%.DS_Store$",
     "node_modules/",
     "%.pyc$",

--- a/lua/agentic/ui/file_picker.test.lua
+++ b/lua/agentic/ui/file_picker.test.lua
@@ -169,6 +169,8 @@ describe("FilePicker:scan_files", function()
                 FilePicker.GLOB_EXCLUDE_PATTERNS,
                 "settings%.local%.json"
             )
+            -- Local headless Neovim runs can create nvim.log after rg scanned.
+            table.insert(FilePicker.GLOB_EXCLUDE_PATTERNS, "nvim%.log$")
             -- .opencode/.gitignore ignores specific files (bun.lock, package.json, etc.)
             -- rg/fd/git respect nested .gitignore but glob fallback doesn't
             table.insert(FilePicker.GLOB_EXCLUDE_PATTERNS, "%.opencode/bun")

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -2,19 +2,25 @@ local ToolCallDiff = require("agentic.ui.tool_call_diff")
 local BufHelpers = require("agentic.utils.buf_helpers")
 local Config = require("agentic.config")
 local DiffHighlighter = require("agentic.utils.diff_highlighter")
-local DiffPreview = require("agentic.ui.diff_preview")
 local Fold = require("agentic.ui.tool_call_fold")
 local JsonFormat = require("agentic.utils.json_format")
 local Logger = require("agentic.utils.logger")
 local Theme = require("agentic.theme")
 
 local NS_TOOL_BLOCKS = vim.api.nvim_create_namespace("agentic_tool_blocks")
-local NS_PERMISSION_BUTTONS =
-    vim.api.nvim_create_namespace("agentic_permission_buttons")
 local NS_DIFF_HIGHLIGHTS =
     vim.api.nvim_create_namespace("agentic_diff_highlights")
 local NS_STATUS = vim.api.nvim_create_namespace("agentic_status_footer")
 local NS_THINKING = vim.api.nvim_create_namespace("agentic_thinking")
+
+-- Static label map keyed by PermissionOptionKind. Agent-supplied option.name
+-- is intentionally discarded.
+local PERMISSION_OPTION_LABELS = {
+    allow_once = "Allow",
+    allow_always = "Allow Always",
+    reject_once = "Reject",
+    reject_always = "Reject Always",
+}
 
 --- @class agentic.ui.MessageWriter.HighlightRange
 --- @field type "comment"|"old"|"new"|"new_modification" Type of highlight to apply
@@ -27,6 +33,11 @@ local NS_THINKING = vim.api.nvim_create_namespace("agentic_thinking")
 --- @field old string[]
 --- @field all? boolean TODO: check if it's still necessary to replace all occurrences or the agents send multiple requests
 
+--- @class agentic.ui.MessageWriter.PermissionState
+--- @field sorted_options agentic.acp.PermissionOption[] Options sorted by priority
+--- @field is_focused boolean Whether the block is the currently focused permission target
+--- @field focused_button_index? integer 1-indexed; which button inside the focused block is highlighted (h / l selection). Nil = no button focus (block not focused).
+
 --- @class agentic.ui.MessageWriter.ToolCallBlock
 --- @field tool_call_id string
 --- @field kind? agentic.acp.ToolKind
@@ -37,6 +48,7 @@ local NS_THINKING = vim.api.nvim_create_namespace("agentic_thinking")
 --- @field body? string[]
 --- @field diff? agentic.ui.MessageWriter.ToolCallDiff
 --- @field has_fold? boolean
+--- @field permission? agentic.ui.MessageWriter.PermissionState
 
 --- @class agentic.ui.MessageWriter
 --- @field bufnr integer
@@ -44,7 +56,6 @@ local NS_THINKING = vim.api.nvim_create_namespace("agentic_thinking")
 --- @field _last_message_type? string
 --- @field _should_auto_scroll? boolean
 --- @field _scroll_scheduled boolean
---- @field _on_permission_reanchor? fun()
 --- @field _last_sender? "user"|"agent"
 --- @field _provider_name? string
 --- @field _is_restoring boolean
@@ -71,11 +82,6 @@ function MessageWriter:new(bufnr)
     }, self)
 
     return self
-end
-
---- @param callback fun()|nil
-function MessageWriter:set_permission_reanchor_callback(callback)
-    self._on_permission_reanchor = callback
 end
 
 --- @param name string
@@ -106,23 +112,6 @@ function MessageWriter:write_structural_message(update)
     self._last_sender = "user"
     self:write_message(update)
     self._last_sender = saved
-end
-
-function MessageWriter:_notify_permission_reanchor()
-    if self._on_permission_reanchor then
-        self._on_permission_reanchor()
-    end
-end
-
---- Wraps BufHelpers.with_modifiable and fires _notify_permission_reanchor after.
---- The callback may return false to suppress the notification (e.g. on early-return without edits).
---- with_modifiable returns false for invalid buffers, which also suppresses notification.
---- @param fn fun(bufnr: integer): boolean|nil
-function MessageWriter:_with_modifiable_and_notify_permission_reanchor(fn)
-    local result = BufHelpers.with_modifiable(self.bufnr, fn)
-    if result ~= false then
-        self:_notify_permission_reanchor()
-    end
 end
 
 --- @type table<string, "user"|"agent">
@@ -166,7 +155,7 @@ function MessageWriter:_maybe_write_sender_header(session_update_type)
         header = string.format("### %s Agent - %s", icon, name)
     end
 
-    self:_with_modifiable_and_notify_permission_reanchor(function()
+    BufHelpers.with_modifiable(self.bufnr, function()
         self:_append_lines({ "", header, "" })
     end)
 
@@ -198,7 +187,7 @@ function MessageWriter:write_message(update)
 
     local lines = vim.split(text, "\n", { plain = true })
 
-    self:_with_modifiable_and_notify_permission_reanchor(function()
+    BufHelpers.with_modifiable(self.bufnr, function()
         self:_append_lines(lines)
         self:_append_lines({ "" })
     end)
@@ -260,7 +249,7 @@ function MessageWriter:write_message_chunk(update)
 
     self._last_message_type = update.sessionUpdate
 
-    self:_with_modifiable_and_notify_permission_reanchor(function(bufnr)
+    BufHelpers.with_modifiable(self.bufnr, function(bufnr)
         local last_line = vim.api.nvim_buf_line_count(bufnr) - 1
 
         -- Capture start line before writing for new thinking blocks
@@ -400,7 +389,7 @@ function MessageWriter:write_tool_call_block(tool_call_block)
     self:_capture_scroll(self.bufnr)
     self:_maybe_write_sender_header("tool_call")
 
-    self:_with_modifiable_and_notify_permission_reanchor(function(bufnr)
+    BufHelpers.with_modifiable(self.bufnr, function(bufnr)
         local kind = tool_call_block.kind
 
         -- Always add a leading blank line for spacing the previous message chunk
@@ -432,7 +421,7 @@ function MessageWriter:write_tool_call_block(tool_call_block)
         self.tool_call_blocks[tool_call_block.tool_call_id] = tool_call_block
 
         self:_apply_header_highlight(start_row, tool_call_block.status)
-        self:_apply_status_footer(end_row, tool_call_block.status)
+        self:repaint_status_row(tool_call_block.tool_call_id)
 
         local body_start = start_row + 2
         local body_end = end_row - 2
@@ -520,7 +509,7 @@ function MessageWriter:update_tool_call_block(tool_call_block)
         return
     end
 
-    self:_with_modifiable_and_notify_permission_reanchor(function(bufnr)
+    BufHelpers.with_modifiable(self.bufnr, function(bufnr)
         vim.api.nvim_buf_set_lines(
             bufnr,
             start_row,
@@ -541,11 +530,7 @@ function MessageWriter:update_tool_call_block(tool_call_block)
             end
 
             self:_clear_status_namespace(start_row, old_end_row)
-            self:_apply_status_highlights_if_present(
-                start_row,
-                old_end_row,
-                tracker.status
-            )
+            self:_apply_status_highlights_if_present(start_row, tracker)
 
             return false
         end
@@ -587,11 +572,7 @@ function MessageWriter:update_tool_call_block(tool_call_block)
             right_gravity = false,
         })
 
-        self:_apply_status_highlights_if_present(
-            start_row,
-            new_end_row,
-            tracker.status
-        )
+        self:_apply_status_highlights_if_present(start_row, tracker)
 
         if
             not tracker.has_fold
@@ -756,155 +737,78 @@ function MessageWriter:_prepare_block_lines(tool_call_block)
     return lines, highlight_ranges
 end
 
---- Display permission request buttons at the end of the buffer
+--- Set or clear the permission state for a tool call block.
 --- @param tool_call_id string
---- @param options agentic.acp.PermissionOption[]
---- @return integer button_start_row Start row of button block
---- @return integer button_end_row End row of button block
---- @return table<integer, string> option_mapping Mapping from number (1-N) to option_id
-function MessageWriter:display_permission_buttons(tool_call_id, options)
-    local option_mapping = {}
-
-    local lines_to_append = {
-        "### Waiting for your response: ",
-        "",
-    }
-
+--- @param state agentic.ui.MessageWriter.PermissionState|nil nil to clear
+function MessageWriter:set_permission_state(tool_call_id, state)
     local tracker = self.tool_call_blocks[tool_call_id]
-
-    if tracker then
-        -- Sanitize argument to prevent newlines in the permission request, neovim throws error
-        local sanitized_argument = tracker.argument:gsub("\n", "\\n")
-
-        -- Get buffer width and limit the display line
-        local winid = vim.fn.bufwinid(self.bufnr)
-
-        local buf_width = 80 -- default fallback width, in case buf is not visible
-        if winid ~= -1 then
-            buf_width = vim.api.nvim_win_get_width(winid)
-        end
-
-        local tool_line =
-            string.format(" %s(%s)", tracker.kind, sanitized_argument)
-
-        -- Truncate if longer than buffer width, leaving space for "...)"
-        if #tool_line > buf_width then
-            tool_line = tool_line:sub(1, buf_width - 4) .. "...)"
-        end
-
-        vim.list_extend(lines_to_append, {
-            tool_line,
-            "", -- Blank line prevents markdown inline markers from spanning to next content
-        })
+    if not tracker then
+        return
     end
-
-    for i, option in ipairs(options) do
-        table.insert(
-            lines_to_append,
-            string.format(
-                "%d. %s %s",
-                i,
-                Config.permission_icons[option.kind] or "",
-                option.name
-            )
-        )
-        option_mapping[i] = option.optionId
-    end
-
-    table.insert(lines_to_append, "--- ---")
-
-    local hint_line_index =
-        DiffPreview.add_navigation_hint(tracker, lines_to_append)
-
-    table.insert(lines_to_append, "")
-
-    -- Ensure exactly one empty separator line before the permission block.
-    -- During reanchor, remove_permission_buttons leaves a trailing empty
-    -- line — reuse it instead of adding another one.
-    local line_count = vim.api.nvim_buf_line_count(self.bufnr)
-    local last_line = vim.api.nvim_buf_get_lines(
-        self.bufnr,
-        line_count - 1,
-        line_count,
-        false
-    )[1]
-
-    if last_line == "" then
-        -- Buffer already ends with an empty line (left by
-        -- remove_permission_buttons during reanchor). Reuse it as
-        -- separator — include it in the block range so it gets
-        -- cleaned up, but don't add another one.
-        line_count = line_count - 1
-    else
-        -- No trailing empty line — prepend one as separator
-        table.insert(lines_to_append, 1, "")
-    end
-
-    -- The separator line shifts hint position by 1 in both cases:
-    -- existing empty line included in block range, or prepended empty line.
-    if hint_line_index then
-        hint_line_index = hint_line_index + 1
-    end
-
-    local button_start_row = line_count
-
-    self:_capture_scroll(self.bufnr)
-
-    BufHelpers.with_modifiable(self.bufnr, function()
-        self:_append_lines(lines_to_append)
-    end)
-
-    self:_apply_scroll(self.bufnr)
-
-    local button_end_row = vim.api.nvim_buf_line_count(self.bufnr) - 1
-
-    if hint_line_index then
-        DiffPreview.apply_hint_styling(
-            self.bufnr,
-            NS_PERMISSION_BUTTONS,
-            button_start_row,
-            hint_line_index
-        )
-    end
-
-    -- Create extmark to track button block
-    vim.api.nvim_buf_set_extmark(
-        self.bufnr,
-        NS_PERMISSION_BUTTONS,
-        button_start_row,
-        0,
-        {
-            end_row = button_end_row,
-            right_gravity = false,
-        }
-    )
-
-    return button_start_row, button_end_row, option_mapping
+    tracker.permission = state
 end
 
---- @param start_row integer Start row of button block
---- @param end_row integer End row of button block
-function MessageWriter:remove_permission_buttons(start_row, end_row)
-    pcall(
-        vim.api.nvim_buf_clear_namespace,
-        self.bufnr,
-        NS_PERMISSION_BUTTONS,
-        start_row,
-        end_row + 1
-    )
+--- @param tool_call_id string
+--- @return integer|nil index 1-indexed focused button or nil when no permission state
+function MessageWriter:get_focused_button_index(tool_call_id)
+    local tracker = self.tool_call_blocks[tool_call_id]
+    if not tracker or not tracker.permission then
+        return nil
+    end
+    return tracker.permission.focused_button_index
+end
 
-    BufHelpers.with_modifiable(self.bufnr, function(bufnr)
-        pcall(
-            vim.api.nvim_buf_set_lines,
-            bufnr,
-            start_row,
-            end_row + 1,
-            false,
-            {
-                "", -- a leading as separator from previous content
-            }
-        )
-    end)
+--- @param tool_call_id string
+--- @return integer|nil col 0-indexed start column of the first permission button, or nil
+function MessageWriter:_get_first_button_col(tool_call_id)
+    local tracker = self.tool_call_blocks[tool_call_id]
+    if not tracker or not tracker.permission then
+        return nil
+    end
+    local _, segments = self:_build_status_row(tracker)
+    -- segments[1] is the status word; segments[2] is the first button.
+    if not segments[2] then
+        return nil
+    end
+    return segments[2][1]
+end
+
+--- Recompute and write the status row (row N) for the given tool call block.
+--- Used by both the writer itself (initial render / updates) and the
+--- PermissionManager when toggling buttons / focus.
+--- @param tool_call_id string
+function MessageWriter:repaint_status_row(tool_call_id)
+    local tracker = self.tool_call_blocks[tool_call_id]
+    if not tracker then
+        return
+    end
+    local end_row = self:_get_block_end_row(tool_call_id)
+    if not end_row then
+        return
+    end
+    local text, hl_segments = self:_build_status_row(tracker)
+    self:_render_status_row(end_row, text, hl_segments)
+end
+
+--- Return the 0-indexed last row of the block, or nil when no block tracker
+--- or extmark is found.
+--- @param tool_call_id string
+--- @return integer|nil end_row
+function MessageWriter:_get_block_end_row(tool_call_id)
+    local tracker = self.tool_call_blocks[tool_call_id]
+    if not tracker or not tracker.extmark_id then
+        return nil
+    end
+    local pos = vim.api.nvim_buf_get_extmark_by_id(
+        self.bufnr,
+        NS_TOOL_BLOCKS,
+        tracker.extmark_id,
+        { details = true }
+    )
+    if not pos or not pos[1] then
+        return nil
+    end
+    return pos[3] and pos[3].end_row
 end
 
 --- Replay saved chat history messages into the buffer.
@@ -937,7 +841,7 @@ function MessageWriter:replay_history_messages(messages)
             local lines = vim.split(text, "\n", { plain = true })
             local start_line
 
-            self:_with_modifiable_and_notify_permission_reanchor(function(bufnr)
+            BufHelpers.with_modifiable(self.bufnr, function(bufnr)
                 start_line = vim.api.nvim_buf_line_count(bufnr)
                 self:_append_lines(lines)
                 self:_append_lines({ "" })
@@ -1078,28 +982,96 @@ function MessageWriter:_apply_header_highlight(header_line, status)
     })
 end
 
---- @param footer_line integer 0-indexed footer line number
---- @param status string Status value (pending, completed, etc.)
-function MessageWriter:_apply_status_footer(footer_line, status)
-    if
-        not vim.api.nvim_buf_is_valid(self.bufnr)
-        or not status
-        or status == ""
-    then
-        return
+--- @class agentic.ui.MessageWriter.StatusSegment
+--- @field [1] integer start_col 0-indexed inclusive
+--- @field [2] integer end_col 0-indexed exclusive
+--- @field [3] string hl_group
+
+--- Build the text + highlight segments for the status row (row N) of a block.
+--- Pending blocks with an attached PermissionState include inline buttons.
+--- @param tracker agentic.ui.MessageWriter.ToolCallBlock
+--- @return string text
+--- @return agentic.ui.MessageWriter.StatusSegment[] segments
+function MessageWriter:_build_status_row(tracker)
+    local status = tracker.status
+    if not status or status == "" then
+        return "", {}
     end
 
     local icons = Config.status_icons or {}
-
     local icon = icons[status] or ""
-    local hl_group = Theme.get_status_hl_group(status)
+    local status_label = icon ~= "" and (icon .. " " .. status) or status
 
-    vim.api.nvim_buf_set_extmark(self.bufnr, NS_STATUS, footer_line, 0, {
-        virt_text = {
-            { string.format(" %s %s ", icon, status), hl_group },
-        },
-        virt_text_pos = "overlay",
-    })
+    local text = " " .. status_label
+    --- @type agentic.ui.MessageWriter.StatusSegment[]
+    local segments = {
+        { 1, #text, Theme.get_status_hl_group(status) },
+    }
+
+    local perm = tracker.permission
+    if status ~= "pending" or not perm then
+        return text, segments
+    end
+
+    local permission_icons = Config.permission_icons or {}
+    local focused_btn = perm.focused_button_index
+    for i, option in ipairs(perm.sorted_options) do
+        local label = PERMISSION_OPTION_LABELS[option.kind] or option.kind
+        local btn_icon = permission_icons[option.kind] or ""
+        local body
+        if perm.is_focused then
+            body = string.format("%d %s %s", i, btn_icon, label)
+        else
+            body = string.format("%s %s", btn_icon, label)
+        end
+        -- No brackets: the bg highlight on the padded span is the button.
+        local btn = " " .. body .. " "
+
+        text = text .. "  "
+        local start_col = #text
+        text = text .. btn
+        local end_col = #text
+
+        local is_button_focused = perm.is_focused and i == focused_btn
+        local hl_group
+        if not is_button_focused then
+            hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_INACTIVE
+        elseif option.kind == "allow_once" or option.kind == "allow_always" then
+            hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_ALLOW
+        else
+            hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_REJECT
+        end
+        table.insert(segments, { start_col, end_col, hl_group })
+    end
+
+    return text, segments
+end
+
+--- Write text and apply highlight segments at the given row in NS_STATUS.
+--- @param row integer 0-indexed row
+--- @param text string
+--- @param hl_segments agentic.ui.MessageWriter.StatusSegment[]
+function MessageWriter:_render_status_row(row, text, hl_segments)
+    if not vim.api.nvim_buf_is_valid(self.bufnr) then
+        return
+    end
+
+    BufHelpers.with_modifiable(self.bufnr, function(bufnr)
+        local line_count = vim.api.nvim_buf_line_count(bufnr)
+        if row >= line_count then
+            return false
+        end
+        pcall(vim.api.nvim_buf_set_lines, bufnr, row, row + 1, false, { text })
+    end)
+
+    pcall(vim.api.nvim_buf_clear_namespace, self.bufnr, NS_STATUS, row, row + 1)
+
+    for _, seg in ipairs(hl_segments) do
+        vim.api.nvim_buf_set_extmark(self.bufnr, NS_STATUS, row, seg[1], {
+            end_col = seg[2],
+            hl_group = seg[3],
+        })
+    end
 end
 
 --- Sets or updates a thinking highlight extmark over the given line range.
@@ -1143,16 +1115,11 @@ function MessageWriter:_clear_status_namespace(start_row, end_row)
 end
 
 --- @param start_row integer
---- @param end_row integer
---- @param status string|nil
-function MessageWriter:_apply_status_highlights_if_present(
-    start_row,
-    end_row,
-    status
-)
-    if status then
-        self:_apply_header_highlight(start_row, status)
-        self:_apply_status_footer(end_row, status)
+--- @param tracker agentic.ui.MessageWriter.ToolCallBlock
+function MessageWriter:_apply_status_highlights_if_present(start_row, tracker)
+    if tracker.status then
+        self:_apply_header_highlight(start_row, tracker.status)
+        self:repaint_status_row(tracker.tool_call_id)
     end
 end
 

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -13,8 +13,8 @@ local NS_DIFF_HIGHLIGHTS =
 local NS_STATUS = vim.api.nvim_create_namespace("agentic_status_footer")
 local NS_THINKING = vim.api.nvim_create_namespace("agentic_thinking")
 
--- Static label map keyed by PermissionOptionKind. Agent-supplied option.name
--- is intentionally discarded.
+-- Static label map keyed by PermissionOptionKind
+-- Agent-supplied option.name is intentionally discarded
 local PERMISSION_OPTION_LABELS = {
     allow_once = "Allow",
     allow_always = "Allow Always",
@@ -759,18 +759,22 @@ function MessageWriter:get_focused_button_index(tool_call_id)
 end
 
 --- @param tool_call_id string
---- @return integer|nil col 0-indexed start column of the first permission button, or nil
-function MessageWriter:_get_first_button_col(tool_call_id)
+--- @param index integer 1-indexed button position
+--- @return integer|nil col 0-indexed start column of the Nth permission button, or nil
+function MessageWriter:get_button_col(tool_call_id, index)
     local tracker = self.tool_call_blocks[tool_call_id]
     if not tracker or not tracker.permission then
         return nil
     end
+
     local _, segments = self:_build_status_row(tracker)
-    -- segments[1] is the status word; segments[2] is the first button.
-    if not segments[2] then
+    -- segments[1] is the status word; segments[1 + i] is the i-th button.
+    local seg = segments[1 + index]
+    if not seg then
         return nil
     end
-    return segments[2][1]
+
+    return seg[1]
 end
 
 --- Recompute and write the status row (row N) for the given tool call block.
@@ -779,13 +783,17 @@ end
 --- @param tool_call_id string
 function MessageWriter:repaint_status_row(tool_call_id)
     local tracker = self.tool_call_blocks[tool_call_id]
+
     if not tracker then
         return
     end
-    local end_row = self:_get_block_end_row(tool_call_id)
+
+    local end_row = self:get_block_end_row(tool_call_id)
+
     if not end_row then
         return
     end
+
     local text, hl_segments = self:_build_status_row(tracker)
     self:_render_status_row(end_row, text, hl_segments)
 end
@@ -796,34 +804,41 @@ end
 --- @return integer|nil start_row
 function MessageWriter:_get_block_start_row(tool_call_id)
     local tracker = self.tool_call_blocks[tool_call_id]
+
     if not tracker or not tracker.extmark_id then
         return nil
     end
+
     local pos = vim.api.nvim_buf_get_extmark_by_id(
         self.bufnr,
         NS_TOOL_BLOCKS,
         tracker.extmark_id,
         {}
     )
+
     return pos and pos[1]
 end
 
 --- @param tool_call_id string
 --- @return integer|nil end_row
-function MessageWriter:_get_block_end_row(tool_call_id)
+function MessageWriter:get_block_end_row(tool_call_id)
     local tracker = self.tool_call_blocks[tool_call_id]
+
     if not tracker or not tracker.extmark_id then
         return nil
     end
+
     local pos = vim.api.nvim_buf_get_extmark_by_id(
         self.bufnr,
         NS_TOOL_BLOCKS,
         tracker.extmark_id,
         { details = true }
     )
+
     if not pos or not pos[1] then
         return nil
     end
+
     return pos[3] and pos[3].end_row
 end
 
@@ -1010,6 +1025,7 @@ end
 --- @return agentic.ui.MessageWriter.StatusSegment[] segments
 function MessageWriter:_build_status_row(tracker)
     local status = tracker.status
+
     if not status or status == "" then
         return "", {}
     end
@@ -1025,22 +1041,25 @@ function MessageWriter:_build_status_row(tracker)
     }
 
     local perm = tracker.permission
+
     if status ~= "pending" or not perm then
         return text, segments
     end
 
     local permission_icons = Config.permission_icons or {}
     local focused_btn = perm.focused_button_index
+
     for i, option in ipairs(perm.sorted_options) do
         local label = PERMISSION_OPTION_LABELS[option.kind] or option.kind
         local btn_icon = permission_icons[option.kind] or ""
-        local body
+        local body = ""
+
         if perm.is_focused then
             body = string.format("%d %s %s", i, btn_icon, label)
         else
             body = string.format("%s %s", btn_icon, label)
         end
-        -- No brackets: the bg highlight on the padded span is the button.
+
         local btn = " " .. body .. " "
 
         text = text .. "  "
@@ -1050,6 +1069,7 @@ function MessageWriter:_build_status_row(tracker)
 
         local is_button_focused = perm.is_focused and i == focused_btn
         local hl_group
+
         if not is_button_focused then
             hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_INACTIVE
         elseif option.kind == "allow_once" or option.kind == "allow_always" then

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -1057,10 +1057,6 @@ function MessageWriter:_render_status_row(row, text, hl_segments)
     end
 
     BufHelpers.with_modifiable(self.bufnr, function(bufnr)
-        local line_count = vim.api.nvim_buf_line_count(bufnr)
-        if row >= line_count then
-            return false
-        end
         pcall(vim.api.nvim_buf_set_lines, bufnr, row, row + 1, false, { text })
     end)
 

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -325,6 +325,34 @@ function MessageWriter:_append_lines(lines)
     end
 end
 
+--- @param cursor_line integer 1-indexed window cursor row
+--- @return boolean
+function MessageWriter:_cursor_on_permission_button_row(cursor_line)
+    local row = cursor_line - 1
+    local marks = vim.api.nvim_buf_get_extmarks(
+        self.bufnr,
+        NS_STATUS,
+        { row, 0 },
+        { row + 1, 0 },
+        { details = true, hl_name = true }
+    )
+
+    for _, mark in ipairs(marks) do
+        local details = mark[4]
+        local hl_group = details and details.hl_group
+
+        if
+            hl_group == Theme.HL_GROUPS.PERMISSION_BUTTON_INACTIVE
+            or hl_group == Theme.HL_GROUPS.PERMISSION_BUTTON_ALLOW
+            or hl_group == Theme.HL_GROUPS.PERMISSION_BUTTON_REJECT
+        then
+            return true
+        end
+    end
+
+    return false
+end
+
 --- @param bufnr integer
 --- @return boolean should_scroll
 function MessageWriter:_check_auto_scroll(bufnr)
@@ -340,6 +368,11 @@ function MessageWriter:_check_auto_scroll(bufnr)
     end
 
     local cursor_line = vim.api.nvim_win_get_cursor(winid)[1]
+
+    if self:_cursor_on_permission_button_row(cursor_line) then
+        return false
+    end
+
     local total_lines = vim.api.nvim_buf_line_count(bufnr)
     local distance_from_bottom = total_lines - cursor_line
 

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -1034,7 +1034,7 @@ function MessageWriter:_build_status_row(tracker)
     local icon = icons[status] or ""
     local status_label = icon ~= "" and (icon .. " " .. status) or status
 
-    local text = " " .. status_label
+    local text = " " .. status_label .. " "
     --- @type agentic.ui.MessageWriter.StatusSegment[]
     local segments = {
         { 1, #text, Theme.get_status_hl_group(status) },

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -1037,7 +1037,7 @@ function MessageWriter:_build_status_row(tracker)
     local text = " " .. status_label .. " "
     --- @type agentic.ui.MessageWriter.StatusSegment[]
     local segments = {
-        { 1, #text, Theme.get_status_hl_group(status) },
+        { 0, #text, Theme.get_status_hl_group(status) },
     }
 
     local perm = tracker.permission

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -530,7 +530,7 @@ function MessageWriter:update_tool_call_block(tool_call_block)
             end
 
             self:_clear_status_namespace(start_row, old_end_row)
-            self:_apply_status_highlights_if_present(start_row, tracker)
+            self:_apply_status_highlights_if_present(tracker)
 
             return false
         end
@@ -572,7 +572,7 @@ function MessageWriter:update_tool_call_block(tool_call_block)
             right_gravity = false,
         })
 
-        self:_apply_status_highlights_if_present(start_row, tracker)
+        self:_apply_status_highlights_if_present(tracker)
 
         if
             not tracker.has_fold
@@ -792,6 +792,22 @@ end
 
 --- Return the 0-indexed last row of the block, or nil when no block tracker
 --- or extmark is found.
+--- @param tool_call_id string
+--- @return integer|nil start_row
+function MessageWriter:_get_block_start_row(tool_call_id)
+    local tracker = self.tool_call_blocks[tool_call_id]
+    if not tracker or not tracker.extmark_id then
+        return nil
+    end
+    local pos = vim.api.nvim_buf_get_extmark_by_id(
+        self.bufnr,
+        NS_TOOL_BLOCKS,
+        tracker.extmark_id,
+        {}
+    )
+    return pos and pos[1]
+end
+
 --- @param tool_call_id string
 --- @return integer|nil end_row
 function MessageWriter:_get_block_end_row(tool_call_id)
@@ -1110,13 +1126,17 @@ function MessageWriter:_clear_status_namespace(start_row, end_row)
     )
 end
 
---- @param start_row integer
 --- @param tracker agentic.ui.MessageWriter.ToolCallBlock
-function MessageWriter:_apply_status_highlights_if_present(start_row, tracker)
-    if tracker.status then
-        self:_apply_header_highlight(start_row, tracker.status)
-        self:repaint_status_row(tracker.tool_call_id)
+function MessageWriter:_apply_status_highlights_if_present(tracker)
+    if not tracker.status then
+        return
     end
+    local start_row = self:_get_block_start_row(tracker.tool_call_id)
+    if not start_row then
+        return
+    end
+    self:_apply_header_highlight(start_row, tracker.status)
+    self:repaint_status_row(tracker.tool_call_id)
 end
 
 function MessageWriter:destroy() end

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -206,6 +206,58 @@ describe("agentic.ui.MessageWriter", function()
                 or ""
         end
 
+        --- @param tool_call_id string
+        --- @return vim.api.keyset.get_extmark_item[]
+        local function status_marks(tool_call_id)
+            local row = block_end_row(tool_call_id)
+            local ns = vim.api.nvim_create_namespace("agentic_status_footer")
+            return vim.api.nvim_buf_get_extmarks(
+                bufnr,
+                ns,
+                { row, 0 },
+                { row + 1, 0 },
+                { details = true }
+            )
+        end
+
+        --- @param marks vim.api.keyset.get_extmark_item[]
+        --- @param hl_group string
+        --- @return integer
+        local function count_hl_marks(marks, hl_group)
+            local count = 0
+            for _, em in ipairs(marks) do
+                if em[4].hl_group == hl_group then
+                    count = count + 1
+                end
+            end
+            return count
+        end
+
+        local ALLOW_REJECT_OPTIONS = {
+            {
+                optionId = "allow-once",
+                name = "Allow once",
+                kind = "allow_once",
+            },
+            {
+                optionId = "reject-once",
+                name = "Reject once",
+                kind = "reject_once",
+            },
+        }
+
+        --- @param id string
+        --- @param state { is_focused: boolean, focused_button_index?: integer, sorted_options?: table[] }
+        local function setup_permission_block(id, state)
+            writer:write_tool_call_block(make_tool_call_block(id, "pending"))
+            writer:set_permission_state(id, {
+                sorted_options = state.sorted_options or ALLOW_REJECT_OPTIONS,
+                is_focused = state.is_focused,
+                focused_button_index = state.focused_button_index,
+            })
+            writer:repaint_status_row(id)
+        end
+
         it(
             "writes the status word as real text at row N for non-pending blocks",
             function()
@@ -230,25 +282,7 @@ describe("agentic.ui.MessageWriter", function()
         it(
             "renders inline buttons for pending non-focused permission state",
             function()
-                writer:write_tool_call_block(
-                    make_tool_call_block("row-n-inactive", "pending")
-                )
-                writer:set_permission_state("row-n-inactive", {
-                    sorted_options = {
-                        {
-                            optionId = "allow-once",
-                            name = "Allow once",
-                            kind = "allow_once",
-                        },
-                        {
-                            optionId = "reject-once",
-                            name = "Reject once",
-                            kind = "reject_once",
-                        },
-                    },
-                    is_focused = false,
-                })
-                writer:repaint_status_row("row-n-inactive")
+                setup_permission_block("row-n-inactive", { is_focused = false })
 
                 local text = status_row_text("row-n-inactive")
                 assert.truthy(text:find("pending"))
@@ -260,25 +294,7 @@ describe("agentic.ui.MessageWriter", function()
         )
 
         it("renders inline buttons with digit prefixes when focused", function()
-            writer:write_tool_call_block(
-                make_tool_call_block("row-n-focused", "pending")
-            )
-            writer:set_permission_state("row-n-focused", {
-                sorted_options = {
-                    {
-                        optionId = "allow-once",
-                        name = "Allow once",
-                        kind = "allow_once",
-                    },
-                    {
-                        optionId = "reject-once",
-                        name = "Reject once",
-                        kind = "reject_once",
-                    },
-                },
-                is_focused = true,
-            })
-            writer:repaint_status_row("row-n-focused")
+            setup_permission_block("row-n-focused", { is_focused = true })
 
             local text = status_row_text("row-n-focused")
             assert.truthy(text:find("1 "))
@@ -287,140 +303,56 @@ describe("agentic.ui.MessageWriter", function()
             assert.truthy(text:find("Reject"))
         end)
 
-        --- @param marks vim.api.keyset.get_extmark_item[]
-        --- @param hl_group string
-        --- @return integer
-        local function count_hl_marks(marks, hl_group)
-            local count = 0
-            for _, em in ipairs(marks) do
-                if em[4].hl_group == hl_group then
-                    count = count + 1
-                end
-            end
-            return count
-        end
+        for _, case in ipairs({
+            {
+                index = 1,
+                focused_hl = "AgenticPermissionButtonAllow",
+                unfocused_hl = "AgenticPermissionButtonReject",
+                label = "allow",
+            },
+            {
+                index = 2,
+                focused_hl = "AgenticPermissionButtonReject",
+                unfocused_hl = "AgenticPermissionButtonAllow",
+                label = "reject",
+            },
+        }) do
+            it(
+                "applies "
+                    .. case.label
+                    .. " hl only on the focused "
+                    .. case.label
+                    .. " button (focused_button_index = "
+                    .. case.index
+                    .. ")",
+                function()
+                    local id = "row-n-hl-" .. case.label
+                    setup_permission_block(id, {
+                        is_focused = true,
+                        focused_button_index = case.index,
+                    })
 
-        --- @param tool_call_id string
-        --- @return vim.api.keyset.get_extmark_item[]
-        local function status_marks(tool_call_id)
-            local row = block_end_row(tool_call_id)
-            local ns = vim.api.nvim_create_namespace("agentic_status_footer")
-            return vim.api.nvim_buf_get_extmarks(
-                bufnr,
-                ns,
-                { row, 0 },
-                { row + 1, 0 },
-                { details = true }
+                    local marks = status_marks(id)
+                    assert.equal(1, count_hl_marks(marks, case.focused_hl))
+                    assert.equal(0, count_hl_marks(marks, case.unfocused_hl))
+                    -- The non-focused button stays inactive.
+                    assert.equal(
+                        1,
+                        count_hl_marks(marks, "AgenticPermissionButtonInactive")
+                    )
+                end
             )
         end
 
         it(
-            "applies allow hl only on the focused allow button (focused_button_index = 1)",
-            function()
-                writer:write_tool_call_block(
-                    make_tool_call_block("row-n-hl-allow", "pending")
-                )
-                writer:set_permission_state("row-n-hl-allow", {
-                    sorted_options = {
-                        {
-                            optionId = "allow-once",
-                            name = "Allow once",
-                            kind = "allow_once",
-                        },
-                        {
-                            optionId = "reject-once",
-                            name = "Reject once",
-                            kind = "reject_once",
-                        },
-                    },
-                    is_focused = true,
-                    focused_button_index = 1,
-                })
-                writer:repaint_status_row("row-n-hl-allow")
-
-                local marks = status_marks("row-n-hl-allow")
-                assert.equal(
-                    1,
-                    count_hl_marks(marks, "AgenticPermissionButtonAllow")
-                )
-                assert.equal(
-                    0,
-                    count_hl_marks(marks, "AgenticPermissionButtonReject")
-                )
-                -- The non-focused reject button stays inactive.
-                assert.equal(
-                    1,
-                    count_hl_marks(marks, "AgenticPermissionButtonInactive")
-                )
-            end
-        )
-
-        it(
-            "applies reject hl only on the focused reject button (focused_button_index = 2)",
-            function()
-                writer:write_tool_call_block(
-                    make_tool_call_block("row-n-hl-reject", "pending")
-                )
-                writer:set_permission_state("row-n-hl-reject", {
-                    sorted_options = {
-                        {
-                            optionId = "allow-once",
-                            name = "Allow once",
-                            kind = "allow_once",
-                        },
-                        {
-                            optionId = "reject-once",
-                            name = "Reject once",
-                            kind = "reject_once",
-                        },
-                    },
-                    is_focused = true,
-                    focused_button_index = 2,
-                })
-                writer:repaint_status_row("row-n-hl-reject")
-
-                local marks = status_marks("row-n-hl-reject")
-                assert.equal(
-                    1,
-                    count_hl_marks(marks, "AgenticPermissionButtonReject")
-                )
-                assert.equal(
-                    0,
-                    count_hl_marks(marks, "AgenticPermissionButtonAllow")
-                )
-                -- The non-focused allow button stays inactive.
-                assert.equal(
-                    1,
-                    count_hl_marks(marks, "AgenticPermissionButtonInactive")
-                )
-            end
-        )
-
-        it(
             "applies inactive highlight group for non-focused permission buttons",
             function()
-                writer:write_tool_call_block(
-                    make_tool_call_block("row-n-hl-inactive", "pending")
+                setup_permission_block(
+                    "row-n-hl-inactive",
+                    { is_focused = false }
                 )
-                writer:set_permission_state("row-n-hl-inactive", {
-                    sorted_options = {
-                        {
-                            optionId = "allow-once",
-                            name = "Allow once",
-                            kind = "allow_once",
-                        },
-                        {
-                            optionId = "reject-once",
-                            name = "Reject once",
-                            kind = "reject_once",
-                        },
-                    },
-                    is_focused = false,
-                })
-                writer:repaint_status_row("row-n-hl-inactive")
 
                 local marks = status_marks("row-n-hl-inactive")
-
                 assert.equal(
                     2,
                     count_hl_marks(marks, "AgenticPermissionButtonInactive")
@@ -429,21 +361,11 @@ describe("agentic.ui.MessageWriter", function()
         )
 
         it("button labels are not wrapped in square brackets", function()
-            writer:write_tool_call_block(
-                make_tool_call_block("row-n-nobracket", "pending")
-            )
-            writer:set_permission_state("row-n-nobracket", {
-                sorted_options = {
-                    {
-                        optionId = "allow-once",
-                        name = "Allow once",
-                        kind = "allow_once",
-                    },
-                },
+            setup_permission_block("row-n-nobracket", {
+                sorted_options = { ALLOW_REJECT_OPTIONS[1] },
                 is_focused = true,
                 focused_button_index = 1,
             })
-            writer:repaint_status_row("row-n-nobracket")
 
             local text = status_row_text("row-n-nobracket")
             assert.is_nil(text:find("%["))
@@ -454,21 +376,11 @@ describe("agentic.ui.MessageWriter", function()
         it(
             "clears buttons when permission state is removed and repainted",
             function()
-                writer:write_tool_call_block(
-                    make_tool_call_block("row-n-clear", "pending")
-                )
-                writer:set_permission_state("row-n-clear", {
-                    sorted_options = {
-                        {
-                            optionId = "allow-once",
-                            name = "Allow once",
-                            kind = "allow_once",
-                        },
-                    },
+                setup_permission_block("row-n-clear", {
+                    sorted_options = { ALLOW_REJECT_OPTIONS[1] },
                     is_focused = true,
                     focused_button_index = 1,
                 })
-                writer:repaint_status_row("row-n-clear")
                 assert.truthy(status_row_text("row-n-clear"):find("Allow"))
 
                 writer:set_permission_state("row-n-clear", nil)
@@ -1086,8 +998,17 @@ describe("agentic.ui.MessageWriter", function()
         --- @type agentic.UserConfig.Folding|nil
         local saved_folding
 
+        local LONG_BODY =
+            { "L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8", "L9", "L10" }
+
         before_each(function()
             saved_folding = Config.folding
+            Config.folding = { tool_calls = { enabled = true, threshold = 5 } }
+            Config.auto_scroll = { threshold = 10 }
+
+            Fold.setup_window(winid, bufnr)
+            vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "intro" })
+            vim.api.nvim_win_set_cursor(winid, { 1, 0 })
         end)
 
         after_each(function()
@@ -1112,18 +1033,27 @@ describe("agentic.ui.MessageWriter", function()
             return start_row, start_row + 1, end_row - 1, end_row
         end
 
+        --- @param tool_call_id string
+        local function assert_fold_closed(tool_call_id)
+            local _, top_pad_row, bottom_pad_row = block_layout(tool_call_id)
+            vim.api.nvim_win_call(winid, function()
+                assert.equal(
+                    vim.fn.foldclosed(top_pad_row + 1),
+                    top_pad_row + 1
+                )
+                assert.equal(
+                    vim.fn.foldclosedend(top_pad_row + 1),
+                    bottom_pad_row + 1
+                )
+            end)
+            assert.is_true(
+                writer.tool_call_blocks[tool_call_id].has_fold == true
+            )
+        end
+
         it(
             "closes a manual fold when update_tool_call_block crosses the fold threshold",
             function()
-                Config.folding = {
-                    tool_calls = { enabled = true, threshold = 5 },
-                }
-                Config.auto_scroll = { threshold = 10 }
-
-                Fold.setup_window(winid, bufnr)
-                vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "intro" })
-                vim.api.nvim_win_set_cursor(winid, { 1, 0 })
-
                 writer:write_tool_call_block({
                     tool_call_id = "fold-mat",
                     status = "pending",
@@ -1140,93 +1070,29 @@ describe("agentic.ui.MessageWriter", function()
                 writer:update_tool_call_block({
                     tool_call_id = "fold-mat",
                     status = "completed",
-                    body = {
-                        "L1",
-                        "L2",
-                        "L3",
-                        "L4",
-                        "L5",
-                        "L6",
-                        "L7",
-                        "L8",
-                        "L9",
-                        "L10",
-                    },
+                    body = LONG_BODY,
                 })
 
-                local _, new_top_pad_row, new_bottom_pad_row =
-                    block_layout("fold-mat")
-                vim.api.nvim_win_call(winid, function()
-                    local fold_start = vim.fn.foldclosed(new_top_pad_row + 1)
-                    local fold_end = vim.fn.foldclosedend(new_top_pad_row + 1)
-                    assert.equal(fold_start, new_top_pad_row + 1)
-                    assert.equal(fold_end, new_bottom_pad_row + 1)
-                end)
-
-                local tracker = writer.tool_call_blocks["fold-mat"]
-                assert.is_true(tracker.has_fold == true)
+                assert_fold_closed("fold-mat")
             end
         )
 
         it(
             "closes a manual fold when write_tool_call_block crosses the fold threshold",
             function()
-                Config.folding = {
-                    tool_calls = { enabled = true, threshold = 5 },
-                }
-                Config.auto_scroll = { threshold = 10 }
-
-                Fold.setup_window(winid, bufnr)
-                vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "intro" })
-                vim.api.nvim_win_set_cursor(winid, { 1, 0 })
-
                 writer:write_tool_call_block({
                     tool_call_id = "fold-on-write",
                     status = "completed",
                     kind = "execute",
                     argument = "ls",
-                    body = {
-                        "L1",
-                        "L2",
-                        "L3",
-                        "L4",
-                        "L5",
-                        "L6",
-                        "L7",
-                        "L8",
-                        "L9",
-                        "L10",
-                    },
+                    body = LONG_BODY,
                 })
 
-                local _, top_pad_row, bottom_pad_row =
-                    block_layout("fold-on-write")
-                vim.api.nvim_win_call(winid, function()
-                    assert.equal(
-                        vim.fn.foldclosed(top_pad_row + 1),
-                        top_pad_row + 1
-                    )
-                    assert.equal(
-                        vim.fn.foldclosedend(top_pad_row + 1),
-                        bottom_pad_row + 1
-                    )
-                end)
-
-                local tracker = writer.tool_call_blocks["fold-on-write"]
-                assert.is_true(tracker.has_fold == true)
+                assert_fold_closed("fold-on-write")
             end
         )
 
         it("does not create a fold when block stays below threshold", function()
-            Config.folding = {
-                tool_calls = { enabled = true, threshold = 5 },
-            }
-            Config.auto_scroll = { threshold = 10 }
-
-            Fold.setup_window(winid, bufnr)
-            vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "intro" })
-            vim.api.nvim_win_set_cursor(winid, { 1, 0 })
-
             writer:write_tool_call_block({
                 tool_call_id = "no-fold",
                 status = "pending",
@@ -1245,14 +1111,6 @@ describe("agentic.ui.MessageWriter", function()
         end)
 
         it("emits anchor pad lines around the body in every block", function()
-            Config.folding = {
-                tool_calls = { enabled = true, threshold = 5 },
-            }
-            Config.auto_scroll = { threshold = 10 }
-
-            Fold.setup_window(winid, bufnr)
-            vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "intro" })
-
             writer:write_tool_call_block({
                 tool_call_id = "anchors",
                 status = "pending",

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -181,81 +181,304 @@ describe("agentic.ui.MessageWriter", function()
         end)
     end)
 
-    describe("permission_reanchor callback", function()
-        --- @type TestStub
-        local schedule_stub
-
-        before_each(function()
-            schedule_stub = spy.stub(vim, "schedule")
-        end)
-
-        after_each(function()
-            schedule_stub:revert()
-        end)
-
-        it(
-            "stores and fires callback via set_permission_reanchor_callback",
-            function()
-                local callback_spy = spy.new(function() end)
-                writer:set_permission_reanchor_callback(
-                    callback_spy --[[@as function]]
-                )
-
-                writer:_notify_permission_reanchor()
-
-                assert.spy(callback_spy).was.called(1)
-            end
-        )
-
-        it("clears callback when set to nil", function()
-            local callback_spy = spy.new(function() end)
-            writer:set_permission_reanchor_callback(
-                callback_spy --[[@as function]]
+    describe("status row", function()
+        --- @param tool_call_id string
+        --- @return integer
+        local function block_end_row(tool_call_id)
+            local tracker = writer.tool_call_blocks[tool_call_id]
+            local NS = vim.api.nvim_create_namespace("agentic_tool_blocks")
+            local pos = vim.api.nvim_buf_get_extmark_by_id(
+                bufnr,
+                NS,
+                tracker.extmark_id,
+                { details = true }
             )
-            writer:set_permission_reanchor_callback(nil)
+            --- @type integer
+            local end_row = pos[3].end_row
+            return end_row
+        end
 
-            writer:_notify_permission_reanchor()
-
-            assert.spy(callback_spy).was.called(0)
-        end)
+        --- @param tool_call_id string
+        --- @return string
+        local function status_row_text(tool_call_id)
+            local row = block_end_row(tool_call_id)
+            return vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
+                or ""
+        end
 
         it(
-            "fires callback for each write method that produces content",
+            "writes the status word as real text at row N for non-pending blocks",
             function()
-                local block = make_tool_call_block("cb-setup", "pending")
-                writer:write_tool_call_block(block)
-
-                local callback_spy = spy.new(function() end)
-                writer:set_permission_reanchor_callback(
-                    callback_spy --[[@as function]]
-                )
-
-                writer:write_message(make_update("hello"))
-                writer:write_message_chunk(make_update("chunk"))
                 writer:write_tool_call_block(
-                    make_tool_call_block("cb-1", "pending")
+                    make_tool_call_block("row-n-completed", "completed")
                 )
-                writer:update_tool_call_block({
-                    tool_call_id = "cb-setup",
-                    status = "completed",
-                    body = { "done" },
-                })
 
-                assert.spy(callback_spy).was.called(4)
+                local text = status_row_text("row-n-completed")
+                assert.truthy(text:find("completed"))
+                assert.is_true(#text > 0)
             end
         )
 
-        it("does not fire callback when content is empty", function()
-            local callback_spy = spy.new(function() end)
-            writer:set_permission_reanchor_callback(
-                callback_spy --[[@as function]]
+        it("writes pending status word as real text at row N", function()
+            writer:write_tool_call_block(
+                make_tool_call_block("row-n-pending", "pending")
             )
 
-            writer:write_message(make_update(""))
-            writer:write_message_chunk(make_update(""))
-
-            assert.spy(callback_spy).was.called(0)
+            assert.truthy(status_row_text("row-n-pending"):find("pending"))
         end)
+
+        it(
+            "renders inline buttons for pending non-focused permission state",
+            function()
+                writer:write_tool_call_block(
+                    make_tool_call_block("row-n-inactive", "pending")
+                )
+                writer:set_permission_state("row-n-inactive", {
+                    sorted_options = {
+                        {
+                            optionId = "allow-once",
+                            name = "Allow once",
+                            kind = "allow_once",
+                        },
+                        {
+                            optionId = "reject-once",
+                            name = "Reject once",
+                            kind = "reject_once",
+                        },
+                    },
+                    is_focused = false,
+                })
+                writer:repaint_status_row("row-n-inactive")
+
+                local text = status_row_text("row-n-inactive")
+                assert.truthy(text:find("pending"))
+                assert.truthy(text:find("Allow"))
+                assert.truthy(text:find("Reject"))
+                -- non-focused: no digit prefix
+                assert.is_nil(text:find("1 "))
+            end
+        )
+
+        it("renders inline buttons with digit prefixes when focused", function()
+            writer:write_tool_call_block(
+                make_tool_call_block("row-n-focused", "pending")
+            )
+            writer:set_permission_state("row-n-focused", {
+                sorted_options = {
+                    {
+                        optionId = "allow-once",
+                        name = "Allow once",
+                        kind = "allow_once",
+                    },
+                    {
+                        optionId = "reject-once",
+                        name = "Reject once",
+                        kind = "reject_once",
+                    },
+                },
+                is_focused = true,
+            })
+            writer:repaint_status_row("row-n-focused")
+
+            local text = status_row_text("row-n-focused")
+            assert.truthy(text:find("1 "))
+            assert.truthy(text:find("2 "))
+            assert.truthy(text:find("Allow"))
+            assert.truthy(text:find("Reject"))
+        end)
+
+        --- @param marks vim.api.keyset.get_extmark_item[]
+        --- @param hl_group string
+        --- @return integer
+        local function count_hl_marks(marks, hl_group)
+            local count = 0
+            for _, em in ipairs(marks) do
+                if em[4].hl_group == hl_group then
+                    count = count + 1
+                end
+            end
+            return count
+        end
+
+        --- @param tool_call_id string
+        --- @return vim.api.keyset.get_extmark_item[]
+        local function status_marks(tool_call_id)
+            local row = block_end_row(tool_call_id)
+            local ns = vim.api.nvim_create_namespace("agentic_status_footer")
+            return vim.api.nvim_buf_get_extmarks(
+                bufnr,
+                ns,
+                { row, 0 },
+                { row + 1, 0 },
+                { details = true }
+            )
+        end
+
+        it(
+            "applies allow hl only on the focused allow button (focused_button_index = 1)",
+            function()
+                writer:write_tool_call_block(
+                    make_tool_call_block("row-n-hl-allow", "pending")
+                )
+                writer:set_permission_state("row-n-hl-allow", {
+                    sorted_options = {
+                        {
+                            optionId = "allow-once",
+                            name = "Allow once",
+                            kind = "allow_once",
+                        },
+                        {
+                            optionId = "reject-once",
+                            name = "Reject once",
+                            kind = "reject_once",
+                        },
+                    },
+                    is_focused = true,
+                    focused_button_index = 1,
+                })
+                writer:repaint_status_row("row-n-hl-allow")
+
+                local marks = status_marks("row-n-hl-allow")
+                assert.equal(
+                    1,
+                    count_hl_marks(marks, "AgenticPermissionButtonAllow")
+                )
+                assert.equal(
+                    0,
+                    count_hl_marks(marks, "AgenticPermissionButtonReject")
+                )
+                -- The non-focused reject button stays inactive.
+                assert.equal(
+                    1,
+                    count_hl_marks(marks, "AgenticPermissionButtonInactive")
+                )
+            end
+        )
+
+        it(
+            "applies reject hl only on the focused reject button (focused_button_index = 2)",
+            function()
+                writer:write_tool_call_block(
+                    make_tool_call_block("row-n-hl-reject", "pending")
+                )
+                writer:set_permission_state("row-n-hl-reject", {
+                    sorted_options = {
+                        {
+                            optionId = "allow-once",
+                            name = "Allow once",
+                            kind = "allow_once",
+                        },
+                        {
+                            optionId = "reject-once",
+                            name = "Reject once",
+                            kind = "reject_once",
+                        },
+                    },
+                    is_focused = true,
+                    focused_button_index = 2,
+                })
+                writer:repaint_status_row("row-n-hl-reject")
+
+                local marks = status_marks("row-n-hl-reject")
+                assert.equal(
+                    1,
+                    count_hl_marks(marks, "AgenticPermissionButtonReject")
+                )
+                assert.equal(
+                    0,
+                    count_hl_marks(marks, "AgenticPermissionButtonAllow")
+                )
+                -- The non-focused allow button stays inactive.
+                assert.equal(
+                    1,
+                    count_hl_marks(marks, "AgenticPermissionButtonInactive")
+                )
+            end
+        )
+
+        it(
+            "applies inactive highlight group for non-focused permission buttons",
+            function()
+                writer:write_tool_call_block(
+                    make_tool_call_block("row-n-hl-inactive", "pending")
+                )
+                writer:set_permission_state("row-n-hl-inactive", {
+                    sorted_options = {
+                        {
+                            optionId = "allow-once",
+                            name = "Allow once",
+                            kind = "allow_once",
+                        },
+                        {
+                            optionId = "reject-once",
+                            name = "Reject once",
+                            kind = "reject_once",
+                        },
+                    },
+                    is_focused = false,
+                })
+                writer:repaint_status_row("row-n-hl-inactive")
+
+                local marks = status_marks("row-n-hl-inactive")
+
+                assert.equal(
+                    2,
+                    count_hl_marks(marks, "AgenticPermissionButtonInactive")
+                )
+            end
+        )
+
+        it("button labels are not wrapped in square brackets", function()
+            writer:write_tool_call_block(
+                make_tool_call_block("row-n-nobracket", "pending")
+            )
+            writer:set_permission_state("row-n-nobracket", {
+                sorted_options = {
+                    {
+                        optionId = "allow-once",
+                        name = "Allow once",
+                        kind = "allow_once",
+                    },
+                },
+                is_focused = true,
+                focused_button_index = 1,
+            })
+            writer:repaint_status_row("row-n-nobracket")
+
+            local text = status_row_text("row-n-nobracket")
+            assert.is_nil(text:find("%["))
+            assert.is_nil(text:find("%]"))
+            assert.truthy(text:find("Allow"))
+        end)
+
+        it(
+            "clears buttons when permission state is removed and repainted",
+            function()
+                writer:write_tool_call_block(
+                    make_tool_call_block("row-n-clear", "pending")
+                )
+                writer:set_permission_state("row-n-clear", {
+                    sorted_options = {
+                        {
+                            optionId = "allow-once",
+                            name = "Allow once",
+                            kind = "allow_once",
+                        },
+                    },
+                    is_focused = true,
+                    focused_button_index = 1,
+                })
+                writer:repaint_status_row("row-n-clear")
+                assert.truthy(status_row_text("row-n-clear"):find("Allow"))
+
+                writer:set_permission_state("row-n-clear", nil)
+                writer:repaint_status_row("row-n-clear")
+
+                local text = status_row_text("row-n-clear")
+                assert.is_nil(text:find("Allow"))
+                assert.truthy(text:find("pending"))
+            end
+        )
     end)
 
     describe("_prepare_block_lines", function()

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -124,6 +124,47 @@ describe("agentic.ui.MessageWriter", function()
         }
     end
 
+    --- @param tool_call_id string
+    --- @return integer
+    local function block_end_row(tool_call_id)
+        local tracker = writer.tool_call_blocks[tool_call_id]
+        local NS = vim.api.nvim_create_namespace("agentic_tool_blocks")
+        local pos = vim.api.nvim_buf_get_extmark_by_id(
+            bufnr,
+            NS,
+            tracker.extmark_id,
+            { details = true }
+        )
+        --- @type integer
+        local end_row = pos[3].end_row
+        return end_row
+    end
+
+    local ALLOW_REJECT_OPTIONS = {
+        {
+            optionId = "allow-once",
+            name = "Allow once",
+            kind = "allow_once",
+        },
+        {
+            optionId = "reject-once",
+            name = "Reject once",
+            kind = "reject_once",
+        },
+    }
+
+    --- @param id string
+    --- @param state { is_focused: boolean, focused_button_index?: integer, sorted_options?: table[] }
+    local function setup_permission_block(id, state)
+        writer:write_tool_call_block(make_tool_call_block(id, "pending"))
+        writer:set_permission_state(id, {
+            sorted_options = state.sorted_options or ALLOW_REJECT_OPTIONS,
+            is_focused = state.is_focused,
+            focused_button_index = state.focused_button_index,
+        })
+        writer:repaint_status_row(id)
+    end
+
     local NS_THINKING = vim.api.nvim_create_namespace("agentic_thinking")
 
     --- @return vim.api.keyset.get_extmark_item[]
@@ -179,25 +220,39 @@ describe("agentic.ui.MessageWriter", function()
             vim.api.nvim_set_current_tabpage(tab2)
             vim.cmd("tabclose")
         end)
+
+        it(
+            "returns false when cursor is parked on a permission button row",
+            function()
+                setup_permission_block("auto-scroll-permission-row", {
+                    is_focused = false,
+                })
+                vim.api.nvim_win_set_cursor(winid, {
+                    block_end_row("auto-scroll-permission-row") + 1,
+                    0,
+                })
+
+                assert.is_false(writer:_check_auto_scroll(bufnr))
+            end
+        )
+
+        it(
+            "still auto-scrolls when cursor is on a non-permission status row",
+            function()
+                writer:write_tool_call_block(
+                    make_tool_call_block("auto-scroll-status-row", "pending")
+                )
+                vim.api.nvim_win_set_cursor(winid, {
+                    block_end_row("auto-scroll-status-row") + 1,
+                    0,
+                })
+
+                assert.is_true(writer:_check_auto_scroll(bufnr))
+            end
+        )
     end)
 
     describe("status row", function()
-        --- @param tool_call_id string
-        --- @return integer
-        local function block_end_row(tool_call_id)
-            local tracker = writer.tool_call_blocks[tool_call_id]
-            local NS = vim.api.nvim_create_namespace("agentic_tool_blocks")
-            local pos = vim.api.nvim_buf_get_extmark_by_id(
-                bufnr,
-                NS,
-                tracker.extmark_id,
-                { details = true }
-            )
-            --- @type integer
-            local end_row = pos[3].end_row
-            return end_row
-        end
-
         --- @param tool_call_id string
         --- @return string
         local function status_row_text(tool_call_id)
@@ -231,31 +286,6 @@ describe("agentic.ui.MessageWriter", function()
                 end
             end
             return count
-        end
-
-        local ALLOW_REJECT_OPTIONS = {
-            {
-                optionId = "allow-once",
-                name = "Allow once",
-                kind = "allow_once",
-            },
-            {
-                optionId = "reject-once",
-                name = "Reject once",
-                kind = "reject_once",
-            },
-        }
-
-        --- @param id string
-        --- @param state { is_focused: boolean, focused_button_index?: integer, sorted_options?: table[] }
-        local function setup_permission_block(id, state)
-            writer:write_tool_call_block(make_tool_call_block(id, "pending"))
-            writer:set_permission_state(id, {
-                sorted_options = state.sorted_options or ALLOW_REJECT_OPTIONS,
-                is_focused = state.is_focused,
-                focused_button_index = state.focused_button_index,
-            })
-            writer:repaint_status_row(id)
         end
 
         it(

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -363,10 +363,11 @@ end
 
 --- Install the per-block focus keymaps: digits 1..N for direct dispatch,
 --- h / l / <Left> / <Right> for button-focus cycling, and <CR> for submit.
---- All keymaps are `expr = true`: they only fire when the cursor is on the
---- focused block's row N. Off-row, they fall through to the original key so
---- the user can navigate / count normally. The digit mapping and focused_id
---- are captured in the closure at install time (snapshot).
+--- Digits fire from anywhere in the chat buffer (direct dispatch is the whole
+--- point of inline permissions). Motion / submit keys are `expr = true` and
+--- only fire on the focused block's row N; off-row they return the original
+--- key so the user can navigate / count normally. The digit mapping and
+--- focused_id are captured in the closure at install time (snapshot).
 --- @param focused_id string Snapshot of focused id at install time
 --- @param mapping table<integer, string> Snapshot of digit -> option_id at install time
 --- @protected
@@ -403,18 +404,11 @@ function PermissionManager:_install_focus_keymaps(focused_id, mapping)
         local option_id = snapshot[i]
         if option_id then
             local digit = tostring(i)
-            BufHelpers.keymap_set(
-                bufnr,
-                "n",
-                digit,
-                gated(digit, function()
-                    self:resolve(focused_id, option_id)
-                end),
-                {
-                    desc = "Permission: select option " .. digit,
-                    expr = true,
-                }
-            )
+            BufHelpers.keymap_set(bufnr, "n", digit, function()
+                self:resolve(focused_id, option_id)
+            end, {
+                desc = "Permission: select option " .. digit,
+            })
         end
     end
 

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -478,16 +478,12 @@ function PermissionManager:_remove_focus_keymaps()
         return
     end
 
+    local bufnr = self.message_writer.bufnr
     for i = 1, MAX_DIGIT_KEYS do
-        pcall(
-            vim.keymap.del,
-            "n",
-            tostring(i),
-            { buffer = self.message_writer.bufnr }
-        )
+        BufHelpers.keymap_del(bufnr, "n", tostring(i))
     end
     for _, lhs in ipairs({ "h", "l", "<Left>", "<Right>", "<CR>" }) do
-        pcall(vim.keymap.del, "n", lhs, { buffer = self.message_writer.bufnr })
+        BufHelpers.keymap_del(bufnr, "n", lhs)
     end
 end
 

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -16,7 +16,7 @@ local PERMISSION_KIND_PRIORITY = {
     reject_always = 4,
 }
 
-local MAX_DIGIT_KEYS = 4
+local MAX_DIGIT_KEYS = vim.tbl_count(PERMISSION_KIND_PRIORITY)
 
 --- @class agentic.ui.PermissionManager.PermissionRequest
 --- @field tool_call_id string
@@ -46,6 +46,7 @@ function PermissionManager:new(message_writer)
     -- their callback returns early when `_order` is empty, so pressing the key
     -- with no pending blocks is a no-op.
     local cfg = (Config.keymaps and Config.keymaps.permission) or {}
+
     BufHelpers.multi_keymap_set(
         cfg.cycle_next or "<C-n>",
         message_writer.bufnr,
@@ -54,6 +55,7 @@ function PermissionManager:new(message_writer)
         end,
         { desc = "Permission: focus next pending tool call" }
     )
+
     BufHelpers.multi_keymap_set(
         cfg.cycle_prev or "<C-p>",
         message_writer.bufnr,
@@ -69,10 +71,7 @@ end
 --- @param options agentic.acp.PermissionOption[]
 --- @return agentic.acp.PermissionOption[]
 function PermissionManager._sort_permission_options(options)
-    local sorted = {}
-    for _, option in ipairs(options) do
-        table.insert(sorted, option)
-    end
+    local sorted = vim.list_extend({}, options)
 
     table.sort(sorted, function(a, b)
         local priority_a = PERMISSION_KIND_PRIORITY[a.kind] or 999
@@ -102,6 +101,7 @@ function PermissionManager:add_request(request, callback)
     end
 
     local tool_call_id = request.toolCall.toolCallId
+
     if self.pending[tool_call_id] then
         Logger.debug(
             "PermissionManager: Duplicate request for " .. tool_call_id
@@ -143,11 +143,15 @@ function PermissionManager:_cycle_button(direction)
     if not self.focused_id then
         return
     end
+
     local pending = self.pending[self.focused_id]
+
     if not pending then
         return
     end
+
     local n = #pending.sorted_options
+
     if n == 0 then
         return
     end
@@ -155,6 +159,7 @@ function PermissionManager:_cycle_button(direction)
     local current = self.message_writer:get_focused_button_index(
         self.focused_id
     ) or 1
+
     local new_idx = ((current - 1 + direction + n) % n) + 1
 
     self.message_writer:set_permission_state(self.focused_id, {
@@ -163,24 +168,50 @@ function PermissionManager:_cycle_button(direction)
         focused_button_index = new_idx,
     })
     self.message_writer:repaint_status_row(self.focused_id)
+    self:_jump_cursor_to_button(self.focused_id, new_idx)
+end
+
+--- @param tool_call_id string
+--- @param button_index integer 1-indexed
+--- @protected
+function PermissionManager:_jump_cursor_to_button(tool_call_id, button_index)
+    local row = self.message_writer:get_block_end_row(tool_call_id)
+    if not row then
+        return
+    end
+
+    local winid = self:_find_visible_chat_winid()
+    if not winid then
+        return
+    end
+
+    local col = self.message_writer:get_button_col(tool_call_id, button_index)
+    if not col then
+        return
+    end
+
+    pcall(vim.api.nvim_win_set_cursor, winid, { row + 1, col })
 end
 
 --- Resolve the focused block with its currently focused button's option.
---- @protected
 function PermissionManager:_submit_focused_button()
     if not self.focused_id then
         return
     end
+
     local pending = self.pending[self.focused_id]
     if not pending then
         return
     end
+
     local idx = self.message_writer:get_focused_button_index(self.focused_id)
         or 1
     local opt = pending.sorted_options[idx]
+
     if not opt then
         return
     end
+
     self:resolve(self.focused_id, opt.optionId)
 end
 
@@ -190,6 +221,7 @@ end
 --- @param option_id string|nil
 function PermissionManager:resolve(tool_call_id, option_id)
     local request = self.pending[tool_call_id]
+
     if not request then
         return
     end
@@ -197,6 +229,7 @@ function PermissionManager:resolve(tool_call_id, option_id)
     local was_focused = self.focused_id == tool_call_id
 
     self.pending[tool_call_id] = nil
+
     for i, id in ipairs(self._order) do
         if id == tool_call_id then
             table.remove(self._order, i)
@@ -226,10 +259,7 @@ end
 --- pending callback with nil.
 function PermissionManager:clear()
     --- @type string[]
-    local ids = {}
-    for _, tool_call_id in ipairs(self._order) do
-        table.insert(ids, tool_call_id)
-    end
+    local ids = vim.list_extend({}, self._order)
 
     for _, tool_call_id in ipairs(ids) do
         local request = self.pending[tool_call_id]
@@ -263,6 +293,7 @@ end
 --- @protected
 function PermissionManager:_set_focus(new_id)
     local old_id = self.focused_id
+
     if new_id == old_id then
         return
     end
@@ -380,10 +411,11 @@ function PermissionManager:_install_focus_keymaps(pending)
         })
     end
 
-    local prev_button = function()
+    local function prev_button()
         self:_cycle_button(-1)
     end
-    local next_button = function()
+
+    local function next_button()
         self:_cycle_button(1)
     end
 
@@ -393,6 +425,7 @@ function PermissionManager:_install_focus_keymaps(pending)
             expr = true,
         })
     end
+
     for _, lhs in ipairs({ "l", "<Right>" }) do
         BufHelpers.keymap_set(bufnr, "n", lhs, gated(lhs, next_button), {
             desc = "Permission: focus next button",
@@ -430,13 +463,11 @@ function PermissionManager:_find_visible_chat_winid()
 end
 
 --- @return boolean
---- @protected
 function PermissionManager:_cursor_on_focused_row()
     if not self.focused_id then
         return false
     end
-    --- @diagnostic disable-next-line: invisible
-    local row = self.message_writer:_get_block_end_row(self.focused_id)
+    local row = self.message_writer:get_block_end_row(self.focused_id)
     if not row then
         return false
     end
@@ -449,7 +480,6 @@ function PermissionManager:_cursor_on_focused_row()
     return cursor_row == row + 1
 end
 
---- @protected
 function PermissionManager:_remove_focus_keymaps()
     if not vim.api.nvim_buf_is_valid(self.message_writer.bufnr) then
         return
@@ -465,10 +495,8 @@ function PermissionManager:_remove_focus_keymaps()
 end
 
 --- @param tool_call_id string
---- @protected
 function PermissionManager:_jump_cursor_to(tool_call_id)
-    --- @diagnostic disable-next-line: invisible
-    local row = self.message_writer:_get_block_end_row(tool_call_id)
+    local row = self.message_writer:get_block_end_row(tool_call_id)
     if not row then
         return
     end
@@ -484,7 +512,7 @@ function PermissionManager:_jump_cursor_to(tool_call_id)
     end
 
     --- @diagnostic disable-next-line: invisible
-    local col = self.message_writer:_get_first_button_col(tool_call_id) or 0
+    local col = self.message_writer:get_button_col(tool_call_id, 1) or 0
     pcall(vim.api.nvim_win_set_cursor, winid, { row + 1, col })
     -- `zb` (not `zz`) matches the chat auto-scroll convention (`G0zb`),
     -- anchoring row N near the bottom of the window where the user expects

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -29,6 +29,7 @@ local MAX_DIGIT_KEYS = vim.tbl_count(PERMISSION_KIND_PRIORITY)
 --- @field pending table<string, agentic.ui.PermissionManager.PermissionRequest> Pending requests keyed by tool_call_id
 --- @field _order string[] Insertion order of pending tool_call_ids
 --- @field focused_id? string Currently focused tool_call_id
+--- @field _cycle_keymaps_installed boolean
 local PermissionManager = {}
 PermissionManager.__index = PermissionManager
 
@@ -40,32 +41,49 @@ function PermissionManager:new(message_writer)
         pending = {},
         _order = {},
         focused_id = nil,
+        _cycle_keymaps_installed = false,
     }, self)
 
-    -- Cycle keymaps stay installed for the lifetime of the PermissionManager;
-    -- their callback returns early when `_order` is empty, so pressing the key
-    -- with no pending blocks is a no-op.
-    local cfg = (Config.keymaps and Config.keymaps.permission) or {}
-
-    BufHelpers.multi_keymap_set(
-        cfg.cycle_next or "<C-n>",
-        message_writer.bufnr,
-        function()
-            self:_cycle_focus(1)
-        end,
-        { desc = "Permission: focus next pending tool call" }
-    )
-
-    BufHelpers.multi_keymap_set(
-        cfg.cycle_prev or "<C-p>",
-        message_writer.bufnr,
-        function()
-            self:_cycle_focus(-1)
-        end,
-        { desc = "Permission: focus previous pending tool call" }
-    )
-
     return self
+end
+
+function PermissionManager:_install_cycle_keymaps()
+    if self._cycle_keymaps_installed then
+        return
+    end
+
+    if not vim.api.nvim_buf_is_valid(self.message_writer.bufnr) then
+        return
+    end
+
+    local cfg = (Config.keymaps and Config.keymaps.permission) or {}
+    local bufnr = self.message_writer.bufnr
+
+    BufHelpers.multi_keymap_set(cfg.cycle_next or "<C-n>", bufnr, function()
+        self:_cycle_focus(1)
+    end, { desc = "Permission: focus next pending tool call" })
+
+    BufHelpers.multi_keymap_set(cfg.cycle_prev or "<C-p>", bufnr, function()
+        self:_cycle_focus(-1)
+    end, { desc = "Permission: focus previous pending tool call" })
+
+    self._cycle_keymaps_installed = true
+end
+
+function PermissionManager:_remove_cycle_keymaps()
+    if not self._cycle_keymaps_installed then
+        return
+    end
+
+    if vim.api.nvim_buf_is_valid(self.message_writer.bufnr) then
+        local cfg = (Config.keymaps and Config.keymaps.permission) or {}
+        local bufnr = self.message_writer.bufnr
+
+        BufHelpers.multi_keymap_del(cfg.cycle_next or "<C-n>", bufnr)
+        BufHelpers.multi_keymap_del(cfg.cycle_prev or "<C-p>", bufnr)
+    end
+
+    self._cycle_keymaps_installed = false
 end
 
 --- @param options agentic.acp.PermissionOption[]
@@ -122,6 +140,10 @@ function PermissionManager:add_request(request, callback)
 
     self.pending[tool_call_id] = pending_req
     table.insert(self._order, tool_call_id)
+
+    if #self._order == 1 then
+        self:_install_cycle_keymaps()
+    end
 
     if self.focused_id == nil then
         self:_set_focus(tool_call_id)
@@ -273,6 +295,7 @@ function PermissionManager:clear()
 
     self._order = {}
     self:_remove_focus_keymaps()
+    self:_remove_cycle_keymaps()
     self.focused_id = nil
 end
 
@@ -312,6 +335,7 @@ function PermissionManager:_set_focus(new_id)
     self:_remove_focus_keymaps()
 
     if new_id == nil then
+        self:_remove_cycle_keymaps()
         return
     end
 

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -1,4 +1,6 @@
+--- @diagnostic disable: invisible
 local BufHelpers = require("agentic.utils.buf_helpers")
+local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
 
 -- Priority order for permission option kinds based on ACP tool-calls documentation
@@ -15,12 +17,20 @@ local PERMISSION_KIND_PRIORITY = {
     reject_always = 4,
 }
 
+local MAX_DIGIT_KEYS = 4
+
+--- @class agentic.ui.PermissionManager.PermissionRequest
+--- @field tool_call_id string
+--- @field request agentic.acp.RequestPermission
+--- @field callback fun(option_id: string|nil)
+--- @field sorted_options agentic.acp.PermissionOption[]
+
 --- @class agentic.ui.PermissionManager
---- @field message_writer agentic.ui.MessageWriter Reference to MessageWriter instance
---- @field queue table[] Queue of pending requests {toolCallId, request, callback}
---- @field current_request? agentic.ui.PermissionManager.PermissionRequest Currently displayed request with button positions
---- @field keymap_info table[] Keymap info for cleanup {mode, lhs}
---- @field _reanchoring boolean Guard flag to prevent recursive _on_permission_reanchor during reanchor
+--- @field message_writer agentic.ui.MessageWriter
+--- @field pending table<string, agentic.ui.PermissionManager.PermissionRequest> Pending requests keyed by tool_call_id
+--- @field _order string[] Insertion order of pending tool_call_ids
+--- @field focused_id? string Currently focused tool_call_id
+--- @field _cycle_keymaps_installed boolean Whether the cycle_next / cycle_prev keymaps are installed on the chat buffer
 local PermissionManager = {}
 PermissionManager.__index = PermissionManager
 
@@ -29,109 +39,15 @@ PermissionManager.__index = PermissionManager
 function PermissionManager:new(message_writer)
     local instance = setmetatable({
         message_writer = message_writer,
-        queue = {},
-        current_request = nil,
-        keymap_info = {},
-        _reanchoring = false,
+        pending = {},
+        _order = {},
+        focused_id = nil,
+        _cycle_keymaps_installed = false,
     }, self)
 
+    instance:_install_cycle_keymaps()
+
     return instance
-end
-
---- Add a new permission request to the queue to be processed sequentially
---- @param request agentic.acp.RequestPermission
---- @param callback fun(option_id: string|nil)
-function PermissionManager:add_request(request, callback)
-    if not request.toolCall or not request.toolCall.toolCallId then
-        Logger.debug(
-            "PermissionManager: Invalid request - missing toolCall.toolCallId"
-        )
-        return
-    end
-
-    local toolCallId = request.toolCall.toolCallId
-    table.insert(self.queue, { toolCallId, request, callback })
-
-    if not self.current_request then
-        self:_process_next()
-    end
-end
-
-function PermissionManager:_process_next()
-    if #self.queue == 0 then
-        return
-    end
-
-    local item = table.remove(self.queue, 1)
-    local toolCallId = item[1]
-    local request = item[2]
-    local callback = item[3]
-    local sorted_options = self._sort_permission_options(request.options)
-
-    local button_start_row, button_end_row, option_mapping =
-        self.message_writer:display_permission_buttons(
-            request.toolCall.toolCallId,
-            sorted_options
-        )
-
-    ---@class agentic.ui.PermissionManager.PermissionRequest
-    self.current_request = {
-        toolCallId = toolCallId,
-        request = request,
-        callback = callback,
-        button_start_row = button_start_row,
-        button_end_row = button_end_row,
-        option_mapping = option_mapping,
-    }
-
-    self:_setup_keymaps(option_mapping)
-
-    self.message_writer:set_permission_reanchor_callback(function()
-        self:_reanchor_permission_prompt()
-    end)
-end
-
-function PermissionManager:_reanchor_permission_prompt()
-    if self._reanchoring or not self.current_request then
-        return
-    end
-
-    self._reanchoring = true
-
-    --- @type agentic.ui.PermissionManager.PermissionRequest
-    local current = self.current_request
-
-    local ok, err = pcall(function()
-        self.message_writer:remove_permission_buttons(
-            current.button_start_row,
-            current.button_end_row
-        )
-        self:_remove_keymaps()
-
-        local sorted_options =
-            self._sort_permission_options(current.request.options)
-
-        local button_start_row, button_end_row, option_mapping =
-            self.message_writer:display_permission_buttons(
-                current.request.toolCall.toolCallId,
-                sorted_options
-            )
-
-        current.button_start_row = button_start_row
-        current.button_end_row = button_end_row
-        current.option_mapping = option_mapping
-
-        self:_setup_keymaps(option_mapping)
-    end)
-
-    self._reanchoring = false
-
-    if not ok then
-        Logger.notify(
-            "Error during permission prompt reanchor: " .. vim.inspect(err),
-            vim.log.levels.ERROR
-        )
-    end
 end
 
 --- @param options agentic.acp.PermissionOption[]
@@ -151,97 +67,448 @@ function PermissionManager._sort_permission_options(options)
     return sorted
 end
 
---- Complete the current request and process next in queue
---- @param option_id string|nil
-function PermissionManager:_complete_request(option_id)
-    local current = self.current_request
-    if not current then
+--- @return boolean
+function PermissionManager:has_pending()
+    return next(self.pending) ~= nil
+end
+
+--- Register a new permission request. Multiple requests can be pending
+--- simultaneously; out-of-order resolution is supported.
+--- @param request agentic.acp.RequestPermission
+--- @param callback fun(option_id: string|nil)
+function PermissionManager:add_request(request, callback)
+    if not request.toolCall or not request.toolCall.toolCallId then
+        Logger.debug(
+            "PermissionManager: Invalid request - missing toolCall.toolCallId"
+        )
         return
     end
 
-    self.message_writer:remove_permission_buttons(
-        current.button_start_row,
-        current.button_end_row
-    )
-
-    self:_remove_keymaps()
-    self.message_writer:set_permission_reanchor_callback(nil)
-    current.callback(option_id)
-
-    self.current_request = nil
-    self:_process_next()
-end
-
---- Clear all displayed buttons and keymaps, cancel all pending requests
-function PermissionManager:clear()
-    if self.current_request then
-        self.message_writer:remove_permission_buttons(
-            self.current_request.button_start_row,
-            self.current_request.button_end_row
+    local tool_call_id = request.toolCall.toolCallId
+    if self.pending[tool_call_id] then
+        Logger.debug(
+            "PermissionManager: Duplicate request for " .. tool_call_id
         )
-        self:_remove_keymaps()
-        self.message_writer:set_permission_reanchor_callback(nil)
-
-        pcall(self.current_request.callback, nil)
-        self.current_request = nil
+        return
     end
 
-    for _, item in ipairs(self.queue) do
-        local callback = item[3]
-        pcall(callback, nil)
-    end
+    local sorted_options = self._sort_permission_options(request.options)
 
-    self.queue = {}
+    --- @type agentic.ui.PermissionManager.PermissionRequest
+    local pending_req = {
+        tool_call_id = tool_call_id,
+        request = request,
+        callback = callback,
+        sorted_options = sorted_options,
+    }
+
+    self.pending[tool_call_id] = pending_req
+    table.insert(self._order, tool_call_id)
+
+    self.message_writer:set_permission_state(tool_call_id, {
+        sorted_options = sorted_options,
+        is_focused = false,
+        focused_button_index = 1,
+    })
+
+    if self.focused_id == nil then
+        self:_set_focus(tool_call_id)
+    else
+        self.message_writer:repaint_status_row(tool_call_id)
+    end
 end
 
---- Remove permission request for a specific tool call ID (e.g., when tool call fails)
---- @param toolCallId string
-function PermissionManager:remove_request_by_tool_call_id(toolCallId)
-    self.queue = vim.tbl_filter(function(item)
-        return item[1] ~= toolCallId
-    end, self.queue)
-
-    if
-        self.current_request
-        and self.current_request.toolCallId == toolCallId
-    then
-        self:_complete_request(nil)
+--- Move button focus within the currently focused block. Wraps. No-op when
+--- no block is focused or it has zero options.
+--- @param direction integer 1 = right (l), -1 = left (h)
+--- @protected
+function PermissionManager:_cycle_button(direction)
+    if not self.focused_id then
+        return
     end
+    local pending = self.pending[self.focused_id]
+    if not pending then
+        return
+    end
+    local n = #pending.sorted_options
+    if n == 0 then
+        return
+    end
+
+    local current = self.message_writer:get_focused_button_index(
+        self.focused_id
+    ) or 1
+    local new_idx = ((current - 1 + direction + n) % n) + 1
+
+    self.message_writer:set_permission_state(self.focused_id, {
+        sorted_options = pending.sorted_options,
+        is_focused = true,
+        focused_button_index = new_idx,
+    })
+    self.message_writer:repaint_status_row(self.focused_id)
 end
 
---- @param option_mapping table<integer, string> Mapping from number (1-N) to option_id
-function PermissionManager:_setup_keymaps(option_mapping)
-    self:_remove_keymaps()
+--- Resolve the focused block with its currently focused button's option.
+--- @protected
+function PermissionManager:_submit_focused_button()
+    if not self.focused_id then
+        return
+    end
+    local pending = self.pending[self.focused_id]
+    if not pending then
+        return
+    end
+    local idx = self.message_writer:get_focused_button_index(self.focused_id)
+        or 1
+    local opt = pending.sorted_options[idx]
+    if not opt then
+        return
+    end
+    self:resolve(self.focused_id, opt.optionId)
+end
 
-    -- Add buffer-local key mappings for each option
-    for number, option_id in pairs(option_mapping) do
-        local lhs = tostring(number)
-        local callback = function()
-            self:_complete_request(option_id)
+--- Fire the callback for tool_call_id with option_id and remove the request.
+--- If the resolved request was focused, advances focus to next pending head.
+--- @param tool_call_id string
+--- @param option_id string|nil
+function PermissionManager:resolve(tool_call_id, option_id)
+    local request = self.pending[tool_call_id]
+    if not request then
+        return
+    end
+
+    local was_focused = self.focused_id == tool_call_id
+
+    self.pending[tool_call_id] = nil
+    for i, id in ipairs(self._order) do
+        if id == tool_call_id then
+            table.remove(self._order, i)
+            break
         end
+    end
 
-        BufHelpers.keymap_set(self.message_writer.bufnr, "n", lhs, callback, {
-            desc = "Select permission option " .. tostring(number),
-        })
+    self.message_writer:set_permission_state(tool_call_id, nil)
 
-        table.insert(self.keymap_info, { mode = "n", lhs = lhs })
+    pcall(request.callback, option_id)
+
+    -- Repaint the resolved block (no longer pending → status word only).
+    -- Skip this when the focused request was resolved, because _set_focus
+    -- below will handle the repaint as part of the focus transition.
+    if not was_focused then
+        self.message_writer:repaint_status_row(tool_call_id)
+    end
+
+    if was_focused then
+        local next_id = self._order[1]
+        self:_set_focus(next_id)
     end
 end
 
-function PermissionManager:_remove_keymaps()
+--- Clear all pending requests (e.g. on session stop or teardown). Fires every
+--- pending callback with nil.
+function PermissionManager:clear()
+    --- @type string[]
+    local ids = {}
+    for _, tool_call_id in ipairs(self._order) do
+        table.insert(ids, tool_call_id)
+    end
+
+    for _, tool_call_id in ipairs(ids) do
+        local request = self.pending[tool_call_id]
+        if request then
+            self.pending[tool_call_id] = nil
+            self.message_writer:set_permission_state(tool_call_id, nil)
+            pcall(request.callback, nil)
+        end
+    end
+
+    self._order = {}
+    self:_remove_focus_keymaps()
+    self.focused_id = nil
+
+    for _, tool_call_id in ipairs(ids) do
+        self.message_writer:repaint_status_row(tool_call_id)
+    end
+end
+
+--- Remove permission request for a specific tool call ID (e.g. when tool call
+--- fails before user granted it). Equivalent to resolve with nil option_id.
+--- @param tool_call_id string
+function PermissionManager:remove_request_by_tool_call_id(tool_call_id)
+    if self.pending[tool_call_id] then
+        self:resolve(tool_call_id, nil)
+    end
+end
+
+--- Set focus to new_id (may be nil to clear focus). Repaints the previously
+--- focused block (if still pending) and the new focused block, rotates the
+--- focus keymaps (digits + h/l/<CR>), and jumps the cursor to the new
+--- focused row. Resets focused_button_index to 1 on every block-focus change.
+--- @param new_id string|nil
+--- @protected
+function PermissionManager:_set_focus(new_id)
+    local old_id = self.focused_id
+    if new_id == old_id then
+        return
+    end
+
+    self.focused_id = new_id
+
+    if old_id and self.pending[old_id] then
+        self.message_writer:set_permission_state(old_id, {
+            sorted_options = self.pending[old_id].sorted_options,
+            is_focused = false,
+            focused_button_index = 1,
+        })
+        self.message_writer:repaint_status_row(old_id)
+    end
+
+    self:_remove_focus_keymaps()
+
+    if new_id == nil then
+        return
+    end
+
+    local pending = self.pending[new_id]
+    if not pending then
+        self.focused_id = nil
+        return
+    end
+
+    --- @type table<integer, string>
+    local mapping = {}
+    for i, opt in ipairs(pending.sorted_options) do
+        if i > MAX_DIGIT_KEYS then
+            break
+        end
+        mapping[i] = opt.optionId
+    end
+    self:_install_focus_keymaps(new_id, mapping)
+
+    self.message_writer:set_permission_state(new_id, {
+        sorted_options = pending.sorted_options,
+        is_focused = true,
+        focused_button_index = 1,
+    })
+    self.message_writer:repaint_status_row(new_id)
+    self:_jump_cursor_to(new_id)
+end
+
+--- @param direction integer 1 for next, -1 for previous
+--- @protected
+function PermissionManager:_cycle_focus(direction)
+    local n = #self._order
+    if n == 0 then
+        return
+    end
+
+    local current_idx = nil
+    if self.focused_id then
+        for i, id in ipairs(self._order) do
+            if id == self.focused_id then
+                current_idx = i
+                break
+            end
+        end
+    end
+
+    if not current_idx then
+        self:_set_focus(self._order[1])
+        return
+    end
+
+    local new_idx = ((current_idx - 1 + direction + n) % n) + 1
+    local target_id = self._order[new_idx]
+
+    -- Single-pending case (or cycle landing on same id): focus is unchanged
+    -- but the user still expects the cursor to jump back onto the focused row.
+    if target_id == self.focused_id then
+        self:_jump_cursor_to(target_id)
+        return
+    end
+
+    self:_set_focus(target_id)
+end
+
+--- Install the configured block-cycle keymaps (`cycle_next` / `cycle_prev`)
+--- on the chat buffer. Permanent. No-op when there are no pending blocks.
+--- @protected
+function PermissionManager:_install_cycle_keymaps()
+    if self._cycle_keymaps_installed then
+        return
+    end
+    self._cycle_keymaps_installed = true
+
+    local cfg = (Config.keymaps and Config.keymaps.permission) or {}
+    BufHelpers.multi_keymap_set(
+        cfg.cycle_next or "<C-n>",
+        self.message_writer.bufnr,
+        function()
+            self:_cycle_focus(1)
+        end,
+        { desc = "Permission: focus next pending tool call" }
+    )
+    BufHelpers.multi_keymap_set(
+        cfg.cycle_prev or "<C-p>",
+        self.message_writer.bufnr,
+        function()
+            self:_cycle_focus(-1)
+        end,
+        { desc = "Permission: focus previous pending tool call" }
+    )
+end
+
+--- Install the per-block focus keymaps: digits 1..N for direct dispatch,
+--- h / l / <Left> / <Right> for button-focus cycling, and <CR> for submit.
+--- All keymaps are `expr = true`: they only fire when the cursor is on the
+--- focused block's row N. Off-row, they fall through to the original key so
+--- the user can navigate / count normally. The digit mapping and focused_id
+--- are captured in the closure at install time (snapshot).
+--- @param focused_id string Snapshot of focused id at install time
+--- @param mapping table<integer, string> Snapshot of digit -> option_id at install time
+--- @protected
+function PermissionManager:_install_focus_keymaps(focused_id, mapping)
+    --- @type table<integer, string>
+    local snapshot = {}
+    for k, v in pairs(mapping) do
+        snapshot[k] = v
+    end
+
+    --- Build an expr-keymap callback that runs `action` only when the cursor
+    --- is on the focused row. Off-row, returns `fallback_keys` (typed via
+    --- noremap), giving the user normal cursor / count behavior.
+    --- @param fallback_keys string
+    --- @param action fun()
+    --- @return fun(): string
+    local function gated(fallback_keys, action)
+        return function()
+            if self:_cursor_on_focused_row() then
+                action()
+                return ""
+            end
+            return fallback_keys
+        end
+    end
+
+    local bufnr = self.message_writer.bufnr
+
+    for i = 1, MAX_DIGIT_KEYS do
+        local option_id = snapshot[i]
+        if option_id then
+            local digit = tostring(i)
+            BufHelpers.keymap_set(
+                bufnr,
+                "n",
+                digit,
+                gated(digit, function()
+                    self:resolve(focused_id, option_id)
+                end),
+                {
+                    desc = "Permission: select option " .. digit,
+                    expr = true,
+                }
+            )
+        end
+    end
+
+    local prev_button = function()
+        self:_cycle_button(-1)
+    end
+    local next_button = function()
+        self:_cycle_button(1)
+    end
+
+    for _, lhs in ipairs({ "h", "<Left>" }) do
+        BufHelpers.keymap_set(bufnr, "n", lhs, gated(lhs, prev_button), {
+            desc = "Permission: focus previous button",
+            expr = true,
+        })
+    end
+    for _, lhs in ipairs({ "l", "<Right>" }) do
+        BufHelpers.keymap_set(bufnr, "n", lhs, gated(lhs, next_button), {
+            desc = "Permission: focus next button",
+            expr = true,
+        })
+    end
+
+    BufHelpers.keymap_set(
+        bufnr,
+        "n",
+        "<CR>",
+        gated("<CR>", function()
+            self:_submit_focused_button()
+        end),
+        {
+            desc = "Permission: submit focused button",
+            expr = true,
+        }
+    )
+end
+
+--- @return boolean
+--- @protected
+function PermissionManager:_cursor_on_focused_row()
+    if not self.focused_id then
+        return false
+    end
+    local row = self.message_writer:_get_block_end_row(self.focused_id)
+    if not row then
+        return false
+    end
+
+    local bufnr = self.message_writer.bufnr
+    local wins = vim.fn.win_findbuf(bufnr)
+    if #wins == 0 then
+        return false
+    end
+    local cursor_row = vim.api.nvim_win_get_cursor(wins[1])[1]
+    return cursor_row == row + 1
+end
+
+--- @protected
+function PermissionManager:_remove_focus_keymaps()
     if not vim.api.nvim_buf_is_valid(self.message_writer.bufnr) then
         return
     end
 
-    for _, info in ipairs(self.keymap_info) do
+    for i = 1, MAX_DIGIT_KEYS do
         pcall(
             vim.keymap.del,
-            info.mode,
-            info.lhs,
+            "n",
+            tostring(i),
             { buffer = self.message_writer.bufnr }
         )
     end
-    self.keymap_info = {}
+    for _, lhs in ipairs({ "h", "l", "<Left>", "<Right>", "<CR>" }) do
+        pcall(vim.keymap.del, "n", lhs, { buffer = self.message_writer.bufnr })
+    end
+end
+
+--- @param tool_call_id string
+--- @protected
+function PermissionManager:_jump_cursor_to(tool_call_id)
+    local row = self.message_writer:_get_block_end_row(tool_call_id)
+    if not row then
+        return
+    end
+
+    local bufnr = self.message_writer.bufnr
+    local wins = vim.fn.win_findbuf(bufnr)
+    if #wins == 0 then
+        return
+    end
+    local winid = wins[1]
+
+    local line_count = vim.api.nvim_buf_line_count(bufnr)
+    if row + 1 > line_count then
+        return
+    end
+
+    local col = self.message_writer:_get_first_button_col(tool_call_id) or 0
+    pcall(vim.api.nvim_win_set_cursor, winid, { row + 1, col })
+    vim.api.nvim_win_call(winid, function()
+        vim.cmd("noautocmd normal! zz")
+    end)
 end
 
 return PermissionManager

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -189,18 +189,19 @@ function PermissionManager:resolve(tool_call_id, option_id)
 
     self.message_writer:set_permission_state(tool_call_id, nil)
 
+    -- Repaint BEFORE the callback so the user sees the buttons gone
+    -- immediately. The callback hits the ACP provider; any subsequent
+    -- agent update arrives on a later tick (notifications cross
+    -- `vim.schedule`), so no UI race. _set_focus below cannot do this
+    -- repaint for us because it skips the old-id branch once the id has
+    -- been removed from `pending`, and skips the new-id branch when there
+    -- is no next head.
+    self.message_writer:repaint_status_row(tool_call_id)
+
     pcall(request.callback, option_id)
 
-    -- Repaint the resolved block (no longer pending → status word only).
-    -- Skip this when the focused request was resolved, because _set_focus
-    -- below will handle the repaint as part of the focus transition.
-    if not was_focused then
-        self.message_writer:repaint_status_row(tool_call_id)
-    end
-
     if was_focused then
-        local next_id = self._order[1]
-        self:_set_focus(next_id)
+        self:_set_focus(self._order[1])
     end
 end
 
@@ -331,7 +332,9 @@ function PermissionManager:_cycle_focus(direction)
 end
 
 --- Install the configured block-cycle keymaps (`cycle_next` / `cycle_prev`)
---- on the chat buffer. Permanent. No-op when there are no pending blocks.
+--- on the chat buffer. The keymaps stay installed for the lifetime of the
+--- PermissionManager; their callback (`_cycle_focus`) returns early when
+--- `_order` is empty, so pressing the key with no pending blocks is a no-op.
 --- @protected
 function PermissionManager:_install_cycle_keymaps()
     if self._cycle_keymaps_installed then
@@ -377,13 +380,17 @@ function PermissionManager:_install_focus_keymaps(focused_id, mapping)
     --- Build an expr-keymap callback that runs `action` only when the cursor
     --- is on the focused row. Off-row, returns `fallback_keys` (typed via
     --- noremap), giving the user normal cursor / count behavior.
+    --- On-row, defers the action via `vim.schedule` because expr-keymaps run
+    --- inside textlock and cannot call `nvim_buf_set_lines` directly. Without
+    --- the defer, the row-N text rewrite in `repaint_status_row` silently
+    --- fails and the button labels stay visible (only their highlights drop).
     --- @param fallback_keys string
     --- @param action fun()
     --- @return fun(): string
     local function gated(fallback_keys, action)
         return function()
             if self:_cursor_on_focused_row() then
-                action()
+                vim.schedule(action)
                 return ""
             end
             return fallback_keys
@@ -506,8 +513,11 @@ function PermissionManager:_jump_cursor_to(tool_call_id)
 
     local col = self.message_writer:_get_first_button_col(tool_call_id) or 0
     pcall(vim.api.nvim_win_set_cursor, winid, { row + 1, col })
+    -- `zb` (not `zz`) matches the chat auto-scroll convention (`G0zb`),
+    -- anchoring row N near the bottom of the window where the user expects
+    -- new chat content to live.
     vim.api.nvim_win_call(winid, function()
-        vim.cmd("noautocmd normal! zz")
+        vim.cmd("noautocmd normal! zb")
     end)
 end
 

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -1,4 +1,3 @@
---- @diagnostic disable: invisible
 local BufHelpers = require("agentic.utils.buf_helpers")
 local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
@@ -30,24 +29,41 @@ local MAX_DIGIT_KEYS = 4
 --- @field pending table<string, agentic.ui.PermissionManager.PermissionRequest> Pending requests keyed by tool_call_id
 --- @field _order string[] Insertion order of pending tool_call_ids
 --- @field focused_id? string Currently focused tool_call_id
---- @field _cycle_keymaps_installed boolean Whether the cycle_next / cycle_prev keymaps are installed on the chat buffer
 local PermissionManager = {}
 PermissionManager.__index = PermissionManager
 
 --- @param message_writer agentic.ui.MessageWriter
 --- @return agentic.ui.PermissionManager
 function PermissionManager:new(message_writer)
-    local instance = setmetatable({
+    self = setmetatable({
         message_writer = message_writer,
         pending = {},
         _order = {},
         focused_id = nil,
-        _cycle_keymaps_installed = false,
     }, self)
 
-    instance:_install_cycle_keymaps()
+    -- Cycle keymaps stay installed for the lifetime of the PermissionManager;
+    -- their callback returns early when `_order` is empty, so pressing the key
+    -- with no pending blocks is a no-op.
+    local cfg = (Config.keymaps and Config.keymaps.permission) or {}
+    BufHelpers.multi_keymap_set(
+        cfg.cycle_next or "<C-n>",
+        message_writer.bufnr,
+        function()
+            self:_cycle_focus(1)
+        end,
+        { desc = "Permission: focus next pending tool call" }
+    )
+    BufHelpers.multi_keymap_set(
+        cfg.cycle_prev or "<C-p>",
+        message_writer.bufnr,
+        function()
+            self:_cycle_focus(-1)
+        end,
+        { desc = "Permission: focus previous pending tool call" }
+    )
 
-    return instance
+    return self
 end
 
 --- @param options agentic.acp.PermissionOption[]
@@ -81,6 +97,7 @@ function PermissionManager:add_request(request, callback)
         Logger.debug(
             "PermissionManager: Invalid request - missing toolCall.toolCallId"
         )
+        pcall(callback, nil)
         return
     end
 
@@ -89,6 +106,7 @@ function PermissionManager:add_request(request, callback)
         Logger.debug(
             "PermissionManager: Duplicate request for " .. tool_call_id
         )
+        pcall(callback, nil)
         return
     end
 
@@ -105,15 +123,14 @@ function PermissionManager:add_request(request, callback)
     self.pending[tool_call_id] = pending_req
     table.insert(self._order, tool_call_id)
 
-    self.message_writer:set_permission_state(tool_call_id, {
-        sorted_options = sorted_options,
-        is_focused = false,
-        focused_button_index = 1,
-    })
-
     if self.focused_id == nil then
         self:_set_focus(tool_call_id)
     else
+        self.message_writer:set_permission_state(tool_call_id, {
+            sorted_options = sorted_options,
+            is_focused = false,
+            focused_button_index = 1,
+        })
         self.message_writer:repaint_status_row(tool_call_id)
     end
 end
@@ -276,15 +293,7 @@ function PermissionManager:_set_focus(new_id)
         return
     end
 
-    --- @type table<integer, string>
-    local mapping = {}
-    for i, opt in ipairs(pending.sorted_options) do
-        if i > MAX_DIGIT_KEYS then
-            break
-        end
-        mapping[i] = opt.optionId
-    end
-    self:_install_focus_keymaps(new_id, mapping)
+    self:_install_focus_keymaps(pending)
 
     self.message_writer:set_permission_state(new_id, {
         sorted_options = pending.sorted_options,
@@ -296,7 +305,6 @@ function PermissionManager:_set_focus(new_id)
 end
 
 --- @param direction integer 1 for next, -1 for previous
---- @protected
 function PermissionManager:_cycle_focus(direction)
     local n = #self._order
     if n == 0 then
@@ -331,53 +339,15 @@ function PermissionManager:_cycle_focus(direction)
     self:_set_focus(target_id)
 end
 
---- Install the configured block-cycle keymaps (`cycle_next` / `cycle_prev`)
---- on the chat buffer. The keymaps stay installed for the lifetime of the
---- PermissionManager; their callback (`_cycle_focus`) returns early when
---- `_order` is empty, so pressing the key with no pending blocks is a no-op.
---- @protected
-function PermissionManager:_install_cycle_keymaps()
-    if self._cycle_keymaps_installed then
-        return
-    end
-    self._cycle_keymaps_installed = true
-
-    local cfg = (Config.keymaps and Config.keymaps.permission) or {}
-    BufHelpers.multi_keymap_set(
-        cfg.cycle_next or "<C-n>",
-        self.message_writer.bufnr,
-        function()
-            self:_cycle_focus(1)
-        end,
-        { desc = "Permission: focus next pending tool call" }
-    )
-    BufHelpers.multi_keymap_set(
-        cfg.cycle_prev or "<C-p>",
-        self.message_writer.bufnr,
-        function()
-            self:_cycle_focus(-1)
-        end,
-        { desc = "Permission: focus previous pending tool call" }
-    )
-end
-
 --- Install the per-block focus keymaps: digits 1..N for direct dispatch,
 --- h / l / <Left> / <Right> for button-focus cycling, and <CR> for submit.
 --- Digits fire from anywhere in the chat buffer (direct dispatch is the whole
 --- point of inline permissions). Motion / submit keys are `expr = true` and
 --- only fire on the focused block's row N; off-row they return the original
---- key so the user can navigate / count normally. The digit mapping and
---- focused_id are captured in the closure at install time (snapshot).
---- @param focused_id string Snapshot of focused id at install time
---- @param mapping table<integer, string> Snapshot of digit -> option_id at install time
+--- key so the user can navigate / count normally.
+--- @param pending agentic.ui.PermissionManager.PermissionRequest
 --- @protected
-function PermissionManager:_install_focus_keymaps(focused_id, mapping)
-    --- @type table<integer, string>
-    local snapshot = {}
-    for k, v in pairs(mapping) do
-        snapshot[k] = v
-    end
-
+function PermissionManager:_install_focus_keymaps(pending)
     --- Build an expr-keymap callback that runs `action` only when the cursor
     --- is on the focused row. Off-row, returns `fallback_keys` (typed via
     --- noremap), giving the user normal cursor / count behavior.
@@ -400,16 +370,17 @@ function PermissionManager:_install_focus_keymaps(focused_id, mapping)
 
     local bufnr = self.message_writer.bufnr
 
-    for i = 1, MAX_DIGIT_KEYS do
-        local option_id = snapshot[i]
-        if option_id then
-            local digit = tostring(i)
-            BufHelpers.keymap_set(bufnr, "n", digit, function()
-                self:resolve(focused_id, option_id)
-            end, {
-                desc = "Permission: select option " .. digit,
-            })
+    for i, opt in ipairs(pending.sorted_options) do
+        if i > MAX_DIGIT_KEYS then
+            break
         end
+        local digit = tostring(i)
+        local option_id = opt.optionId
+        BufHelpers.keymap_set(bufnr, "n", digit, function()
+            self:resolve(pending.tool_call_id, option_id)
+        end, {
+            desc = "Permission: select option " .. digit,
+        })
     end
 
     local prev_button = function()
@@ -446,23 +417,38 @@ function PermissionManager:_install_focus_keymaps(focused_id, mapping)
     )
 end
 
+--- Find the first focusable window showing the chat buffer. The chat buffer
+--- may also live in a non-focusable float (`ChatWidget._hidden_chat_winid`)
+--- while the widget is hidden; cursor moves there are invisible to the user,
+--- so we skip those windows.
+--- @return integer|nil winid
+--- @protected
+function PermissionManager:_find_visible_chat_winid()
+    for _, winid in ipairs(vim.fn.win_findbuf(self.message_writer.bufnr)) do
+        if vim.api.nvim_win_get_config(winid).focusable then
+            return winid
+        end
+    end
+    return nil
+end
+
 --- @return boolean
 --- @protected
 function PermissionManager:_cursor_on_focused_row()
     if not self.focused_id then
         return false
     end
+    --- @diagnostic disable-next-line: invisible
     local row = self.message_writer:_get_block_end_row(self.focused_id)
     if not row then
         return false
     end
 
-    local bufnr = self.message_writer.bufnr
-    local wins = vim.fn.win_findbuf(bufnr)
-    if #wins == 0 then
+    local winid = self:_find_visible_chat_winid()
+    if not winid then
         return false
     end
-    local cursor_row = vim.api.nvim_win_get_cursor(wins[1])[1]
+    local cursor_row = vim.api.nvim_win_get_cursor(winid)[1]
     return cursor_row == row + 1
 end
 
@@ -484,23 +470,23 @@ end
 --- @param tool_call_id string
 --- @protected
 function PermissionManager:_jump_cursor_to(tool_call_id)
+    --- @diagnostic disable-next-line: invisible
     local row = self.message_writer:_get_block_end_row(tool_call_id)
     if not row then
         return
     end
 
-    local bufnr = self.message_writer.bufnr
-    local wins = vim.fn.win_findbuf(bufnr)
-    if #wins == 0 then
+    local winid = self:_find_visible_chat_winid()
+    if not winid then
         return
     end
-    local winid = wins[1]
 
-    local line_count = vim.api.nvim_buf_line_count(bufnr)
+    local line_count = vim.api.nvim_buf_line_count(self.message_writer.bufnr)
     if row + 1 > line_count then
         return
     end
 
+    --- @diagnostic disable-next-line: invisible
     local col = self.message_writer:_get_first_button_col(tool_call_id) or 0
     pcall(vim.api.nvim_win_set_cursor, winid, { row + 1, col })
     -- `zb` (not `zz`) matches the chat auto-scroll convention (`G0zb`),

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -236,6 +236,7 @@ function PermissionManager:clear()
         if request then
             self.pending[tool_call_id] = nil
             self.message_writer:set_permission_state(tool_call_id, nil)
+            self.message_writer:repaint_status_row(tool_call_id)
             pcall(request.callback, nil)
         end
     end
@@ -243,10 +244,6 @@ function PermissionManager:clear()
     self._order = {}
     self:_remove_focus_keymaps()
     self.focused_id = nil
-
-    for _, tool_call_id in ipairs(ids) do
-        self.message_writer:repaint_status_row(tool_call_id)
-    end
 end
 
 --- Remove permission request for a specific tool call ID (e.g. when tool call

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -81,6 +81,9 @@ describe("agentic.ui.PermissionManager", function()
 
     before_each(function()
         schedule_stub = spy.stub(vim, "schedule")
+        schedule_stub:invokes(function(fn)
+            fn()
+        end)
 
         MessageWriter = require("agentic.ui.message_writer")
         PermissionManager = require("agentic.ui.permission_manager")
@@ -678,6 +681,65 @@ describe("agentic.ui.PermissionManager", function()
             assert.is_false(pm:has_pending())
             assert.is_false(has_buf_keymap("n", "1"))
         end)
+    end)
+
+    describe("resolve hygiene", function()
+        --- @param tool_call_id string
+        --- @return string
+        local function status_row_text(tool_call_id)
+            local row = writer:_get_block_end_row(tool_call_id) or 0
+            return vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
+                or ""
+        end
+
+        it("strips buttons from row N as soon as the user resolves", function()
+            seed_block("tc-only")
+            local cb = spy.new(function() end)
+            pm:add_request(make_request("tc-only"), cb --[[@as function]])
+
+            assert.truthy(status_row_text("tc-only"):find("Allow"))
+
+            local digit_cb = (function()
+                for _, km in ipairs(vim.api.nvim_buf_get_keymap(bufnr, "n")) do
+                    if km.lhs == "1" then
+                        return km.callback
+                    end
+                end
+                return nil
+            end)()
+            assert.is_not_nil(digit_cb)
+            if digit_cb then
+                digit_cb()
+            end
+
+            assert.spy(cb).was.called(1)
+            local text = status_row_text("tc-only")
+            assert.is_nil(text:find("Allow"))
+            assert.is_nil(text:find("Reject"))
+            assert.truthy(text:find("pending"))
+        end)
+
+        it(
+            "strips buttons from a non-focused block when it is resolved",
+            function()
+                seed_block("tc-1")
+                seed_block("tc-2")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+                pm:add_request(
+                    make_request("tc-2"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                pm:resolve("tc-2", nil)
+
+                local text = status_row_text("tc-2")
+                assert.is_nil(text:find("Allow"))
+                assert.is_nil(text:find("Reject"))
+            end
+        )
     end)
 
     describe("remove_request_by_tool_call_id", function()

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -21,7 +21,7 @@ describe("agentic.ui.PermissionManager", function()
     --- Build a permission request with the given tool_call_id. Defaults to
     --- one allow_once + one reject_once option; pass opts.options to override.
     --- @param tool_call_id string
-    --- @param opts? { options?: agentic.acp.PermissionOption[] }
+    --- @param opts { options?: agentic.acp.PermissionOption[] }|nil
     --- @return agentic.acp.RequestPermission
     local function make_request(tool_call_id, opts)
         local options = opts and opts.options

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -391,17 +391,6 @@ describe("agentic.ui.PermissionManager", function()
     end)
 
     describe("button-level focus (h / l / <CR>)", function()
-        --- @param lhs string
-        --- @return function|nil
-        local function get_keymap_callback(lhs)
-            for _, km in ipairs(vim.api.nvim_buf_get_keymap(bufnr, "n")) do
-                if km.lhs == lhs then
-                    return km.callback
-                end
-            end
-            return nil
-        end
-
         it(
             "resets focused_button_index to 1 on each block focus change",
             function()
@@ -419,7 +408,7 @@ describe("agentic.ui.PermissionManager", function()
 
                 assert.equal(1, writer:get_focused_button_index("tc-1"))
 
-                local l_cb = get_keymap_callback("l")
+                local l_cb = get_digit_callback("l")
                 assert.is_not_nil(l_cb)
                 if l_cb then
                     l_cb()
@@ -440,7 +429,7 @@ describe("agentic.ui.PermissionManager", function()
                 spy.new(function() end) --[[@as function]]
             )
 
-            local l_cb = get_keymap_callback("l")
+            local l_cb = get_digit_callback("l")
             assert.is_not_nil(l_cb)
             if l_cb then
                 l_cb()
@@ -457,7 +446,7 @@ describe("agentic.ui.PermissionManager", function()
                 spy.new(function() end) --[[@as function]]
             )
 
-            local h_cb = get_keymap_callback("h")
+            local h_cb = get_digit_callback("h")
             assert.is_not_nil(h_cb)
             if h_cb then
                 h_cb() -- wraps from 1 to last (2)
@@ -474,8 +463,8 @@ describe("agentic.ui.PermissionManager", function()
                 local cb = spy.new(function() end)
                 pm:add_request(make_request("tc-1"), cb --[[@as function]])
 
-                local l_cb = get_keymap_callback("l")
-                local cr_cb = get_keymap_callback("<CR>")
+                local l_cb = get_digit_callback("l")
+                local cr_cb = get_digit_callback("<CR>")
                 assert.is_not_nil(l_cb)
                 assert.is_not_nil(cr_cb)
                 if l_cb then
@@ -517,8 +506,8 @@ describe("agentic.ui.PermissionManager", function()
                     spy.new(function() end) --[[@as function]]
                 )
 
-                local right_cb = get_keymap_callback("<Right>")
-                local left_cb = get_keymap_callback("<Left>")
+                local right_cb = get_digit_callback("<Right>")
+                local left_cb = get_digit_callback("<Left>")
                 assert.is_not_nil(right_cb)
                 assert.is_not_nil(left_cb)
                 if right_cb then
@@ -542,9 +531,9 @@ describe("agentic.ui.PermissionManager", function()
                 -- Move cursor off the focused row.
                 vim.api.nvim_win_set_cursor(winid, { 1, 0 })
 
-                local l_cb = get_keymap_callback("l")
-                local cr_cb = get_keymap_callback("<CR>")
-                local digit_cb = get_keymap_callback("1")
+                local l_cb = get_digit_callback("l")
+                local cr_cb = get_digit_callback("<CR>")
+                local digit_cb = get_digit_callback("1")
                 assert.is_not_nil(l_cb)
                 assert.is_not_nil(cr_cb)
                 assert.is_not_nil(digit_cb)
@@ -699,14 +688,7 @@ describe("agentic.ui.PermissionManager", function()
 
             assert.truthy(status_row_text("tc-only"):find("Allow"))
 
-            local digit_cb = (function()
-                for _, km in ipairs(vim.api.nvim_buf_get_keymap(bufnr, "n")) do
-                    if km.lhs == "1" then
-                        return km.callback
-                    end
-                end
-                return nil
-            end)()
+            local digit_cb = get_digit_callback("1")
             assert.is_not_nil(digit_cb)
             if digit_cb then
                 digit_cb()

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -274,10 +274,27 @@ describe("agentic.ui.PermissionManager", function()
     end)
 
     describe("bracket cycle", function()
-        it("installs the configured cycle_next / cycle_prev keymaps", function()
-            assert.is_true(has_buf_keymap("n", "<C-N>"))
-            assert.is_true(has_buf_keymap("n", "<C-P>"))
-        end)
+        it(
+            "installs cycle keymaps only while permissions are pending",
+            function()
+                assert.is_false(has_buf_keymap("n", "<C-N>"))
+                assert.is_false(has_buf_keymap("n", "<C-P>"))
+
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                assert.is_true(has_buf_keymap("n", "<C-N>"))
+                assert.is_true(has_buf_keymap("n", "<C-P>"))
+
+                pm:resolve("tc-1", "allow-once")
+
+                assert.is_false(has_buf_keymap("n", "<C-N>"))
+                assert.is_false(has_buf_keymap("n", "<C-P>"))
+            end
+        )
 
         it("forward cycle wraps to first", function()
             seed_block("tc-1")
@@ -711,6 +728,8 @@ describe("agentic.ui.PermissionManager", function()
             assert.is_nil(pm.focused_id)
             assert.is_false(pm:has_pending())
             assert.is_false(has_buf_keymap("n", "1"))
+            assert.is_false(has_buf_keymap("n", "<C-N>"))
+            assert.is_false(has_buf_keymap("n", "<C-P>"))
         end)
     end)
 

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -261,7 +261,7 @@ describe("agentic.ui.PermissionManager", function()
                     spy.new(function() end) --[[@as function]]
                 )
 
-                local end_row_2 = writer:_get_block_end_row("tc-2")
+                local end_row_2 = writer:get_block_end_row("tc-2")
                 assert.is_not_nil(end_row_2)
 
                 pm:_cycle_focus(1)
@@ -338,8 +338,8 @@ describe("agentic.ui.PermissionManager", function()
                     spy.new(function() end) --[[@as function]]
                 )
 
-                local end_row = writer:_get_block_end_row("tc-only")
-                local first_btn_col = writer:_get_first_button_col("tc-only")
+                local end_row = writer:get_block_end_row("tc-only")
+                local first_btn_col = writer:get_button_col("tc-only", 1)
                 assert.is_not_nil(end_row)
 
                 -- Move cursor away from the focused row.
@@ -439,6 +439,32 @@ describe("agentic.ui.PermissionManager", function()
             end
         end)
 
+        it(
+            "l moves cursor to the start col of the newly focused button",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                local end_row = writer:get_block_end_row("tc-1")
+                assert.is_not_nil(end_row)
+
+                local l_cb = get_digit_callback("l")
+                assert.is_not_nil(l_cb)
+                if l_cb then
+                    l_cb()
+                end
+
+                local expected_col = writer:get_button_col("tc-1", 2)
+                assert.is_not_nil(expected_col)
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((end_row or 0) + 1, cursor[1])
+                assert.equal(expected_col, cursor[2])
+            end
+        )
+
         it("h cycles button focus backward and wraps", function()
             seed_block("tc-1")
             pm:add_request(
@@ -486,8 +512,8 @@ describe("agentic.ui.PermissionManager", function()
                 spy.new(function() end) --[[@as function]]
             )
 
-            local end_row = writer:_get_block_end_row("tc-1")
-            local first_btn_col = writer:_get_first_button_col("tc-1")
+            local end_row = writer:get_block_end_row("tc-1")
+            local first_btn_col = writer:get_button_col("tc-1", 1)
             assert.is_not_nil(end_row)
             assert.is_not_nil(first_btn_col)
             assert.is_true((first_btn_col or 0) > 0)
@@ -692,7 +718,7 @@ describe("agentic.ui.PermissionManager", function()
         --- @param tool_call_id string
         --- @return string
         local function status_row_text(tool_call_id)
-            local row = writer:_get_block_end_row(tool_call_id) or 0
+            local row = writer:get_block_end_row(tool_call_id) or 0
             return vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
                 or ""
         end

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -522,7 +522,7 @@ describe("agentic.ui.PermissionManager", function()
         )
 
         it(
-            "keymaps are no-op (fall through) when cursor is off the focused row",
+            "motion / submit keymaps fall through when cursor is off the focused row",
             function()
                 seed_block("tc-1")
                 local cb = spy.new(function() end)
@@ -533,17 +533,12 @@ describe("agentic.ui.PermissionManager", function()
 
                 local l_cb = get_digit_callback("l")
                 local cr_cb = get_digit_callback("<CR>")
-                local digit_cb = get_digit_callback("1")
                 assert.is_not_nil(l_cb)
                 assert.is_not_nil(cr_cb)
-                assert.is_not_nil(digit_cb)
 
                 -- expr=true: returning the original key falls through to default behavior.
                 if l_cb then
                     assert.equal("l", l_cb())
-                end
-                if digit_cb then
-                    assert.equal("1", digit_cb())
                 end
                 if cr_cb then
                     assert.equal("<CR>", cr_cb())
@@ -552,6 +547,27 @@ describe("agentic.ui.PermissionManager", function()
                 -- No resolve fired, button index unchanged.
                 assert.spy(cb).was.called(0)
                 assert.equal(1, writer:get_focused_button_index("tc-1"))
+            end
+        )
+
+        it(
+            "digit keymaps fire from anywhere in the chat buffer (off-row included)",
+            function()
+                seed_block("tc-1")
+                local cb = spy.new(function() end)
+                pm:add_request(make_request("tc-1"), cb --[[@as function]])
+
+                -- Move cursor off the focused row.
+                vim.api.nvim_win_set_cursor(winid, { 1, 0 })
+
+                local digit_cb = get_digit_callback("1")
+                assert.is_not_nil(digit_cb)
+                if digit_cb then
+                    digit_cb()
+                end
+
+                assert.spy(cb).was.called(1)
+                assert.equal("allow-once", cb.calls[1][1])
             end
         )
 

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -17,19 +17,15 @@ describe("agentic.ui.PermissionManager", function()
     local pm
     --- @type TestStub
     local schedule_stub
-    --- @type TestStub
-    local hint_stub
-    --- @type TestStub
-    local hint_style_stub
 
+    --- Build a permission request with the given tool_call_id. Defaults to
+    --- one allow_once + one reject_once option; pass opts.options to override.
+    --- @param tool_call_id string
+    --- @param opts? { options?: agentic.acp.PermissionOption[] }
     --- @return agentic.acp.RequestPermission
-    local function make_request(tool_call_id)
-        return {
-            sessionId = "test-session",
-            toolCall = {
-                toolCallId = tool_call_id,
-            },
-            options = {
+    local function make_request(tool_call_id, opts)
+        local options = opts and opts.options
+            or {
                 {
                     optionId = "allow-once",
                     name = "Allow once",
@@ -40,21 +36,24 @@ describe("agentic.ui.PermissionManager", function()
                     name = "Reject once",
                     kind = "reject_once",
                 },
-            },
+            }
+        return {
+            sessionId = "test-session",
+            toolCall = { toolCallId = tool_call_id },
+            options = options,
         }
     end
 
-    local function inject_content_and_reanchor()
-        vim.bo[bufnr].modifiable = true
-        vim.api.nvim_buf_set_lines(
-            bufnr,
-            -1,
-            -1,
-            false,
-            { "new tool call output line 1", "new tool call output line 2" }
-        )
-        vim.bo[bufnr].modifiable = false
-        writer:_notify_permission_reanchor()
+    --- Write a tool call block so the writer can resolve its row N.
+    --- @param tool_call_id string
+    local function seed_block(tool_call_id)
+        writer:write_tool_call_block({
+            tool_call_id = tool_call_id,
+            status = "pending",
+            kind = "execute",
+            argument = "ls",
+            body = { "output" },
+        })
     end
 
     --- @param mode string
@@ -69,13 +68,19 @@ describe("agentic.ui.PermissionManager", function()
         return false
     end
 
+    --- @param lhs string
+    --- @return function|nil
+    local function get_digit_callback(lhs)
+        for _, km in ipairs(vim.api.nvim_buf_get_keymap(bufnr, "n")) do
+            if km.lhs == lhs then
+                return km.callback
+            end
+        end
+        return nil
+    end
+
     before_each(function()
         schedule_stub = spy.stub(vim, "schedule")
-
-        local DiffPreview = require("agentic.ui.diff_preview")
-        hint_stub = spy.stub(DiffPreview, "add_navigation_hint")
-        hint_stub:returns(nil)
-        hint_style_stub = spy.stub(DiffPreview, "apply_hint_styling")
 
         MessageWriter = require("agentic.ui.message_writer")
         PermissionManager = require("agentic.ui.permission_manager")
@@ -97,8 +102,6 @@ describe("agentic.ui.PermissionManager", function()
 
     after_each(function()
         schedule_stub:revert()
-        hint_stub:revert()
-        hint_style_stub:revert()
 
         if winid and vim.api.nvim_win_is_valid(winid) then
             vim.api.nvim_win_close(winid, true)
@@ -108,206 +111,592 @@ describe("agentic.ui.PermissionManager", function()
         end
     end)
 
-    describe("reanchor permission prompt", function()
-        it("moves buttons to buffer bottom and preserves keymaps", function()
+    describe("concurrent pending map", function()
+        it(
+            "keeps both requests in pending and preserves insertion order",
+            function()
+                seed_block("tc-a")
+                seed_block("tc-b")
+
+                pm:add_request(
+                    make_request("tc-a"),
+                    spy.new(function() end) --[[@as function]]
+                )
+                pm:add_request(
+                    make_request("tc-b"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                assert.is_not_nil(pm.pending["tc-a"])
+                assert.is_not_nil(pm.pending["tc-b"])
+                assert.equal("tc-a", pm._order[1])
+                assert.equal("tc-b", pm._order[2])
+                assert.is_true(pm:has_pending())
+            end
+        )
+
+        it(
+            "fires only the matching callback on resolve and leaves others pending",
+            function()
+                seed_block("tc-a")
+                seed_block("tc-b")
+
+                local cb_a = spy.new(function() end)
+                local cb_b = spy.new(function() end)
+
+                pm:add_request(make_request("tc-a"), cb_a --[[@as function]])
+                pm:add_request(make_request("tc-b"), cb_b --[[@as function]])
+
+                pm:resolve("tc-a", "allow-once")
+
+                assert.spy(cb_a).was.called(1)
+                assert.spy(cb_b).was.called(0)
+                assert.is_nil(pm.pending["tc-a"])
+                assert.is_not_nil(pm.pending["tc-b"])
+            end
+        )
+
+        it("supports out-of-order resolution", function()
+            seed_block("tc-a")
+            seed_block("tc-b")
+
+            local cb_a = spy.new(function() end)
+            local cb_b = spy.new(function() end)
+
+            pm:add_request(make_request("tc-a"), cb_a --[[@as function]])
+            pm:add_request(make_request("tc-b"), cb_b --[[@as function]])
+
+            pm:resolve("tc-b", "reject-once")
+
+            assert.spy(cb_b).was.called(1)
+            assert.spy(cb_a).was.called(0)
+            assert.is_not_nil(pm.pending["tc-a"])
+            assert.is_nil(pm.pending["tc-b"])
+        end)
+    end)
+
+    describe("focus head tracking", function()
+        it(
+            "first arrival sets focused_id and installs digit keymaps",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                assert.equal("tc-1", pm.focused_id)
+                assert.is_true(has_buf_keymap("n", "1"))
+                assert.is_true(has_buf_keymap("n", "2"))
+            end
+        )
+
+        it("subsequent arrivals do not steal focus", function()
+            seed_block("tc-1")
+            seed_block("tc-2")
+
             pm:add_request(
                 make_request("tc-1"),
                 spy.new(function() end) --[[@as function]]
             )
-
-            local line_count_before = vim.api.nvim_buf_line_count(bufnr)
-            inject_content_and_reanchor()
-            local line_count_after = vim.api.nvim_buf_line_count(bufnr)
-
-            assert.is_true(line_count_after > line_count_before)
-
-            local last_lines = vim.api.nvim_buf_get_lines(bufnr, -3, -1, false)
-            local found_permission = false
-            for _, line in ipairs(last_lines) do
-                if line:find("Allow once") or line:find("--- ---") then
-                    found_permission = true
-                    break
-                end
-            end
-            assert.is_true(found_permission)
-
-            assert.is_true(has_buf_keymap("n", "1"))
-            assert.is_true(has_buf_keymap("n", "2"))
-        end)
-
-        it("does not trigger recursive _on_permission_reanchor", function()
-            local notify_spy = spy.on(writer, "_notify_permission_reanchor")
-
             pm:add_request(
                 make_request("tc-2"),
                 spy.new(function() end) --[[@as function]]
             )
 
-            notify_spy:reset()
-            writer:_notify_permission_reanchor()
-
-            assert.equal(1, notify_spy.call_count)
-
-            notify_spy:revert()
+            assert.equal("tc-1", pm.focused_id)
         end)
-    end)
 
-    describe("callback lifecycle", function()
-        it(
-            "_complete_request clears the permission reanchor callback",
-            function()
-                pm:add_request(
-                    make_request("tc-3"),
-                    spy.new(function() end) --[[@as function]]
-                )
+        it("resolving the focused request snaps focus to next head", function()
+            seed_block("tc-1")
+            seed_block("tc-2")
 
-                pm:_complete_request("allow-once")
-
-                assert.is_nil(writer._on_permission_reanchor)
-            end
-        )
-
-        it("clear() clears the permission reanchor callback", function()
             pm:add_request(
-                make_request("tc-4"),
+                make_request("tc-1"),
+                spy.new(function() end) --[[@as function]]
+            )
+            pm:add_request(
+                make_request("tc-2"),
                 spy.new(function() end) --[[@as function]]
             )
 
-            pm:clear()
+            pm:resolve("tc-1", "allow-once")
 
-            assert.is_nil(writer._on_permission_reanchor)
+            assert.equal("tc-2", pm.focused_id)
+        end)
+
+        it(
+            "clears focus and removes digit keymaps when queue drains",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+                assert.is_true(has_buf_keymap("n", "1"))
+
+                pm:resolve("tc-1", "allow-once")
+
+                assert.is_nil(pm.focused_id)
+                assert.is_false(has_buf_keymap("n", "1"))
+                assert.is_false(has_buf_keymap("n", "2"))
+            end
+        )
+
+        it(
+            "jumps the cursor to row N of the new focused block on focus change",
+            function()
+                seed_block("tc-1")
+                seed_block("tc-2")
+
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+                pm:add_request(
+                    make_request("tc-2"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                local end_row_2 = writer:_get_block_end_row("tc-2")
+                assert.is_not_nil(end_row_2)
+
+                pm:_cycle_focus(1)
+                assert.equal("tc-2", pm.focused_id)
+
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal(end_row_2 + 1, cursor[1])
+            end
+        )
+    end)
+
+    describe("bracket cycle", function()
+        it("installs the configured cycle_next / cycle_prev keymaps", function()
+            assert.is_true(has_buf_keymap("n", "<C-N>"))
+            assert.is_true(has_buf_keymap("n", "<C-P>"))
+        end)
+
+        it("forward cycle wraps to first", function()
+            seed_block("tc-1")
+            seed_block("tc-2")
+            seed_block("tc-3")
+
+            pm:add_request(
+                make_request("tc-1"),
+                spy.new(function() end) --[[@as function]]
+            )
+            pm:add_request(
+                make_request("tc-2"),
+                spy.new(function() end) --[[@as function]]
+            )
+            pm:add_request(
+                make_request("tc-3"),
+                spy.new(function() end) --[[@as function]]
+            )
+
+            pm:_cycle_focus(1)
+            assert.equal("tc-2", pm.focused_id)
+            pm:_cycle_focus(1)
+            assert.equal("tc-3", pm.focused_id)
+            pm:_cycle_focus(1)
+            assert.equal("tc-1", pm.focused_id)
+        end)
+
+        it("backward cycle wraps to last", function()
+            seed_block("tc-1")
+            seed_block("tc-2")
+            seed_block("tc-3")
+
+            pm:add_request(
+                make_request("tc-1"),
+                spy.new(function() end) --[[@as function]]
+            )
+            pm:add_request(
+                make_request("tc-2"),
+                spy.new(function() end) --[[@as function]]
+            )
+            pm:add_request(
+                make_request("tc-3"),
+                spy.new(function() end) --[[@as function]]
+            )
+
+            pm:_cycle_focus(-1)
+            assert.equal("tc-3", pm.focused_id)
+            pm:_cycle_focus(-1)
+            assert.equal("tc-2", pm.focused_id)
+        end)
+
+        it(
+            "cycle_next / cycle_prev jumps cursor to the focused row even with only one pending block",
+            function()
+                seed_block("tc-only")
+                pm:add_request(
+                    make_request("tc-only"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                local end_row = writer:_get_block_end_row("tc-only")
+                local first_btn_col = writer:_get_first_button_col("tc-only")
+                assert.is_not_nil(end_row)
+
+                -- Move cursor away from the focused row.
+                vim.api.nvim_win_set_cursor(winid, { 1, 0 })
+
+                pm:_cycle_focus(1)
+
+                assert.equal("tc-only", pm.focused_id)
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((end_row or 0) + 1, cursor[1])
+                assert.equal(first_btn_col, cursor[2])
+            end
+        )
+
+        it("cycle is a no-op when pending is empty", function()
+            assert.has_no_errors(function()
+                pm:_cycle_focus(1)
+                pm:_cycle_focus(-1)
+            end)
+            assert.is_nil(pm.focused_id)
+        end)
+
+        it("focus transition triggers exactly 2 status-row repaints", function()
+            seed_block("tc-1")
+            seed_block("tc-2")
+
+            pm:add_request(
+                make_request("tc-1"),
+                spy.new(function() end) --[[@as function]]
+            )
+            pm:add_request(
+                make_request("tc-2"),
+                spy.new(function() end) --[[@as function]]
+            )
+
+            local repaint_spy = spy.on(writer, "repaint_status_row")
+            pm:_cycle_focus(1)
+
+            assert.equal(2, repaint_spy.call_count)
+            local ids = {}
+            for _, call in ipairs(repaint_spy.calls) do
+                ids[call[2]] = true
+            end
+            assert.is_true(ids["tc-1"])
+            assert.is_true(ids["tc-2"])
+
+            repaint_spy:revert()
         end)
     end)
 
-    describe("empty line accumulation during reanchor", function()
-        --- @return string[]
-        local function get_lines()
-            return vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-        end
-
-        --- @return integer
-        local function count_trailing_empty_lines()
-            local lines = get_lines()
-            local count = 0
-            for i = #lines, 1, -1 do
-                if lines[i] == "" then
-                    count = count + 1
-                else
-                    break
+    describe("button-level focus (h / l / <CR>)", function()
+        --- @param lhs string
+        --- @return function|nil
+        local function get_keymap_callback(lhs)
+            for _, km in ipairs(vim.api.nvim_buf_get_keymap(bufnr, "n")) do
+                if km.lhs == lhs then
+                    return km.callback
                 end
             end
-            return count
+            return nil
         end
 
         it(
-            "single display+remove leaves exactly one trailing separator",
+            "resets focused_button_index to 1 on each block focus change",
             function()
-                vim.bo[bufnr].modifiable = true
-                vim.api.nvim_buf_set_lines(
-                    bufnr,
-                    0,
-                    -1,
-                    false,
-                    { "line 1", "line 2", "line 3" }
-                )
-                vim.bo[bufnr].modifiable = false
-
-                local lines_before = vim.api.nvim_buf_line_count(bufnr)
+                seed_block("tc-1")
+                seed_block("tc-2")
 
                 pm:add_request(
-                    make_request("tc-sep-1"),
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+                pm:add_request(
+                    make_request("tc-2"),
                     spy.new(function() end) --[[@as function]]
                 )
 
-                assert.is_true(
-                    vim.api.nvim_buf_line_count(bufnr) > lines_before
+                assert.equal(1, writer:get_focused_button_index("tc-1"))
+
+                local l_cb = get_keymap_callback("l")
+                assert.is_not_nil(l_cb)
+                if l_cb then
+                    l_cb()
+                end
+                assert.equal(2, writer:get_focused_button_index("tc-1"))
+
+                -- Cycle block focus; new focused block must start at 1.
+                pm:_cycle_focus(1)
+                assert.equal("tc-2", pm.focused_id)
+                assert.equal(1, writer:get_focused_button_index("tc-2"))
+            end
+        )
+
+        it("l cycles button focus forward and wraps", function()
+            seed_block("tc-1")
+            pm:add_request(
+                make_request("tc-1"),
+                spy.new(function() end) --[[@as function]]
+            )
+
+            local l_cb = get_keymap_callback("l")
+            assert.is_not_nil(l_cb)
+            if l_cb then
+                l_cb()
+                assert.equal(2, writer:get_focused_button_index("tc-1"))
+                l_cb() -- cycles back to 1 (only 2 options)
+                assert.equal(1, writer:get_focused_button_index("tc-1"))
+            end
+        end)
+
+        it("h cycles button focus backward and wraps", function()
+            seed_block("tc-1")
+            pm:add_request(
+                make_request("tc-1"),
+                spy.new(function() end) --[[@as function]]
+            )
+
+            local h_cb = get_keymap_callback("h")
+            assert.is_not_nil(h_cb)
+            if h_cb then
+                h_cb() -- wraps from 1 to last (2)
+                assert.equal(2, writer:get_focused_button_index("tc-1"))
+                h_cb()
+                assert.equal(1, writer:get_focused_button_index("tc-1"))
+            end
+        end)
+
+        it(
+            "<CR> resolves the focused block with focused button's option",
+            function()
+                seed_block("tc-1")
+                local cb = spy.new(function() end)
+                pm:add_request(make_request("tc-1"), cb --[[@as function]])
+
+                local l_cb = get_keymap_callback("l")
+                local cr_cb = get_keymap_callback("<CR>")
+                assert.is_not_nil(l_cb)
+                assert.is_not_nil(cr_cb)
+                if l_cb then
+                    l_cb()
+                end
+                if cr_cb then
+                    cr_cb()
+                end
+
+                assert.spy(cb).was.called(1)
+                assert.equal("reject-once", cb.calls[1][1])
+            end
+        )
+
+        it("places cursor on first button column on block focus", function()
+            seed_block("tc-1")
+            pm:add_request(
+                make_request("tc-1"),
+                spy.new(function() end) --[[@as function]]
+            )
+
+            local end_row = writer:_get_block_end_row("tc-1")
+            local first_btn_col = writer:_get_first_button_col("tc-1")
+            assert.is_not_nil(end_row)
+            assert.is_not_nil(first_btn_col)
+            assert.is_true((first_btn_col or 0) > 0)
+
+            local cursor = vim.api.nvim_win_get_cursor(winid)
+            assert.equal((end_row or 0) + 1, cursor[1])
+            assert.equal(first_btn_col, cursor[2])
+        end)
+
+        it(
+            "<Left> / <Right> are installed and cycle button focus when on row",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
                 )
 
-                pm:_complete_request("allow-once")
-
-                -- remove_permission_buttons replaces the block with {""},
-                -- so buffer should be original lines + 1 separator
-                assert.equal(
-                    lines_before + 1,
-                    vim.api.nvim_buf_line_count(bufnr)
-                )
-                assert.equal(1, count_trailing_empty_lines())
+                local right_cb = get_keymap_callback("<Right>")
+                local left_cb = get_keymap_callback("<Left>")
+                assert.is_not_nil(right_cb)
+                assert.is_not_nil(left_cb)
+                if right_cb then
+                    right_cb()
+                    assert.equal(2, writer:get_focused_button_index("tc-1"))
+                end
+                if left_cb then
+                    left_cb()
+                    assert.equal(1, writer:get_focused_button_index("tc-1"))
+                end
             end
         )
 
         it(
-            "does not accumulate empty lines across multiple reanchors",
+            "keymaps are no-op (fall through) when cursor is off the focused row",
             function()
-                vim.bo[bufnr].modifiable = true
-                vim.api.nvim_buf_set_lines(
-                    bufnr,
-                    0,
-                    -1,
-                    false,
-                    { "line 1", "line 2", "line 3" }
-                )
-                vim.bo[bufnr].modifiable = false
+                seed_block("tc-1")
+                local cb = spy.new(function() end)
+                pm:add_request(make_request("tc-1"), cb --[[@as function]])
 
-                pm:add_request(
-                    make_request("tc-accum-1"),
-                    spy.new(function() end) --[[@as function]]
-                )
+                -- Move cursor off the focused row.
+                vim.api.nvim_win_set_cursor(winid, { 1, 0 })
 
-                -- Simulate 5 reanchor cycles (new content triggers reanchor)
-                for _ = 1, 5 do
-                    inject_content_and_reanchor()
+                local l_cb = get_keymap_callback("l")
+                local cr_cb = get_keymap_callback("<CR>")
+                local digit_cb = get_keymap_callback("1")
+                assert.is_not_nil(l_cb)
+                assert.is_not_nil(cr_cb)
+                assert.is_not_nil(digit_cb)
+
+                -- expr=true: returning the original key falls through to default behavior.
+                if l_cb then
+                    assert.equal("l", l_cb())
+                end
+                if digit_cb then
+                    assert.equal("1", digit_cb())
+                end
+                if cr_cb then
+                    assert.equal("<CR>", cr_cb())
                 end
 
-                pm:_complete_request("allow-once")
-
-                -- Should have exactly 1 trailing empty line, not 1 per cycle
-                assert.equal(1, count_trailing_empty_lines())
+                -- No resolve fired, button index unchanged.
+                assert.spy(cb).was.called(0)
+                assert.equal(1, writer:get_focused_button_index("tc-1"))
             end
         )
+
+        it("h / l / <CR> removed when no block is focused", function()
+            seed_block("tc-1")
+            pm:add_request(
+                make_request("tc-1"),
+                spy.new(function() end) --[[@as function]]
+            )
+            assert.is_true(has_buf_keymap("n", "h"))
+            assert.is_true(has_buf_keymap("n", "l"))
+            assert.is_true(has_buf_keymap("n", "<CR>"))
+
+            pm:resolve("tc-1", "allow-once")
+
+            assert.is_false(has_buf_keymap("n", "h"))
+            assert.is_false(has_buf_keymap("n", "l"))
+            assert.is_false(has_buf_keymap("n", "<CR>"))
+        end)
+    end)
+
+    describe("digit keymap lifecycle", function()
+        it("digit 1 resolves the focused block's option 1", function()
+            seed_block("tc-1")
+            local cb = spy.new(function() end)
+            pm:add_request(make_request("tc-1"), cb --[[@as function]])
+
+            local digit_cb = get_digit_callback("1")
+            assert.is_not_nil(digit_cb)
+            if digit_cb then
+                digit_cb()
+            end
+
+            assert.spy(cb).was.called(1)
+            assert.equal("allow-once", cb.calls[1][1])
+        end)
 
         it(
-            "reanchor preserves single separator between content and buttons",
+            "rebinds digit keymaps with new mapping after focus transition",
             function()
-                vim.bo[bufnr].modifiable = true
-                vim.api.nvim_buf_set_lines(
-                    bufnr,
-                    0,
-                    -1,
-                    false,
-                    { "line 1", "line 2", "line 3" }
-                )
-                vim.bo[bufnr].modifiable = false
+                seed_block("tc-1")
+                seed_block("tc-2")
+
+                local cb_1 = spy.new(function() end)
+                local cb_2 = spy.new(function() end)
 
                 pm:add_request(
-                    make_request("tc-sep-2"),
-                    spy.new(function() end) --[[@as function]]
+                    make_request("tc-1", {
+                        options = {
+                            {
+                                optionId = "opt-1-A",
+                                name = "A",
+                                kind = "allow_once",
+                            },
+                            {
+                                optionId = "opt-1-B",
+                                name = "B",
+                                kind = "reject_once",
+                            },
+                        },
+                    }),
+                    cb_1 --[[@as function]]
+                )
+                pm:add_request(
+                    make_request("tc-2", {
+                        options = {
+                            {
+                                optionId = "opt-2-A",
+                                name = "A",
+                                kind = "allow_once",
+                            },
+                            {
+                                optionId = "opt-2-B",
+                                name = "B",
+                                kind = "reject_once",
+                            },
+                        },
+                    }),
+                    cb_2 --[[@as function]]
                 )
 
-                -- Reanchor once
-                inject_content_and_reanchor()
+                pm:_cycle_focus(1)
+                assert.equal("tc-2", pm.focused_id)
 
-                -- Find last injected content line, then count empty lines after it
-                local lines = get_lines()
-                local last_content_idx = 0
-                for i = 1, #lines do
-                    if lines[i]:find("new tool call output") then
-                        last_content_idx = i
-                    end
+                local digit_cb = get_digit_callback("1")
+                assert.is_not_nil(digit_cb)
+                if digit_cb then
+                    digit_cb()
                 end
-                assert.is_true(last_content_idx > 0)
 
-                local empty_count = 0
-                for i = last_content_idx + 1, #lines do
-                    if lines[i] == "" then
-                        empty_count = empty_count + 1
-                    else
-                        break
-                    end
-                end
-                assert.equal(1, empty_count)
-
-                pm:_complete_request("allow-once")
+                assert.spy(cb_2).was.called(1)
+                assert.equal("opt-2-A", cb_2.calls[1][1])
+                assert.spy(cb_1).was.called(0)
             end
         )
+    end)
+
+    describe("clear", function()
+        it("fires all pending callbacks with nil and clears state", function()
+            seed_block("tc-1")
+            seed_block("tc-2")
+
+            local cb_1 = spy.new(function() end)
+            local cb_2 = spy.new(function() end)
+
+            pm:add_request(make_request("tc-1"), cb_1 --[[@as function]])
+            pm:add_request(make_request("tc-2"), cb_2 --[[@as function]])
+
+            pm:clear()
+
+            assert.spy(cb_1).was.called(1)
+            assert.spy(cb_2).was.called(1)
+            assert.is_nil(cb_1.calls[1][1])
+            assert.is_nil(cb_2.calls[1][1])
+            assert.is_nil(pm.focused_id)
+            assert.is_false(pm:has_pending())
+            assert.is_false(has_buf_keymap("n", "1"))
+        end)
+    end)
+
+    describe("remove_request_by_tool_call_id", function()
+        it("fires the callback with nil and advances focus", function()
+            seed_block("tc-1")
+            seed_block("tc-2")
+
+            local cb_1 = spy.new(function() end)
+            local cb_2 = spy.new(function() end)
+
+            pm:add_request(make_request("tc-1"), cb_1 --[[@as function]])
+            pm:add_request(make_request("tc-2"), cb_2 --[[@as function]])
+
+            pm:remove_request_by_tool_call_id("tc-1")
+
+            assert.spy(cb_1).was.called(1)
+            assert.is_nil(cb_1.calls[1][1])
+            assert.spy(cb_2).was.called(0)
+            assert.equal("tc-2", pm.focused_id)
+        end)
     end)
 end)

--- a/lua/agentic/utils/buf_helpers.lua
+++ b/lua/agentic/utils/buf_helpers.lua
@@ -76,7 +76,7 @@ end
 
 --- Deletes a keymap for a specific buffer.
 --- @param bufnr integer
---- @param mode string
+--- @param mode string|string[]
 --- @param lhs string
 function BufHelpers.keymap_del(bufnr, mode, lhs)
     --- @type table
@@ -116,6 +116,31 @@ function BufHelpers.multi_keymap_set(keymaps, bufnr, callback, opts)
         end
 
         BufHelpers.keymap_set(bufnr, modes, keymap, callback, opts)
+    end
+end
+
+--- Deletes multiple keymaps from a KeymapValue config entry for a specific buffer.
+--- @param keymaps agentic.UserConfig.KeymapValue
+--- @param bufnr integer
+function BufHelpers.multi_keymap_del(keymaps, bufnr)
+    if type(keymaps) == "string" then
+        keymaps = { keymaps }
+    end
+
+    for _, key in ipairs(keymaps) do
+        --- @type string|string[]
+        local modes = "n"
+        --- @type string
+        local keymap
+
+        if type(key) == "table" and key.mode then
+            modes = key.mode
+            keymap = key[1]
+        else
+            keymap = key --[[@as string]]
+        end
+
+        BufHelpers.keymap_del(bufnr, modes, keymap)
     end
 end
 

--- a/lua/agentic/utils/buf_helpers.lua
+++ b/lua/agentic/utils/buf_helpers.lua
@@ -74,6 +74,22 @@ function BufHelpers.keymap_set(bufnr, mode, lhs, rhs, opts)
     vim.keymap.set(mode, lhs, rhs, opts)
 end
 
+--- Deletes a keymap for a specific buffer.
+--- @param bufnr integer
+--- @param mode string
+--- @param lhs string
+function BufHelpers.keymap_del(bufnr, mode, lhs)
+    --- @type table
+    local opts
+    -- See keymap_set for the buffer/buf rename rationale.
+    if vim.fn.has("nvim-0.12.1") == 1 then
+        opts = { buf = bufnr }
+    else
+        opts = { buffer = bufnr }
+    end
+    pcall(vim.keymap.del, mode, lhs, opts)
+end
+
 --- Sets multiple keymaps from a KeymapValue config entry for a specific buffer.
 --- Normalizes the config value (string, string[], or array of string/KeymapEntry)
 --- and calls keymap_set for each binding.

--- a/lua/agentic/utils/buf_helpers.test.lua
+++ b/lua/agentic/utils/buf_helpers.test.lua
@@ -150,6 +150,54 @@ describe("BufHelpers", function()
         end)
     end)
 
+    describe("keymap_del", function()
+        --- @type TestStub
+        local keymap_del_stub
+        --- @type TestStub
+        local has_stub
+
+        before_each(function()
+            keymap_del_stub = spy.stub(vim.keymap, "del")
+            has_stub = spy.stub(vim.fn, "has")
+        end)
+
+        after_each(function()
+            keymap_del_stub:revert()
+            has_stub:revert()
+        end)
+
+        -- See keymap_set tests for the 0.12.0-dev / 0.12.1 rename rationale.
+        it("uses `buffer` opt on Neovim < 0.12.1", function()
+            has_stub:invokes(function(feature)
+                return feature == "nvim-0.12.1" and 0 or 1
+            end)
+            local bufnr = vim.api.nvim_create_buf(false, true)
+
+            BufHelpers.keymap_del(bufnr, "n", "x")
+
+            local opts = keymap_del_stub.calls[1][3]
+            assert.equal(bufnr, opts.buffer)
+            assert.is_nil(opts.buf)
+
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end)
+
+        it("uses `buf` opt on Neovim >= 0.12.1", function()
+            has_stub:invokes(function(feature)
+                return feature == "nvim-0.12.1" and 1 or 0
+            end)
+            local bufnr = vim.api.nvim_create_buf(false, true)
+
+            BufHelpers.keymap_del(bufnr, "n", "x")
+
+            local opts = keymap_del_stub.calls[1][3]
+            assert.equal(bufnr, opts.buf)
+            assert.is_nil(opts.buffer)
+
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end)
+    end)
+
     describe("is_buffer_empty", function()
         it("should return true for buffer with single empty line", function()
             local bufnr = vim.api.nvim_create_buf(false, true)

--- a/lua/agentic/utils/buf_helpers.test.lua
+++ b/lua/agentic/utils/buf_helpers.test.lua
@@ -198,6 +198,53 @@ describe("BufHelpers", function()
         end)
     end)
 
+    describe("multi_keymap_del", function()
+        --- @type TestStub
+        local keymap_del_stub
+        --- @type TestStub
+        local has_stub
+
+        before_each(function()
+            keymap_del_stub = spy.stub(vim.keymap, "del")
+            has_stub = spy.stub(vim.fn, "has")
+            has_stub:returns(1)
+        end)
+
+        after_each(function()
+            keymap_del_stub:revert()
+            has_stub:revert()
+        end)
+
+        it("deletes a single string keymap", function()
+            local bufnr = vim.api.nvim_create_buf(false, true)
+
+            BufHelpers.multi_keymap_del("x", bufnr)
+
+            assert.equal(1, keymap_del_stub.call_count)
+            assert.equal("n", keymap_del_stub.calls[1][1])
+            assert.equal("x", keymap_del_stub.calls[1][2])
+
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end)
+
+        it("deletes array entries with configured modes", function()
+            local bufnr = vim.api.nvim_create_buf(false, true)
+
+            BufHelpers.multi_keymap_del({
+                "x",
+                { "y", mode = "i" },
+            }, bufnr)
+
+            assert.equal(2, keymap_del_stub.call_count)
+            assert.equal("n", keymap_del_stub.calls[1][1])
+            assert.equal("x", keymap_del_stub.calls[1][2])
+            assert.equal("i", keymap_del_stub.calls[2][1])
+            assert.equal("y", keymap_del_stub.calls[2][2])
+
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end)
+    end)
+
     describe("is_buffer_empty", function()
         it("should return true for buffer with single empty line", function()
             local bufnr = vim.api.nvim_create_buf(false, true)

--- a/tests/helpers/child.lua
+++ b/tests/helpers/child.lua
@@ -16,7 +16,7 @@ function M.new()
     local root_dir = vim.fn.getcwd()
 
     function child.setup()
-        child.restart({ "-u", "NONE" })
+        child.restart({ "-i", "NONE", "-u", "NONE" })
         child.lua("vim.opt.rtp:prepend(...)", { root_dir })
 
         child.lua([[


### PR DESCRIPTION
Convert top-anchored multi-line permission requests to inline buttons in each tool-call request.

This aligns more with Zed and Cursor UIs, which show individual requests per tool block/widget.

<img width="763" height="670" alt="image" src="https://github.com/user-attachments/assets/a9649306-3ea3-4669-9815-28f860d32ed3" />

---

This also fixes the re-anchor bug when multiple requests arrive in a fast sequence: 

<img width="787" height="468" alt="image" src="https://github.com/user-attachments/assets/feb8f049-a485-45b5-ad5f-6b2def6a9556" />



