### PR TITLE
fix(acp): kill subprocess group so codex-acp grandchildren don't orphan

### DIFF
--- a/docs/adr/0006-acp-subprocess-process-group.md
+++ b/docs/adr/0006-acp-subprocess-process-group.md
@@ -1,0 +1,64 @@
+# 0006. Spawn ACP subprocesses in their own process group
+
+- Status: accepted
+- Last updated: 2026-05-18
+- Commits:
+- Related:
+
+## Context
+
+Several ACP providers ship as a Node wrapper that re-execs a native binary
+(e.g. `codex-acp.js` uses `spawnSync` with no signal handlers). When the
+plugin sends `SIGTERM` to the wrapper on `VimLeavePre`, the wrapper dies but
+the native grandchild is reparented to `init`/`launchd` and keeps running.
+
+`process:kill(signum)` from libuv only signals the direct child PID, so any
+wrapper that does not forward signals leaks its descendants. Observed in `ps`
+as `PPID 1` native `codex-acp` binaries after `:q`.
+
+## Current decision
+
+`acp_transport.create_stdio_transport` spawns every ACP child with
+`uv.spawn({ detached = true })` so the child becomes its own session and
+process-group leader (`setsid`).
+
+`transport:stop` signals the whole group via `uv.kill(-pid, 15)` then
+`uv.kill(-pid, 9)` on POSIX. Windows still uses `process:kill`; libuv's
+detached flag maps to `DETACHED_PROCESS` there and process groups behave
+differently.
+
+Regression test:
+``lua/agentic/acp/acp_transport.test.lua::"kills descendant processes when wrapper does not forward signals"``.
+
+## Consequences
+
+- Wrappers that do not forward signals (codex-acp.js today, any future
+  `spawnSync`/`exec`-style wrapper) are reaped cleanly.
+- ACP children survive a hard kill of nvim (`kill -9`, OOM, segfault) because
+  they are no longer in nvim's process group. Clean exits (`:q`, `:qa`,
+  terminal close that triggers `VimLeavePre`) still tear them down via
+  `AgentInstance:cleanup_all`.
+- Children get no controlling tty. ACP agents are headless stdio servers, so
+  this is invisible to them.
+
+## Rejected / superseded alternatives
+
+| Option                                             | Reason rejected                                                                                                                                              |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Keep `detached = false`, kill direct PID only      | Original behaviour. Leaks codex-acp native grandchildren on every quit.                                                                                      |
+| Walk descendants with `pgrep -P` on stop           | Works without spawn-flag changes and keeps crash-case cleanup via parent pgrp, but adds per-shutdown fork+exec and a race window where new grandchildren spawned during the walk are missed. |
+| File upstream fix in `codex-acp.js` to forward sigs | Right long-term, but does not help users until they upgrade. Pursue in parallel.                                                                             |
+| `PR_SET_PDEATHSIG` so children die with nvim       | Linux-only, not exposed by libuv, would require an FFI shim. Not worth it for the hard-kill edge case.                                                       |
+
+## Changelog
+
+| Date       | Commit | Change                                                                                  |
+| ---------- | ------ | --------------------------------------------------------------------------------------- |
+| 2026-05-18 |        | Initial decision: detached spawn + group kill so non-signal-forwarding wrappers reap cleanly. |
+
+## Sources
+
+- `codex-acp.js`: `spawnSync(binaryPath, ..., { stdio: "inherit" })` with no
+  signal handlers — upstream at `zed-industries/codex-acp:npm/bin/codex-acp.js`.
+- `kill(2)`: negative pid targets the process group on POSIX.
+- libuv `uv_spawn` with `UV_PROCESS_DETACHED` calls `setsid` on POSIX.

--- a/lua/agentic/acp/AGENTS.md
+++ b/lua/agentic/acp/AGENTS.md
@@ -20,7 +20,7 @@ NOTE: Install instructions are in the README.md
 ## Generic ACPClient (no per-provider adapters)
 
 All providers use a **single generic `ACPClient`** (`acp_client.lua`). There are
-no per-provider adapter files.
+no per-provider adapter files. See ADR 0005.
 
 The client parses standard ACP protocol fields and handles provider quirks (e.g.
 `rawInput` fallback for OpenCode) inline via protected methods in `ACPClient`
