### PR TITLE
feat(providers): add Hermes Agent and Oh My Pi as built-in ACP providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 > ⚡ A Chat interface for AI agents in Neovim that works with any provider
 > supporting the [Agent Client Protocol (ACP)](https://agentclientprotocol.com)
 > — including Claude, Gemini, Codex, OpenCode, Cursor Agent, Copilot, Auggie,
-> Mistral Vibe, Cline, Goose, Kiro, Pi, and more.
+> Mistral Vibe, Cline, Goose, Kiro, Pi, Hermes Agent, Oh My Pi, and more.
 
 **Agentic.nvim** brings your AI assistant to Neovim through the implementation
 of the [Agent Client Protocol (ACP)](https://agentclientprotocol.com).
@@ -122,7 +122,7 @@ _...and any future ACP-compatible provider._
   times
 - **🔌 Any ACP Provider** - Works with any AI provider that implements the Agent
   Client Protocol — Claude, Gemini, Codex, OpenCode, Cursor Agent, Copilot,
-  Auggie, Mistral Vibe, Cline, Goose, Kiro, Pi, and any future ACP-compatible
+  Auggie, Mistral Vibe, Cline, Goose, Kiro, Pi, Hermes Agent, Oh My Pi, and any future ACP-compatible
   provider
 - **🔑 Zero Config Authentication** - No API keys needed
   - **Keep you secrets secret**: run `claude /login`, or `gemini auth login`

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -5,7 +5,7 @@
 A Chat interface for AI agents in Neovim that works with any provider
 supporting the Agent Client Protocol (ACP) -- including Claude, Gemini,
 Codex, OpenCode, Cursor Agent, Copilot, Auggie, Mistral Vibe, Cline,
-Goose, Kiro, Pi, and more.
+Goose, Kiro, Pi, Hermes Agent, Oh My Pi, and more.
 
 Type |gO| to see the table of contents.
 
@@ -58,6 +58,8 @@ Supported providers:
   - Goose (goose-acp)
   - Kiro (kiro-acp)
   - Pi (pi-acp)
+  - Hermes Agent (hermes-agent-acp)
+  - Oh My Pi (oh-my-pi-acp)
   - ...and any future ACP-compatible provider
 
 ==============================================================================
@@ -152,6 +154,17 @@ Provider install commands (always check official docs):
     `pnpm add -g pi-acp`
     OR `npm i -g pi-acp`
 
+  hermes-agent                                  *agentic-install-hermes*
+    https://hermes-agent.nousresearch.com/docs/
+    `curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash`
+    Then ensure the ACP extra is installed:
+    `pip install -e '.[acp]'`
+
+  oh-my-pi                                        *agentic-install-omp*
+    https://github.com/can1357/oh-my-pi
+    `curl -fsSL https://raw.githubusercontent.com/can1357/oh-my-pi/main/install.sh | bash`
+    OR clone and build from source.
+
 Optional: |img-clip.nvim| for pasting screenshots from the clipboard.
 Drag-and-drop works without it if your terminal supports it.
 
@@ -172,6 +185,7 @@ Using lazy.nvim: ~
       -- "opencode-acp" | "cursor-acp" | "copilot-acp"
       -- "auggie-acp" | "mistral-vibe-acp" | "cline-acp"
       -- "goose-acp" | "kiro-acp" | "pi-acp"
+      -- "hermes-agent-acp" | "oh-my-pi-acp"
       provider = "claude-agent-acp",
     },
 

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -12,6 +12,8 @@
 --- | "goose-acp"
 --- | "kiro-acp"
 --- | "pi-acp"
+--- | "hermes-agent-acp"
+--- | "oh-my-pi-acp"
 
 --- @alias agentic.UserConfig.HeaderRenderFn fun(parts: agentic.ui.ChatWidget.HeaderParts): string|nil
 
@@ -387,6 +389,20 @@ local ConfigDefault = {
         ["pi-acp"] = {
             name = "Pi ACP",
             command = "pi-acp",
+            env = {},
+        },
+
+        ["hermes-agent-acp"] = {
+            name = "Hermes Agent ACP",
+            command = "hermes",
+            args = { "acp" },
+            env = {},
+        },
+
+        ["oh-my-pi-acp"] = {
+            name = "Oh My Pi ACP",
+            command = "omp",
+            args = { "acp" },
             env = {},
         },
     },


### PR DESCRIPTION
## Summary

Adds [Hermes Agent](https://hermes-agent.nousresearch.com) and [Oh My Pi](https://github.com/can1357/oh-my-pi) as first-class, built-in ACP providers.

Both agents already ship ACP server mode:
- **Hermes**:  (requires Obtaining file:///private/tmp/agentic.nvim-fork)
- **Oh My Pi**: 

This removes the friction of configuring them as custom  entries.

## Changes

-  — type aliases + provider configs
-  — provider list updates
-  — provider list, install instructions, and config comment

## Related

- Hermes ACP docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/acp
- Tracking issue in Hermes repo: https://github.com/NousResearch/hermes-agent/issues/28836

> **Note:**  already in the default list refers to the [Pi](https://pi.dev) agent (by earendil-works), which is a separate project from Oh My Pi. This PR does not touch that entry.