### PR TITLE
fix: Don't detach in uv.spawn on Windows to prevent flashing cmd windows with Copilot CLI

### DIFF
--- a/lua/agentic/acp/acp_transport.lua
+++ b/lua/agentic/acp/acp_transport.lua
@@ -112,7 +112,9 @@ function M.create_stdio_transport(config, callbacks)
             -- leader (setsid). Required so transport:stop can signal the
             -- whole group via uv.kill(-pid, ...) and reap wrappers that
             -- don't forward signals (e.g. codex-acp.js spawnSync).
-            detached = true,
+            -- On Windows, detached allocates a new console window, so we
+            -- skip it there (process:kill() is used for teardown instead).
+            detached = vim.fn.has("win32") == 0,
         }, function(code, signal)
             local cmd_str = config.command
                 .. (#args > 0 and " " .. table.concat(args, " ") or "")

--- a/lua/agentic/acp/acp_transport.lua
+++ b/lua/agentic/acp/acp_transport.lua
@@ -112,8 +112,8 @@ function M.create_stdio_transport(config, callbacks)
             -- leader (setsid). Required so transport:stop can signal the
             -- whole group via uv.kill(-pid, ...) and reap wrappers that
             -- don't forward signals (e.g. codex-acp.js spawnSync).
-            -- On Windows, detached allocates a new console window, so we
-            -- skip it there (process:kill() is used for teardown instead).
+            -- Windows has no process groups, so staying attached is
+            -- preferable (child inherits console and dies with the terminal).
             detached = vim.fn.has("win32") == 0,
         }, function(code, signal)
             local cmd_str = config.command


### PR DESCRIPTION
When opening agentic with Copilot CLI on WIndows, cmd windows will appear for a split second like this:

https://github.com/user-attachments/assets/1cc5381d-a7f5-4841-ae9c-c0bab6ed390b

I believe this is because Copilot CLI is spawning for example git processes which are opened as cmd consoles, you can see that the title of the cmd windows points to git executable.

A fix for this is to not detach the processes in `transport:start` for Windows only, as Copilot CLI does not open separate console windows and rather reuses Neovims when not detached. I tried also with just `hide = true`, but that made no difference. Since we already fall back to just killing the process on Windows, I think this is actually better anyways.