### PR TITLE
fix(ui): handle buffer name collision on session restore

### DIFF
--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -228,6 +228,12 @@ Special write paths bypass `_maybe_write_sender_header`'s normal flow:
     that arrive while buttons are visible re-render the buttons rather than
     wipe them. If you bypass `repaint_status_row` and write to row N directly,
     buttons disappear until the next focus event triggers a repaint.
+- Direct `nvim_buf_set_name` for widget buffers
+  - Session restore (e.g. `mksession` with `blank` in `sessionoptions`)
+    persists agentic buffer names; direct calls raise E95 on reopen. Use
+    `WindowDecoration._set_buffer_name`, which renames any pre-existing
+    holder to `<name>-old-N`. Regression:
+    `lua/agentic/ui/window_decoration.test.lua`.
 
 ## Test invariants
 

--- a/lua/agentic/ui/window_decoration.lua
+++ b/lua/agentic/ui/window_decoration.lua
@@ -195,6 +195,62 @@ local function set_winbar(winid, text)
     vim.wo[winid][0].winbar = winbar_text
 end
 
+--- Returns a normalized path comparable across nvim's stored buffer
+--- names and the input given to `nvim_buf_set_name`. nvim resolves
+--- symlinks and prefixes the cwd; we mirror both.
+--- @param name string
+--- @return string
+local function normalize(name)
+    return vim.fn.resolve(vim.fn.fnamemodify(name, ":p"))
+end
+
+--- Returns the buffer that would collide with `name` on
+--- `nvim_buf_set_name`, or nil. Excludes `bufnr` itself so callers
+--- can use the result to decide whether to rename a different buffer.
+--- @param name string
+--- @param exclude_bufnr integer|nil
+--- @return integer|nil
+local function find_buf_by_name(name, exclude_bufnr)
+    local target = normalize(name)
+    for _, b in ipairs(vim.api.nvim_list_bufs()) do
+        if b ~= exclude_bufnr then
+            local existing = vim.api.nvim_buf_get_name(b)
+            if existing ~= "" and normalize(existing) == target then
+                return b
+            end
+        end
+    end
+    return nil
+end
+
+--- Assigns `buf_name` to `bufnr`, renaming any pre-existing buffer
+--- that already holds the name to `<buf_name>-old-N` (lowest free N
+--- starting at 1) to keep names unique.
+--- Required to survive session restore: `:mksession` (with `blank` in
+--- `sessionoptions`) persists agentic buffer names; on reopen
+--- `nvim_buf_set_name` would otherwise raise E95.
+--- @param bufnr integer
+--- @param buf_name string
+function WindowDecoration._set_buffer_name(bufnr, buf_name)
+    if normalize(vim.api.nvim_buf_get_name(bufnr)) == normalize(buf_name) then
+        return
+    end
+
+    local collider = find_buf_by_name(buf_name, bufnr)
+    local n = 1
+
+    while collider do
+        local candidate = buf_name .. "-old-" .. n
+        if not find_buf_by_name(candidate, bufnr) then
+            vim.api.nvim_buf_set_name(collider, candidate)
+            break
+        end
+        n = n + 1
+    end
+
+    vim.api.nvim_buf_set_name(bufnr, buf_name)
+end
+
 --- Sets the buffer name based on header text and tab count
 --- @param bufnr integer Buffer number
 --- @param header_text string|nil Resolved header text
@@ -207,7 +263,7 @@ local function set_buffer_name(bufnr, header_text, tab_page_id)
     -- Determine if we should show tab suffix based on total tab count
     local total_tabs = #vim.api.nvim_list_tabpages()
 
-    --- @type string|nil
+    --- @type string
     local buf_name
     if total_tabs > 1 then
         buf_name = string.format("%s (Tab %d)", header_text, tab_page_id)
@@ -215,7 +271,7 @@ local function set_buffer_name(bufnr, header_text, tab_page_id)
         buf_name = header_text
     end
 
-    vim.api.nvim_buf_set_name(bufnr, buf_name)
+    WindowDecoration._set_buffer_name(bufnr, buf_name)
 end
 
 --- Renders a header for a window, handling user customization, winbar, and buffer naming

