### PR TITLE
fix(acp): ignore session info updates

### DIFF
--- a/lua/agentic/acp/acp_client_types.lua
+++ b/lua/agentic/acp/acp_client_types.lua
@@ -250,6 +250,11 @@
 --- @field size number Total context window size in tokens
 --- @field cost? { amount: number, currency: string } Cumulative session cost
 
+--- @class agentic.acp.SessionInfoUpdate
+--- @field sessionUpdate "session_info_update"
+--- @field title? string|nil
+--- @field updatedAt? string|nil
+
 --- @class agentic.acp.ConfigOptionsUpdate
 --- @field sessionUpdate "config_option_update"
 --- @field configOptions agentic.acp.ConfigOption[]
@@ -264,6 +269,7 @@
 --- | agentic.acp.AvailableCommandsUpdate
 --- | agentic.acp.CurrentModeUpdate
 --- | agentic.acp.UsageUpdate
+--- | agentic.acp.SessionInfoUpdate
 --- | agentic.acp.ConfigOptionsUpdate
 
 --- @class agentic.acp.PermissionOption

--- a/lua/agentic/acp/acp_client_types.lua
+++ b/lua/agentic/acp/acp_client_types.lua
@@ -252,8 +252,8 @@
 
 --- @class agentic.acp.SessionInfoUpdate
 --- @field sessionUpdate "session_info_update"
---- @field title? string|nil
---- @field updatedAt? string|nil
+--- @field title? string
+--- @field updatedAt? string
 
 --- @class agentic.acp.ConfigOptionsUpdate
 --- @field sessionUpdate "config_option_update"

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -375,6 +375,8 @@ function SessionManager:_on_session_update(update)
         -- Usage updates contain token/cost information - currently informational only
         -- Fields: used (tokens), size (context window), cost (optional: amount, currency)
         -- Keeping silent for now to avoid "press any key" prompts on large JSON output
+    elseif update.sessionUpdate == "session_info_update" then
+        -- Session metadata is currently informational only
     else
         -- TODO: Move this to Logger from notify to debug when confidence is high
         Logger.notify(


### PR DESCRIPTION
- document session info update payload
- avoid noisy unknown update warnings
- preserve hook visibility for metadata