@@ -117,8 +117,7 @@ Invariants:
   and the rest of `_send_request`-based calls hang forever when the
   provider dies.
 - Reconnect (when `provider_config.reconnect` is true) loops back to
-  `connecting`. `reconnect_count` on the client gates max attempts;
-  the transport's `on_reconnect` callback reinvokes `_connect`.
+  `connecting`. See "Reconnect" section below.
 - `_on_ready` fan-out: callers registered via `when_ready` before the
   client reaches `ready` are flushed (each via `vim.schedule`) at the
   moment of transition. After `ready`, new `when_ready` callers fire
@@ -372,3 +371,58 @@ requires it, but currently all providers use the default implementations:
 | `__handle_tool_call_update`   | Builds partial, notifies subscriber       |
 | `__handle_request_permission` | Sends result back to provider             |
 | `__handle_session_update`     | Routes by `sessionUpdate` type            |
+
+## Provider switch (UI-only history replay)
+
+`init.lua::apply_provider_switch` destroys the current **SessionManager**,
+swaps `Config.provider`, creates a new `AgentInstance` / **ACP Session**, and
+then calls `MessageWriter:replay_history_messages` to repaint the chat buffer
+from the prior session's history.
+
+The new provider receives ZERO prior context: no `send_prompt` re-injection,
+no bulk history payload. The replay is a UI repaint only.
+
+Do NOT add a fallback that lazily re-sends history to the new provider
+without an explicit user opt-in — it would silently double-bill tokens and
+change perceived behavior.
+
+## Modes, models, thought level (config options dispatch)
+
+`SessionManager:new_session` dispatches on `SessionCreationResponse`:
+
+- `response.configOptions` present -> new path, handled by
+  `AgentConfigOptions:_handle_new_config_options`.
+- otherwise -> legacy path, `response.modes` populates `AgentModes` and
+  `response.models` populates `AgentModels`.
+
+The new path subsumes the legacy fields; both paths are kept because some
+providers still send only `modes`/`models`.
+
+Selectors are keymap-driven (`Config.keymaps.widget.change_mode`,
+`switch_model`, `change_thought_level`) and use `vim.ui.select`. No public
+`init.lua` entry exists for these — direct access is by keymap only.
+
+## Subprocess lifecycle
+
+Every ACP child is spawned with `uv.spawn({ detached = true })` so it leads
+its own session/process group. `transport:stop` signals the whole group via
+`uv.kill(-pid, 15)` then `uv.kill(-pid, 9)` on POSIX (Windows falls back to
+`process:kill`). This catches wrappers that don't forward signals (e.g.
+`codex-acp.js` uses `spawnSync` with no signal handlers, otherwise its native
+grandchild leaks as `PPID 1`). Trade-off: children outlive a hard `kill -9` of
+nvim. See ADR 0006. Regression:
+``lua/agentic/acp/acp_transport.test.lua::"kills descendant processes when wrapper does not forward signals"``.
+
+## Reconnect
+
+`ACPProviderConfig.reconnect` (boolean, default `false`) opts a provider into
+process-exit reconnection. The transport's `on_state_change("disconnected")`
+defers 2s and re-spawns up to `max_reconnect_attempts` times (default 3).
+
+`_drain_pending_callbacks` rejects every pending RPC with `TRANSPORT_ERROR`
+on each `disconnected` / `error` transition, so reconnect does not silently
+strand callers — they see the rejection, the next `send_prompt` succeeds
+against the re-spawned process if reconnect lands.
+
+No provider has `reconnect = true` in `Config.acp_providers` defaults; users
+opt in per-provider in their `setup`.

--- a/lua/agentic/acp/AGENTS.md
+++ b/lua/agentic/acp/AGENTS.md
@@ -20,7 +20,7 @@ NOTE: Install instructions are in the README.md
 ## Generic ACPClient (no per-provider adapters)
 
 All providers use a **single generic `ACPClient`** (`acp_client.lua`). There are
-no per-provider adapter files. See ADR 0005.
+no per-provider adapter files.
 
 The client parses standard ACP protocol fields and handles provider quirks (e.g.
 `rawInput` fallback for OpenCode) inline via protected methods in `ACPClient`
@@ -117,7 +117,8 @@ Invariants:
   and the rest of `_send_request`-based calls hang forever when the
   provider dies.
 - Reconnect (when `provider_config.reconnect` is true) loops back to
