### PR TITLE
fix: TabClosed destroying wrong session due to tab number/handle mismatch

### DIFF
--- a/lua/agentic/init.lua
+++ b/lua/agentic/init.lua
@@ -376,11 +376,12 @@ function Agentic.setup(opts)
     })
 
     -- Cleanup specific tab instance when tab is closed
+    -- TabClosed ev.match is a tab number (position), not a tabpage handle.
+    -- Scan the registry for sessions whose handle is no longer valid.
     vim.api.nvim_create_autocmd("TabClosed", {
         group = cleanup_group,
-        callback = function(ev)
-            local tab_id = tonumber(ev.match)
-            SessionRegistry.destroy_session(tab_id)
+        callback = function()
+            SessionRegistry.destroy_closed_sessions()
         end,
         desc = "Cleanup Agentic processes on tab close",
     })

--- a/lua/agentic/session_registry.lua
+++ b/lua/agentic/session_registry.lua
@@ -74,6 +74,20 @@ function SessionRegistry.destroy_session(tab_page_id)
     end
 end
 
+--- Destroys sessions whose tabpage is no longer in nvim_list_tabpages()
+function SessionRegistry.destroy_closed_sessions()
+    local valid = {}
+    for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+        valid[tab] = true
+    end
+
+    for tab_page_id in pairs(SessionRegistry.sessions) do
+        if not valid[tab_page_id] then
+            SessionRegistry.destroy_session(tab_page_id)
+        end
+    end
+end
+
 --- @param on_selected fun(provider_name: agentic.UserConfig.ProviderName|nil) Callback that will be called with the selected provider name, if any
 function SessionRegistry.select_provider(on_selected)
     local available_providers = ACPHealth.get_default_provider_names()

--- a/lua/agentic/session_registry.test.lua
+++ b/lua/agentic/session_registry.test.lua
@@ -400,6 +400,74 @@ describe("agentic.SessionRegistry", function()
         end)
     end)
 
+    describe("destroy_closed_sessions", function()
+        --- @type TestStub|nil
+        local list_tabpages_stub
+
+        after_each(function()
+            if list_tabpages_stub then
+                list_tabpages_stub:revert()
+                list_tabpages_stub = nil
+            end
+        end)
+
+        it(
+            "only destroys sessions for tabpages that no longer exist",
+            function()
+                local session_10 = create_mock_session(10)
+                local session_20 = create_mock_session(20)
+                local destroy_10 = spy.new(function() end)
+                local destroy_20 = spy.new(function() end)
+                session_10.destroy = destroy_10
+                session_20.destroy = destroy_20
+
+                SessionRegistry.sessions[10] = session_10
+                SessionRegistry.sessions[20] = session_20
+
+                list_tabpages_stub = spy.stub(vim.api, "nvim_list_tabpages")
+                list_tabpages_stub:returns({ 20 })
+
+                SessionRegistry.destroy_closed_sessions()
+
+                assert.is_nil(SessionRegistry.sessions[10])
+                assert.is_not_nil(SessionRegistry.sessions[20])
+                assert.spy(destroy_10).was.called(1)
+                assert.spy(destroy_20).was.called(0)
+            end
+        )
+
+        it("preserves all sessions when all tabpages are valid", function()
+            local session_10 = create_mock_session(10)
+            local session_20 = create_mock_session(20)
+            local destroy_10 = spy.new(function() end)
+            local destroy_20 = spy.new(function() end)
+            session_10.destroy = destroy_10
+            session_20.destroy = destroy_20
+
+            SessionRegistry.sessions[10] = session_10
+            SessionRegistry.sessions[20] = session_20
+
+            list_tabpages_stub = spy.stub(vim.api, "nvim_list_tabpages")
+            list_tabpages_stub:returns({ 10, 20 })
+
+            SessionRegistry.destroy_closed_sessions()
+
+            assert.is_not_nil(SessionRegistry.sessions[10])
+            assert.is_not_nil(SessionRegistry.sessions[20])
+            assert.spy(destroy_10).was.called(0)
+            assert.spy(destroy_20).was.called(0)
+        end)
+
+        it("handles empty registry gracefully", function()
+            list_tabpages_stub = spy.stub(vim.api, "nvim_list_tabpages")
+            list_tabpages_stub:returns({})
+
+            assert.has_no_errors(function()
+                SessionRegistry.destroy_closed_sessions()
+            end)
+        end)
+    end)
+
     describe("sessions weak table", function()
         it("uses weak value metatable", function()
             local metatable = getmetatable(SessionRegistry.sessions)


### PR DESCRIPTION
## Summary

- `TabClosed` autocmd was using `ev.match` (a 1-based tab **position number**) as the session registry key (a tabpage **handle**). After tab renumbering, the position of a newly closed tab could collide with the handle of an existing session, destroying it.
- Replaced with `SessionRegistry.destroy_closed_sessions()` which scans the registry for handles no longer in `nvim_list_tabpages()`.

### Steps to reproduce the bug

1. `nvim`
2. `:tabnew`
3. `:lua require("agentic").new_session()` — session created in tab handle 2
4. `<Esc>` to leave insert mode
5. `:tabc 1` — close tab 1; surviving tab (handle 2) is now at position 1
6. `:tabnew` — new tab (handle 3) at position 2
7. `:tabc` — `TabClosed` fires with `ev.match = "2"` → `destroy_session(2)` kills the wrong session