--- a/lua/agentic/ui/window_decoration.test.lua
+++ b/lua/agentic/ui/window_decoration.test.lua
@@ -1,0 +1,130 @@
+--- @diagnostic disable: invisible
+local assert = require("tests.helpers.assert")
+
+local function normalize(p)
+    return vim.fn.resolve(vim.fn.fnamemodify(p, ":p"))
+end
+
+local function assert_buf_name(expected, bufnr)
+    assert.equal(
+        normalize(expected),
+        normalize(vim.api.nvim_buf_get_name(bufnr))
+    )
+end
+
+describe("WindowDecoration._set_buffer_name", function()
+    --- @type agentic.ui.WindowDecoration
+    local WindowDecoration
+
+    --- @type integer[]
+    local created_bufs
+
+    before_each(function()
+        package.loaded["agentic.ui.window_decoration"] = nil
+        WindowDecoration = require("agentic.ui.window_decoration")
+        created_bufs = {}
+    end)
+
+    after_each(function()
+        for _, b in ipairs(created_bufs) do
+            pcall(vim.api.nvim_buf_delete, b, { force = true })
+        end
+    end)
+
+    local function new_buf()
+        local b = vim.api.nvim_create_buf(false, true)
+        table.insert(created_bufs, b)
+        return b
+    end
+
+    it("sets name when no buffer holds it", function()
+        local bufnr = new_buf()
+        local name = vim.fn.tempname() .. "_no_collision"
+
+        WindowDecoration._set_buffer_name(bufnr, name)
+
+        assert_buf_name(name, bufnr)
+    end)
+
+    it("renames existing buffer to <name>-old-1 on first collision", function()
+        local existing = new_buf()
+        local name = vim.fn.tempname() .. "_collision"
+        vim.api.nvim_buf_set_name(existing, name)
+
+        local target = new_buf()
+        WindowDecoration._set_buffer_name(target, name)
+
+        assert_buf_name(name, target)
+        assert_buf_name(name .. "-old-1", existing)
+    end)
+
+    it("uses <name>-old-2 when <name>-old-1 also exists", function()
+        local oldest = new_buf()
+        local name = vim.fn.tempname() .. "_double"
+        vim.api.nvim_buf_set_name(oldest, name .. "-old-1")
+
+        local existing = new_buf()
+        vim.api.nvim_buf_set_name(existing, name)
+
+        local target = new_buf()
+        WindowDecoration._set_buffer_name(target, name)
+
+        assert_buf_name(name, target)
+        assert_buf_name(name .. "-old-2", existing)
+        assert_buf_name(name .. "-old-1", oldest)
+    end)
+
+    it("uses <name>-old-3 when -old-1 and -old-2 exist", function()
+        local b1 = new_buf()
+        local name = vim.fn.tempname() .. "_triple"
+        vim.api.nvim_buf_set_name(b1, name .. "-old-1")
+
+        local b2 = new_buf()
+        vim.api.nvim_buf_set_name(b2, name .. "-old-2")
+
+        local existing = new_buf()
+        vim.api.nvim_buf_set_name(existing, name)
+
+        local target = new_buf()
+        WindowDecoration._set_buffer_name(target, name)
+
+        assert_buf_name(name, target)
+        assert_buf_name(name .. "-old-3", existing)
+    end)
+
+    it(
+        "uses <name>-old-4 when name, -old-1, -old-2, -old-3 all pre-exist",
+        function()
+            local name = vim.fn.tempname() .. "_quad"
+
+            local b1 = new_buf()
+            vim.api.nvim_buf_set_name(b1, name .. "-old-1")
+            local b2 = new_buf()
+            vim.api.nvim_buf_set_name(b2, name .. "-old-2")
+            local b3 = new_buf()
+            vim.api.nvim_buf_set_name(b3, name .. "-old-3")
+
+            local existing = new_buf()
+            vim.api.nvim_buf_set_name(existing, name)
+
+            local target = new_buf()
+            WindowDecoration._set_buffer_name(target, name)
+
+            assert_buf_name(name, target)
+            assert_buf_name(name .. "-old-4", existing)
+            assert_buf_name(name .. "-old-1", b1)
+            assert_buf_name(name .. "-old-2", b2)
+            assert_buf_name(name .. "-old-3", b3)
+        end
+    )
+
+    it("is a no-op when bufnr already holds the target name", function()
+        local bufnr = new_buf()
+        local name = vim.fn.tempname() .. "_same"
+        vim.api.nvim_buf_set_name(bufnr, name)
+
+        WindowDecoration._set_buffer_name(bufnr, name)
+
+        assert_buf_name(name, bufnr)
+    end)
+end)


### PR DESCRIPTION
- fix #225
- rename existing buffer to `<name>-old-N` on first free N
- survives `:mksession` cycles persisting agentic buffer names
- guards `set_buffer_name` from raising E95 on reopen