-  `connecting`. See "Reconnect" section below.
+  `connecting`. `reconnect_count` on the client gates max attempts;
+  the transport's `on_reconnect` callback reinvokes `_connect`.
 - `_on_ready` fan-out: callers registered via `when_ready` before the
   client reaches `ready` are flushed (each via `vim.schedule`) at the
   moment of transition. After `ready`, new `when_ready` callers fire
@@ -371,58 +372,3 @@ requires it, but currently all providers use the default implementations:
 | `__handle_tool_call_update`   | Builds partial, notifies subscriber       |
 | `__handle_request_permission` | Sends result back to provider             |
 | `__handle_session_update`     | Routes by `sessionUpdate` type            |
-
-## Provider switch (UI-only history replay)
-
-`init.lua::apply_provider_switch` destroys the current **SessionManager**,
-swaps `Config.provider`, creates a new `AgentInstance` / **ACP Session**, and
-then calls `MessageWriter:replay_history_messages` to repaint the chat buffer
-from the prior session's history.
-
-The new provider receives ZERO prior context: no `send_prompt` re-injection,
-no bulk history payload. The replay is a UI repaint only.
-
-Do NOT add a fallback that lazily re-sends history to the new provider
-without an explicit user opt-in — it would silently double-bill tokens and
-change perceived behavior.
-
-## Modes, models, thought level (config options dispatch)
-
-`SessionManager:new_session` dispatches on `SessionCreationResponse`:
-
-- `response.configOptions` present -> new path, handled by
-  `AgentConfigOptions:_handle_new_config_options`.
-- otherwise -> legacy path, `response.modes` populates `AgentModes` and
-  `response.models` populates `AgentModels`.
-
-The new path subsumes the legacy fields; both paths are kept because some
-providers still send only `modes`/`models`.
-
-Selectors are keymap-driven (`Config.keymaps.widget.change_mode`,
-`switch_model`, `change_thought_level`) and use `vim.ui.select`. No public
-`init.lua` entry exists for these — direct access is by keymap only.
-
-## Subprocess lifecycle
-
-Every ACP child is spawned with `uv.spawn({ detached = true })` so it leads
-its own session/process group. `transport:stop` signals the whole group via
-`uv.kill(-pid, 15)` then `uv.kill(-pid, 9)` on POSIX (Windows falls back to
-`process:kill`). This catches wrappers that don't forward signals (e.g.
-`codex-acp.js` uses `spawnSync` with no signal handlers, otherwise its native
-grandchild leaks as `PPID 1`). Trade-off: children outlive a hard `kill -9` of
-nvim. See ADR 0006. Regression:
-``lua/agentic/acp/acp_transport.test.lua::"kills descendant processes when wrapper does not forward signals"``.
-
-## Reconnect
-
-`ACPProviderConfig.reconnect` (boolean, default `false`) opts a provider into
-process-exit reconnection. The transport's `on_state_change("disconnected")`
-defers 2s and re-spawns up to `max_reconnect_attempts` times (default 3).
-
-`_drain_pending_callbacks` rejects every pending RPC with `TRANSPORT_ERROR`
-on each `disconnected` / `error` transition, so reconnect does not silently
-strand callers — they see the rejection, the next `send_prompt` succeeds
-against the re-spawned process if reconnect lands.
-
-No provider has `reconnect = true` in `Config.acp_providers` defaults; users
-opt in per-provider in their `setup`.

--- a/lua/agentic/acp/acp_transport.lua
+++ b/lua/agentic/acp/acp_transport.lua
@@ -47,6 +47,10 @@ function M.create_stdio_transport(config, callbacks)
         stdout = nil,
         --- @type uv.uv_process_t|nil
         process = nil,
+        --- PID of the spawned child; also used as the negative argument to
+        --- uv.kill so we signal the whole process group on stop (POSIX).
+        --- @type integer|nil
+        pid = nil,
     }
 
     --- @param data string
@@ -104,7 +108,11 @@ function M.create_stdio_transport(config, callbacks)
             args = args,
             env = final_env,
             stdio = { stdin, stdout, stderr },
-            detached = false,
+            -- detached = true makes the child a new session/process-group
+            -- leader (setsid). Required so transport:stop can signal the
+            -- whole group via uv.kill(-pid, ...) and reap wrappers that
+            -- don't forward signals (e.g. codex-acp.js spawnSync).
+            detached = true,
         }, function(code, signal)
             local cmd_str = config.command
                 .. (#args > 0 and " " .. table.concat(args, " ") or "")
@@ -169,6 +177,7 @@ function M.create_stdio_transport(config, callbacks)
         end
 
         self.process = handle
+        self.pid = tonumber(pid)
         self.stdin = stdin
         self.stdout = stdout
 
@@ -234,20 +243,30 @@ function M.create_stdio_transport(config, callbacks)
     function transport:stop()
         if self.process and not self.process:is_closing() then
             local process = self.process
+            local pid = self.pid
             self.process = nil
+            self.pid = nil
 
             if not process then
                 return
             end
 
-            -- Try to terminate gracefully
-            pcall(function()
-                process:kill(15)
-            end)
-            -- then force kill, it'll fail harmlessly if already exited
-            pcall(function()
-                process:kill(9)
-            end)
+            -- Signal the whole process group (negative pid on POSIX) so
+            -- wrappers that don't forward signals (e.g. codex-acp.js
+            -- spawnSync) don't leave orphaned grandchildren. Fall back to
+            -- per-pid kill on Windows where process groups work differently.
+            local is_windows = vim.fn.has("win32") == 1
+            if pid and not is_windows then
+                pcall(uv.kill, -pid, 15)
+                pcall(uv.kill, -pid, 9)
+            else
+                pcall(function()
+                    process:kill(15)
+                end)
+                pcall(function()
+                    process:kill(9)
+                end)
+            end
 
             process:close()
         end

--- a/lua/agentic/acp/acp_transport.lua
+++ b/lua/agentic/acp/acp_transport.lua
@@ -268,6 +268,9 @@ function M.create_stdio_transport(config, callbacks)
                 end)
             end
 
+            -- Safe to close the handle here even though the spawn exit
+            -- callback may still fire; libuv tolerates close-after-exit and
+            -- the callback's own close path is guarded by `if self.process`.
             process:close()
         end
 

--- a/lua/agentic/acp/acp_transport.test.lua
+++ b/lua/agentic/acp/acp_transport.test.lua
@@ -4,6 +4,11 @@ local assert = require("tests.helpers.assert")
 -- Real-subprocess tests for ACPTransport. We bypass `tests/helpers/child.lua`
 -- because its `setup()` mocks `agentic.acp.acp_transport`; here we need the
 -- real module to spawn a real process.
+--
+-- This is the canonical exception to the "MUST stub `agentic.acp.acp_transport`"
+-- rule in `tests/AGENTS.md`: that rule exists for tests that *use* the
+-- transport. This file *tests* the transport itself, so spawning a real
+-- subprocess is the whole point. No provider binary is spawned; only /bin/sh.
 
 describe("ACPTransport process lifecycle", function()
     local child
@@ -51,7 +56,12 @@ describe("ACPTransport process lifecycle", function()
             --   2. emit its PID as a JSON line on stdout
             --   3. `exec cat` so the foreground process holds stdin open
             --      without any signal trap. SIGTERM => cat dies, sleep orphans.
-            child.lua([[
+            --
+            -- The backgrounded `sleep` is in the same session/pgrp as the
+            -- foreground shell because `detached = true` already called
+            -- `setsid` at spawn time and `sh -c` does not create a new pgrp
+            -- without job control. See ADR 0006.
+            local got_pid = child.lua([[
                 local Transport = require("agentic.acp.acp_transport")
                 _G.t = {}
                 _G.transport = Transport.create_stdio_transport({
@@ -66,11 +76,12 @@ describe("ACPTransport process lifecycle", function()
                     on_reconnect = function() end,
                 })
                 _G.transport:start()
-                vim.wait(2000, function()
+                return vim.wait(2000, function()
                     return _G.t.grandchild_pid ~= nil
                 end)
             ]])
 
+            assert.is_true(got_pid)
             local grandchild_pid = child.lua_get([[_G.t.grandchild_pid]])
             assert.is_not_nil(grandchild_pid)
             assert.is_true(is_alive(grandchild_pid))

--- a/lua/agentic/acp/acp_transport.test.lua
+++ b/lua/agentic/acp/acp_transport.test.lua
@@ -68,7 +68,7 @@ describe("ACPTransport process lifecycle", function()
                     command = "/bin/sh",
                     args = {
                         "-c",
-                        'sleep 9999 & echo "{\\"pid\\":$!}"; exec cat >/dev/null',
+                        'sleep 300 & echo "{\\"pid\\":$!}"; exec cat >/dev/null',
                     },
                 }, {
                     on_state_change = function(s) _G.t.state = s end,

--- a/lua/agentic/acp/acp_transport.test.lua
+++ b/lua/agentic/acp/acp_transport.test.lua
@@ -1,0 +1,91 @@
+local MiniTest = require("mini.test")
+local assert = require("tests.helpers.assert")
+
+-- Real-subprocess tests for ACPTransport. We bypass `tests/helpers/child.lua`
+-- because its `setup()` mocks `agentic.acp.acp_transport`; here we need the
+-- real module to spawn a real process.
+
+describe("ACPTransport process lifecycle", function()
+    local child
+
+    before_each(function()
+        child = MiniTest.new_child_neovim()
+        child.restart({ "-i", "NONE", "-u", "NONE" })
+        child.lua("vim.opt.rtp:prepend(...)", { vim.fn.getcwd() })
+    end)
+
+    after_each(function()
+        child.stop()
+    end)
+
+    --- @param pid integer
+    --- @return boolean alive
+    local function is_alive(pid)
+        vim.fn.system({ "kill", "-0", tostring(pid) })
+        return vim.v.shell_error == 0
+    end
+
+    --- @param pid integer
+    --- @param timeout_ms integer
+    --- @return boolean died
+    local function wait_for_death(pid, timeout_ms)
+        local deadline = vim.uv.hrtime() + timeout_ms * 1e6
+        while vim.uv.hrtime() < deadline do
+            if not is_alive(pid) then
+                return true
+            end
+            vim.uv.sleep(25)
+        end
+        return false
+    end
+
+    it(
+        "kills descendant processes when wrapper does not forward signals",
+        function()
+            -- Reproduces the codex-acp.js orphan bug: the npm wrapper uses
+            -- spawnSync with no signal handlers, so SIGTERM kills the wrapper
+            -- but leaves its native child reparented to PID 1.
+            --
+            -- Wrapper:
+            --   1. fork a long-sleeping grandchild
+            --   2. emit its PID as a JSON line on stdout
+            --   3. `exec cat` so the foreground process holds stdin open
+            --      without any signal trap. SIGTERM => cat dies, sleep orphans.
+            child.lua([[
+                local Transport = require("agentic.acp.acp_transport")
+                _G.t = {}
+                _G.transport = Transport.create_stdio_transport({
+                    command = "/bin/sh",
+                    args = {
+                        "-c",
+                        'sleep 9999 & echo "{\\"pid\\":$!}"; exec cat >/dev/null',
+                    },
+                }, {
+                    on_state_change = function(s) _G.t.state = s end,
+                    on_message = function(msg) _G.t.grandchild_pid = msg.pid end,
+                    on_reconnect = function() end,
+                })
+                _G.transport:start()
+                vim.wait(2000, function()
+                    return _G.t.grandchild_pid ~= nil
+                end)
+            ]])
+
+            local grandchild_pid = child.lua_get([[_G.t.grandchild_pid]])
+            assert.is_not_nil(grandchild_pid)
+            assert.is_true(is_alive(grandchild_pid))
+
+            child.lua([[ _G.transport:stop() ]])
+
+            local died = wait_for_death(grandchild_pid, 1500)
+
+            -- Best-effort cleanup if the test failed so we don't leak between
+            -- runs.
+            if not died then
+                vim.fn.system({ "kill", "-9", tostring(grandchild_pid) })
+            end
+
+            assert.is_true(died)
+        end
+    )
+end)


### PR DESCRIPTION
- codex-acp.js spawnSync doesn't forward signals; native binary leaks as PPID 1 on quit
- spawn ACP children detached so each is its own pgrp/session leader (setsid)
- transport:stop signals whole group via uv.kill(-pid, ...) on POSIX
- Windows keeps process:kill (no pgrp semantics there)
- trade-off: children outlive a hard kill -9 of nvim, documented in ADR 0006
- real-subprocess regression test mimics non-forwarding wrapper, no codex needed in CI
