### PR TITLE
feat(ui): display permission buttons stacked per row instead of inline

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -158,8 +158,8 @@ A provider-initiated `session/request_permission` event tied to a specific
 
 **PermissionManager**:
 Per-**Tabpage** owner of pending **Permission Requests**, focus state, per-block
-keymaps. Renders inline buttons on row N of the focused **Tool Call Block**.
-See ADR 0003.
+keymaps. Buttons render one-per-row between bottom_pad and the status row of
+the focused **Tool Call Block** (not inline on row N). See ADR 0003.
 
 ### Message chunks
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -158,8 +158,7 @@ A provider-initiated `session/request_permission` event tied to a specific
 
 **PermissionManager**:
 Per-**Tabpage** owner of pending **Permission Requests**, focus state, per-block
-keymaps. Buttons render one-per-row between bottom_pad and the status row of
-the focused **Tool Call Block** (not inline on row N). See ADR 0003.
+keymaps. Renders buttons inside the focused **Tool Call Block**. See ADR 0003.
 
 ### Message chunks
 
@@ -267,10 +266,10 @@ default.
   (which **Tool Call Block** has buttons active and digit keymaps bound).
   Resolved: bare "focus" = Neovim's window focus; "permission focus" or
   "focused block" for the **PermissionManager** notion.
-- "status row", "row N", "status footer" all refer to the same line: the last
-  row of a **Tool Call Block**, outside the fold range, rendered by
-  `MessageWriter:_render_status_row`. Canonical: **status row** (or `row N`
-  when discussing the block layout diagram).
+- "status row", "status footer" refer to the same line: the last row of a
+  **Tool Call Block**, outside the fold range. Canonical: **status row**.
+  ("row N" was used pre-refactor and overlapped with the permission rows now
+  rendered between `bottom_pad` and the status row; avoid the term.)
 - "Functional test" vs "integration test" — `tests/AGENTS.md` once split these
   into separate categories with overlapping definitions. The split was not
   load-bearing. Resolved: treat as one category. Use either folder

--- a/README.md
+++ b/README.md
@@ -974,7 +974,7 @@ colorscheme.
 | `AgenticStatusFailed`             | Failed tool call status indicator           | `bg=#7a2d2d`                        |
 | `AgenticPermissionButtonAllow`    | Focused button (allow kind)                 | `bg=#2d5a3d, bold=true`             |
 | `AgenticPermissionButtonReject`   | Focused button (reject kind)                | `bg=#7a2d2d, bold=true`             |
-| `AgenticPermissionButtonInactive` | Permission button (non-focused button)      | `bg=#3a3a3a`                        |
+| `AgenticPermissionButtonInactive` | Non-focused permission button               | `bg=#3a3a3a`                        |
 | `AgenticCodeBlockFence`           | The left border decoration on tool calls    | Links to `Directory`                |
 | `AgenticTitle`                    | Window titles in sidebar                    | `bg=#2787b0, fg=#000000, bold=true` |
 | `AgenticThinking`                 | Thinking block text in chat buffer          | Links to `Comment`                  |

--- a/README.md
+++ b/README.md
@@ -972,9 +972,9 @@ colorscheme.
 | `AgenticStatusPending`            | Pending tool call status indicator          | `bg=#5f4d8f`                        |
 | `AgenticStatusCompleted`          | Completed tool call status indicator        | `bg=#2d5a3d`                        |
 | `AgenticStatusFailed`             | Failed tool call status indicator           | `bg=#7a2d2d`                        |
-| `AgenticPermissionButtonAllow`    | Focused allow button (focused button)       | `bg=#2d5a3d, bold=true`             |
-| `AgenticPermissionButtonReject`   | Focused reject button (focused button)      | `bg=#7a2d2d, bold=true`             |
-| `AgenticPermissionButtonInactive` | All non-focused permission buttons          | `bg=#3a3a3a`                        |
+| `AgenticPermissionButtonAllow`    | Focused button (allow kind)                 | `bg=#2d5a3d, bold=true`             |
+| `AgenticPermissionButtonReject`   | Focused button (reject kind)                | `bg=#7a2d2d, bold=true`             |
+| `AgenticPermissionButtonInactive` | Permission button (non-focused button)      | `bg=#3a3a3a`                        |
 | `AgenticCodeBlockFence`           | The left border decoration on tool calls    | Links to `Directory`                |
 | `AgenticTitle`                    | Window titles in sidebar                    | `bg=#2787b0, fg=#000000, bold=true` |
 | `AgenticThinking`                 | Thinking block text in chat buffer          | Links to `Comment`                  |

--- a/README.md
+++ b/README.md
@@ -690,12 +690,14 @@ your setup:
       },
 
       -- Keybindings to cycle focus between pending permission blocks.
-      -- Once a block is focused, per-block keys work on its row N:
-      --   h / <Left>  : focus previous button
-      --   l / <Right> : focus next button
-      --   <CR>        : submit focused button
-      --   1..4        : submit option N directly
-      -- Per-block keys only fire when the cursor is on the focused row.
+      -- Once a block is focused, per-block keys cycle the stacked button
+      -- rows (one button per row, rendered between bottom_pad and the
+      -- status row):
+      --   h / <Left> / k / <Up>    : focus previous button
+      --   l / <Right> / j / <Down> : focus next button
+      --   <CR>                     : submit focused button
+      --   1..4                     : submit option N directly
+      -- Per-block keys only fire while a block is focused.
       permission = {
         cycle_next = "<C-n>",
         cycle_prev = "<C-p>",
@@ -970,8 +972,8 @@ colorscheme.
 | `AgenticStatusPending`            | Pending tool call status indicator          | `bg=#5f4d8f`                        |
 | `AgenticStatusCompleted`          | Completed tool call status indicator        | `bg=#2d5a3d`                        |
 | `AgenticStatusFailed`             | Failed tool call status indicator           | `bg=#7a2d2d`                        |
-| `AgenticPermissionButtonAllow`    | Focused allow button (after `h`/`l` focus)  | `bg=#2d5a3d, bold=true`             |
-| `AgenticPermissionButtonReject`   | Focused reject button (after `h`/`l` focus) | `bg=#7a2d2d, bold=true`             |
+| `AgenticPermissionButtonAllow`    | Focused allow button (focused button)       | `bg=#2d5a3d, bold=true`             |
+| `AgenticPermissionButtonReject`   | Focused reject button (focused button)      | `bg=#7a2d2d, bold=true`             |
 | `AgenticPermissionButtonInactive` | All non-focused permission buttons          | `bg=#3a3a3a`                        |
 | `AgenticCodeBlockFence`           | The left border decoration on tool calls    | Links to `Directory`                |
 | `AgenticTitle`                    | Window titles in sidebar                    | `bg=#2787b0, fg=#000000, bold=true` |

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -516,12 +516,12 @@ These keybindings are automatically set in Agentic buffers:
   [t                     n       Previous tool call
   ]c                     n       Next diff hunk
   [c                     n       Previous diff hunk
-  <C-n>                     n       Cycle to next pending permission block
-  <C-p>                     n       Cycle to previous pending permission block
-  h / <Left> / k / <Up>     n       Focus previous permission button
-  l / <Right> / j / <Down>  n       Focus next permission button
-  <CR>                      n       Submit focused permission button
-  1..4                      n       Submit permission option directly
+  <C-n>                    n       Cycle to next pending permission block
+  <C-p>                    n       Cycle to previous pending permission block
+  h / <Left> / k / <Up>    n       Focus previous permission button
+  l / <Right> / j / <Down> n       Focus next permission button
+  <CR>                     n       Submit focused permission button
+  1..4                     n       Submit permission option directly
 
                                         *agentic-keymaps-customizing*
 Customizing keymaps ~

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -516,12 +516,16 @@ These keybindings are automatically set in Agentic buffers:
   [t                     n       Previous tool call
   ]c                     n       Next diff hunk
   [c                     n       Previous diff hunk
-  <C-n>                    n       Cycle to next pending permission block
-  <C-p>                    n       Cycle to previous pending permission block
-  h / <Left> / k / <Up>    n       Focus previous permission button
-  l / <Right> / j / <Down> n       Focus next permission button
-  <CR>                     n       Submit focused permission button
-  1..4                     n       Submit permission option directly
+
+Permission keymaps (active while a permission request is pending):
+
+  Key                        Mode    Description ~
+  <C-n>                      n       Cycle to next pending permission block
+  <C-p>                      n       Cycle to previous pending permission block
+  h / <Left> / k / <Up>      n       Focus previous permission button
+  l / <Right> / j / <Down>   n       Focus next permission button
+  <CR>                       n       Submit focused permission button
+  1..4                       n       Submit permission option directly
 
                                         *agentic-keymaps-customizing*
 Customizing keymaps ~

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -516,12 +516,12 @@ These keybindings are automatically set in Agentic buffers:
   [t                     n       Previous tool call
   ]c                     n       Next diff hunk
   [c                     n       Previous diff hunk
-  <C-n>                  n       Cycle to next pending permission block
-  <C-p>                  n       Cycle to previous pending permission block
-  h / <Left>             n       Focus previous permission button (on row)
-  l / <Right>            n       Focus next permission button (on row)
-  <CR>                   n       Submit focused permission button (on row)
-  1..4                   n       Submit permission option directly (on row)
+  <C-n>                     n       Cycle to next pending permission block
+  <C-p>                     n       Cycle to previous pending permission block
+  h / <Left> / k / <Up>     n       Focus previous permission button
+  l / <Right> / j / <Down>  n       Focus next permission button
+  <CR>                      n       Submit focused permission button
+  1..4                      n       Submit permission option directly
 
                                         *agentic-keymaps-customizing*
 Customizing keymaps ~
@@ -571,9 +571,9 @@ Override default keybindings via the `keymaps` config option:
   }
 <
 
-The per-block permission keys (`h`, `l`, `<Left>`, `<Right>`, `<CR>`,
-`1`..`4`) are fixed and not configurable. Only `cycle_next` / `cycle_prev`
-can be remapped via `keymaps.permission`.
+The per-block permission keys (`h`, `l`, `j`, `k`, `<Left>`, `<Right>`,
+`<Up>`, `<Down>`, `<CR>`, `1`..`4`) are fixed and not configurable. Only
+`cycle_next` / `cycle_prev` can be remapped via `keymaps.permission`.
 
 Keymap configuration formats:
   - String: `close = "q"` (normal mode by default)

--- a/doc/tags
+++ b/doc/tags
@@ -6,6 +6,7 @@ agentic-config-diff-preview	agentic.txt	/*agentic-config-diff-preview*
 agentic-config-headers	agentic.txt	/*agentic-config-headers*
 agentic-config-hooks	agentic.txt	/*agentic-config-hooks*
 agentic-config-provider	agentic.txt	/*agentic-config-provider*
+agentic-config-provider-switcher	agentic.txt	/*agentic-config-provider-switcher*
 agentic-config-settings	agentic.txt	/*agentic-config-settings*
 agentic-config-windows	agentic.txt	/*agentic-config-windows*
 agentic-configuration	agentic.txt	/*agentic-configuration*

--- a/docs/adr/0003-inline-permission-buttons.md
+++ b/docs/adr/0003-inline-permission-buttons.md
@@ -36,24 +36,11 @@ status row of the tool-call block. The status row carries only the status word
 their own row but no button ever shares a visual row with another button or
 the status word.
 
-Layout for a pending block with K options:
+Layout: See `ui/AGENTS.md` "Tool-call block layout". The buttons-row addendum:
+rows `M+1..M+K` are real text, one per option, outside the fold.
 
-```text
-row 0          header
-row 1          "" top_pad      fold start
-row 2..M-1     body
-row M          "" bottom_pad   fold end
-row M+1..M+K   button rows
-row M+K+1      status row      status word only
-```
-
-Render pipeline:
-`PermissionManager` -> `MessageWriter:repaint_status_row` ->
-`MessageWriter:_build_permission_section` builds
-`{ button_lines, button_segments_per_line, status_text, status_segments }` ->
-`MessageWriter:_render_permission_section(tracker, end_row, section)` deletes
-the prior K rows and inserts the new K in one buffer transaction, rewrites
-the status row, and re-applies NS_STATUS extmark segments.
+Render pipeline: `PermissionManager` -> `MessageWriter:repaint_status_row` ->
+`MessageWriter:_build_permission_section` -> `_render_permission_section`.
 
 ```mermaid
 flowchart TD
@@ -92,10 +79,8 @@ many buttons are currently rendered.
 
 ### Render bookkeeping
 
-`tracker._rendered_button_count` stores the K currently rendered for the
-block. `_render_permission_section` reads it to delete the prior section
-before inserting the new one, then writes the post-render count. The field is
-internal to the render path; only `_render_permission_section` writes it.
+`tracker._rendered_button_count` (written only by
+`MessageWriter:_render_permission_section`) tracks rows for the next repaint.
 
 ### Provider-supplied labels
 
@@ -126,38 +111,26 @@ layout.
 
 ### Row-gated per-block keymaps
 
-Motion / submit keymaps use `expr = true`. On any row of the focused block's
-permission section (button rows OR status row) they fire the action and
-return `""`. Off-row they return the original key, which is replayed with
-`noremap` and falls through to default Neovim behavior. `_cursor_on_focused_row`
-gates the keymap by checking the cursor row against
+Motion / submit keymaps use `expr = true`. On-row they fire the action and
+return `""`; off-row they return the original key (replayed via `noremap`).
+Gating in `PermissionManager:_cursor_on_focused_row` covers
 `[get_button_row(id, 1) .. end_row + 1]`.
 
-Digit keys `1`..`4` are NOT row-gated: they fire from anywhere in the chat
-buffer. Direct dispatch is the whole point of digit shortcuts; gating them
-would force the user to scroll to the block first.
+Digit keys `1`..`4` are NOT row-gated: direct dispatch from anywhere in the
+chat buffer.
 
 ### Cursor placement
 
-On every block-focus transition, `_jump_cursor_to(tool_call_id)`:
-
-1. Resolves the block's `end_row` via its range extmark.
-2. Resolves the first button row via
-   `MessageWriter:get_button_row(id, 1)`.
-3. Sets cursor to `(button_row + 1, 0)` (or `end_row + 1` if no buttons
-   are rendered) and `zb` anchors the row at the window bottom.
-
-On every cycle (`h`/`j`/etc.), `_jump_cursor_to_button(id, idx)` moves cursor
-to the focused button's row with the same `zb` anchor.
+`_jump_cursor_to(id)` lands on button row 1 (fallback `end_row`); cycles call
+`_jump_cursor_to_button(id, idx)`. Both anchor with `zb`.
 
 ### Auto-scroll suppression
 
 `MessageWriter:_check_auto_scroll` stops following new output when the cursor
-row contains a permission-button extmark in `NS_STATUS` OR matches the status
-row of any block whose `tracker.permission` is non-nil. The dual check covers
-both axes: button rows (highlight extmark) and the pending status row (no
-button hl on the status word itself). The tracker scan short-circuits on
-`tracker.permission`, so resolved blocks skip the extmark lookup.
+sits on a permission-button row OR on a pending block's status row. Dual
+check: button rows carry `NS_STATUS` button-hl extmarks; the status row of a
+pending block does not, so we additionally scan trackers (short-circuiting on
+`tracker.permission`).
 
 ### Highlight groups
 
@@ -176,11 +149,8 @@ consistency with the `pending` / `completed` / `failed` pills.
 
 ### Fold interaction
 
-Button rows live BELOW bottom_pad and BELOW the fold end. `Fold.close_range`
-folds 0-indexed `top_pad..bottom_pad`. Button rows and the status row are
-outside the fold. Buttons always visible regardless of fold state.
-
-No change to ADR 0001's manual-fold contract or anchor-pad invariants.
+Button rows live outside the fold (below `bottom_pad`); no fold-management
+special-case needed. ADR 0001's contract is unchanged.
 
 ## Consequences
 

--- a/docs/adr/0003-inline-permission-buttons.md
+++ b/docs/adr/0003-inline-permission-buttons.md
@@ -1,53 +1,55 @@
 # 0003. Permission buttons
 
+<!-- Filename slug kept for grep stability across history; the subject is
+"Permission buttons" since the inline rendering was dropped. -->
+
 - Status: accepted
 - Last updated: 2026-05-27
-- Related: `lua/agentic/ui/permission_manager.lua`,
-  `lua/agentic/ui/message_writer.lua`, `lua/agentic/ui/AGENTS.md`,
-  `lua/agentic/acp/AGENTS.md`
+- Commits: -
+- Related: -
 
 ## Context
 
-The previous permission UI rendered all buttons inline on row N (the status
-row) of the tool-call block. Buttons sat alongside the status word, joined by
-NBSP characters internally so `'linebreak'` would not split a single button
-across two visual rows. Two failures forced a redesign:
+Inline buttons on row N exhibited two failures and one product gap:
 
 1. **Wrap mid-button.** `'breakat'` defaults to `" ^I!@*-+;:,./?"`. Provider-
    supplied `option.name` strings like `"Always allow bash(...)"` contain `/`,
-   `.`, `-`, so even with NBSP joining internal spaces, the button still broke
+   `.`, `-`, so even with NBSP joining internal spaces the button broke
    mid-text at non-space `breakat` chars. `'breakat'` is a global option
-   (`runtime/doc/options.txt`), so it cannot be scoped to the chat window
-   without affecting every other Neovim window.
-2. **Layout overflow on long labels.** With multiple long labels on a single
-   row, buttons spilled into a second visual row and one button could end up
-   orphaned on its own wrapped line, disconnected from the status word.
-
-The static label map that masked these symptoms (`Allow` / `Allow Always` /
-`Reject` / `Reject Always`) hid the provider's intent (e.g. Claude Code's
-`"Yes, and bypass permissions"`) and produced identical text regardless of
-which provider sent the request.
+   (`runtime/doc/options.txt`); scoping it to the chat window would affect
+   every other Neovim window in the user's session.
+2. **Layout overflow on long labels.** Multiple long labels on a single row
+   spilled into a second visual row; one button could end up orphaned on its
+   own wrapped line, disconnected from the status word.
+3. **Static label map hides provider intent.** The fixed `Allow` / `Allow
+   Always` / `Reject` / `Reject Always` labels discarded provider-supplied
+   text (e.g. Claude Code's `"Yes, and bypass permissions"`) and produced
+   identical text regardless of which provider sent the request.
 
 ## Current decision
 
 One button per real buffer row, stacked between the bottom anchor pad and the
-status row of the tool-call block. The status row carries only the status word
-(`pending`, `in_progress`, `completed`, `failed`). Long labels can wrap within
-their own row but no button ever shares a visual row with another button or
-the status word.
+status row. Each pair of buttons is separated by an empty spacer row, and a
+trailing spacer sits above the status row, giving `K = 2 * N` rendered rows
+for N options (N button rows + N spacer rows). The status row carries only
+the status word (`pending`, `in_progress`, `completed`, `failed`). Long
+labels can wrap within their own row; no button ever shares a visual row
+with another button or the status word.
 
 Layout: See `ui/AGENTS.md` "Tool-call block layout". The buttons-row addendum:
-rows `M+1..M+K` are real text, one per option, outside the fold.
+rows `M+1..M+K` are real text, outside the fold; buttons sit on odd offsets,
+spacers on even offsets.
 
-Render pipeline: `PermissionManager` -> `MessageWriter:repaint_status_row` ->
-`MessageWriter:_build_permission_section` -> `_render_permission_section`.
+Render pipeline: `PermissionManager:repaint_status_row` callers ->
+`MessageWriter:repaint_status_row` -> `MessageWriter:_build_permission_section`
+-> `MessageWriter:_render_permission_section`.
 
 ```mermaid
 flowchart TD
     Add["add_request(req, cb)"]
     Map["pending[tool_call_id] = req<br/>append to _order"]
     First{first pending?}
-    Focus["_set_focus(id)<br/>install per-block keymaps<br/>jump cursor to button row 1 + zb"]
+    Focus["_set_focus(id)<br/>install per-block keymaps<br/>anchor status row at window bottom (zb), then place cursor on button row 1"]
     Paint["repaint_status_row<br/>(non-focused state)"]
     Cycle["cycle_next / cycle_prev<br/>(default <C-n> / <C-p>)"]
     Btn["h / l / k / j / <Left> / <Right> / <Up> / <Down>"]
@@ -80,7 +82,9 @@ many buttons are currently rendered.
 ### Render bookkeeping
 
 `tracker._rendered_button_count` (written only by
-`MessageWriter:_render_permission_section`) tracks rows for the next repaint.
+`MessageWriter:_render_permission_section`) tracks the K rendered rows
+(buttons + spacers) for the next repaint. Despite the field name it counts
+rows, not buttons; `K = 2 * N`.
 
 ### Provider-supplied labels
 
@@ -121,8 +125,11 @@ chat buffer.
 
 ### Cursor placement
 
-`_jump_cursor_to(id)` lands on button row 1 (fallback `end_row`); cycles call
-`_jump_cursor_to_button(id, idx)`. Both anchor with `zb`.
+`PermissionManager:_jump_cursor_to(id)` anchors the status row at window
+bottom (`zb`) and then places the cursor on button row 1 (fallback
+`end_row`). `PermissionManager:_jump_cursor_to_button(id, idx)` (cycle path)
+moves the cursor only; it does NOT re-anchor, since re-anchoring on every
+cycle would scroll buttons out of view.
 
 ### Auto-scroll suppression
 
@@ -156,17 +163,14 @@ special-case needed. ADR 0001's contract is unchanged.
 
 - `MessageWriter:_build_permission_section` and
   `_render_permission_section` own the per-row rendering; the older
-  `_build_status_row` is deleted in the same refactor (Task 7 of the
-  implementation plan).
+  `_build_status_row` is deleted.
 - `MessageWriter:get_button_row(id, index)` replaces `get_button_col(id, index)`
   for cursor placement. Buttons are real text at col 0 on their own row;
   cursor lands at `(row + 1, 0)`.
-- `tracker._rendered_button_count` lags the rendered state by one
-  `repaint_status_row` tick. Do not read it outside the render path.
 - `_check_auto_scroll` cost: O(N_blocks) in the worst case (one extmark
-  lookup per pending block). The tracker scan short-circuits on
-  `tracker.permission` so resolved blocks cost nothing; typically only one
-  block is pending at any time.
+  lookup per pending block). The tracker scan short-circuits when no
+  permission rows are rendered (`_rendered_button_count == 0`), so resolved
+  blocks cost nothing; typically only one block is pending at any time.
 - Wrap behaviour: long labels wrap to multiple visual rows within their own
   buffer line. No truncation. If a single provider label is genuinely too
   long for the window width, the user sees a soft-wrapped multi-row button.
@@ -201,6 +205,8 @@ special-case needed. ADR 0001's contract is unchanged.
 | Original plan's `Fold.close_range(..., end_row - 1)`                  | Off-by-one in plan; existing 1-indexed `end_row` already excludes row N from the fold.                                                                      |
 | Fold range INCLUDES row N                                             | Buttons hidden when block folded.                                                                                                                           |
 | Sticky cursor (no jump on focus change)                               | Loses visual anchor; user might press a digit thinking the wrong block is focused.                                                                          |
+| Render agent-supplied `option.name` inline on row N (NBSP-joined)     | Superseded by per-row stacking (this ADR). Same `breakat` failure as the inline decision; left here for traceability.                                       |
+| `]p` / `[p` no-op when target equals current focus (single pending)   | Superseded: cycle keys now jump cursor back onto the focused row even when focus does not change (see `PermissionManager:_cycle_focus`).                    |
 
 ## Changelog
 

--- a/docs/adr/0003-inline-permission-buttons.md
+++ b/docs/adr/0003-inline-permission-buttons.md
@@ -1,49 +1,69 @@
-# 0003. Inline permission buttons
+# 0003. Permission buttons
 
 - Status: accepted
-- Last updated: 2026-05-15
+- Last updated: 2026-05-27
 - Related: `lua/agentic/ui/permission_manager.lua`,
   `lua/agentic/ui/message_writer.lua`, `lua/agentic/ui/AGENTS.md`,
   `lua/agentic/acp/AGENTS.md`
 
 ## Context
 
-The previous permission UI was a single prompt rendered at the chat-buffer
-bottom by `MessageWriter:display_permission_buttons`. `PermissionManager`
-queued requests sequentially: one prompt at a time, dequeue on resolve.
+The previous permission UI rendered all buttons inline on row N (the status
+row) of the tool-call block. Buttons sat alongside the status word, joined by
+NBSP characters internally so `'linebreak'` would not split a single button
+across two visual rows. Two failures forced a redesign:
 
-Two problems:
+1. **Wrap mid-button.** `'breakat'` defaults to `" ^I!@*-+;:,./?"`. Provider-
+   supplied `option.name` strings like `"Always allow bash(...)"` contain `/`,
+   `.`, `-`, so even with NBSP joining internal spaces, the button still broke
+   mid-text at non-space `breakat` chars. `'breakat'` is a global option
+   (`runtime/doc/options.txt`), so it cannot be scoped to the chat window
+   without affecting every other Neovim window.
+2. **Layout overflow on long labels.** With multiple long labels on a single
+   row, buttons spilled into a second visual row and one button could end up
+   orphaned on its own wrapped line, disconnected from the status word.
 
-1. **Visual disconnect.** Multiple pending tool calls collapsed into a single
-   bottom prompt. The header truncated to fit (`kind(arg)` cut to buffer
-   width). Users could not tie the prompt to its originating block, especially
-   when the chat had scrolled past the tool call.
-2. **Reanchor recursion.** Every chat mutation moved the prompt to the new
-   bottom (`_reanchor_permission_prompt`). The write itself fired the
-   post-mutation hook, so a `_reanchoring` flag was required to break the
-   self-trigger loop. Worked, but cost a recursion guard and a stack-overflow
-   trap documented in the UI AGENTS file.
-
-ACP allows multiple concurrent `session/request_permission` calls; each
-carries its own `respond_tx` oneshot. The sequential queue was a UI choice
-masking protocol capability — out-of-order resolution was already supported by
-the wire format.
+The static label map that masked these symptoms (`Allow` / `Allow Always` /
+`Reject` / `Reject Always`) hid the provider's intent (e.g. Claude Code's
+`"Yes, and bypass permissions"`) and produced identical text regardless of
+which provider sent the request.
 
 ## Current decision
 
-One prompt per pending block, rendered as REAL TEXT on row N (the trailing
-slot of the tool-call layout — see `lua/agentic/ui/AGENTS.md` "Tool-call block
-layout") of each block.
+One button per real buffer row, stacked between the bottom anchor pad and the
+status row of the tool-call block. The status row carries only the status word
+(`pending`, `in_progress`, `completed`, `failed`). Long labels can wrap within
+their own row but no button ever shares a visual row with another button or
+the status word.
+
+Layout for a pending block with K options:
+
+```text
+row 0          header
+row 1          "" top_pad      fold start
+row 2..M-1     body
+row M          "" bottom_pad   fold end
+row M+1..M+K   button rows
+row M+K+1      status row      status word only
+```
+
+Render pipeline:
+`PermissionManager` -> `MessageWriter:repaint_status_row` ->
+`MessageWriter:_build_permission_section` builds
+`{ button_lines, button_segments_per_line, status_text, status_segments }` ->
+`MessageWriter:_render_permission_section(tracker, end_row, section)` deletes
+the prior K rows and inserts the new K in one buffer transaction, rewrites
+the status row, and re-applies NS_STATUS extmark segments.
 
 ```mermaid
 flowchart TD
     Add["add_request(req, cb)"]
     Map["pending[tool_call_id] = req<br/>append to _order"]
     First{first pending?}
-    Focus["_set_focus(id)<br/>install per-block keymaps<br/>jump cursor + zb"]
+    Focus["_set_focus(id)<br/>install per-block keymaps<br/>jump cursor to button row 1 + zb"]
     Paint["repaint_status_row<br/>(non-focused state)"]
     Cycle["cycle_next / cycle_prev<br/>(default <C-n> / <C-p>)"]
-    Btn["h / l / <Left> / <Right>"]
+    Btn["h / l / k / j / <Left> / <Right> / <Up> / <Down>"]
     Sub["<CR> or digit 1..4"]
     Res["resolve(id, option_id)"]
     Drain{pending empty?}
@@ -62,6 +82,28 @@ flowchart TD
     Drain -->|yes| Clear
 ```
 
+### Extmark gravity
+
+The block range extmark uses `end_right_gravity = true` at every
+`NS_TOOL_BLOCKS` write site. Inserting K button rows at `bottom_pad_row + 1`
+extends the extmark's `end_row` to the new status row; deleting K rows shrinks
+it. `get_block_end_row(id)` always points at the status row, regardless of how
+many buttons are currently rendered.
+
+### Render bookkeeping
+
+`tracker._rendered_button_count` stores the K currently rendered for the
+block. `_render_permission_section` reads it to delete the prior section
+before inserting the new one, then writes the post-render count. The field is
+internal to the render path; only `_render_permission_section` writes it.
+
+### Provider-supplied labels
+
+Button text uses `option.name` from the ACP request verbatim. The static
+`PERMISSION_OPTION_LABELS` map remains only as a fallback when `option.name`
+is nil or empty. Long or non-English labels are accepted; wrap is acceptable
+because each button has its own buffer line.
+
 ### Concurrency model
 
 - `PermissionManager.pending: table<string, PermissionRequest>` keyed by
@@ -69,80 +111,53 @@ flowchart TD
 - New arrivals appended; do not steal focus.
 - `resolve(id, option_id)` removes from map + `_order`, fires callback. If the
   resolved id was focused, focus snaps to next head (oldest remaining).
-- Head-tracking: focus always points at the oldest pending block.
 
 ### Two-level focus
 
-- **Block-level** (`Config.keymaps.permission.cycle_next` /
-  `cycle_prev`, default `<C-n>` / `<C-p>`): cycles `focused_id` across pending
-  blocks. Buffer-local keymaps are installed only while permissions are
-  pending.
-- **Button-level** (`h` / `l` / `<Left>` / `<Right>`): cycles
-  `focused_button_index` within the focused block. `<CR>` submits. Digits
-  `1`..`4` submit option N directly.
-- Button-level keymaps are installed only while a block is focused; lifecycle
-  tied to `_set_focus`.
+- **Block-level** (`Config.keymaps.permission.cycle_next` / `cycle_prev`,
+  default `<C-n>` / `<C-p>`): cycles `focused_id` across pending blocks.
+- **Button-level** (eight cycle keys: `h`, `l`, `j`, `k`, `<Left>`, `<Right>`,
+  `<Up>`, `<Down>`): cycles `focused_button_index` within the focused block.
+  `<CR>` submits. Digits `1`..`4` submit option N directly.
+
+Horizontal keys (`h`/`l`/arrows) preserved for muscle memory; vertical keys
+(`j`/`k`/`<Up>`/`<Down>`) added so motion direction matches the stacked
+layout.
 
 ### Row-gated per-block keymaps
 
-Motion / submit keymaps (`h`, `l`, `<Left>`, `<Right>`, `<CR>`) use
-`expr = true`. On row N of the focused block they fire the action and return
-`""`. Off-row they return the original key, which is replayed with `noremap`
-and falls through to default Neovim behavior (cursor motion, counts,
-read-only-buffer `<CR>`).
-
-This avoids buffer-wide hijacking of `h`/`l` while a permission is pending,
-without the complexity of an autocmd-driven install/uninstall lifecycle.
+Motion / submit keymaps use `expr = true`. On any row of the focused block's
+permission section (button rows OR status row) they fire the action and
+return `""`. Off-row they return the original key, which is replayed with
+`noremap` and falls through to default Neovim behavior. `_cursor_on_focused_row`
+gates the keymap by checking the cursor row against
+`[get_button_row(id, 1) .. end_row + 1]`.
 
 Digit keys `1`..`4` are NOT row-gated: they fire from anywhere in the chat
-buffer. Direct dispatch is the whole point of inline permissions; gating them
-to row N forces the user to scroll to the block before pressing the digit,
-which defeats the feature. Digits `1`..`9` already have no useful unprefixed
-meaning in the chat buffer (counts only matter as prefixes to motions, which
-work normally since `0` is unbound and prefix-mode swallows digits before any
-mapping triggers).
-
-Regression test:
-`lua/agentic/ui/permission_manager.test.lua::"digit keymaps fire from anywhere in the chat buffer (off-row included)"`.
-
-### Static label map
-
-Button labels are keyed by `PermissionOptionKind`:
-
-```text
-allow_once    -> Allow
-allow_always  -> Allow Always
-reject_once   -> Reject
-reject_always -> Reject Always
-```
-
-Agent-supplied `option.name` is discarded. Different providers send different
-strings for the same kind; rendering provider text would jitter the layout
-and confuse users switching providers mid-session.
+buffer. Direct dispatch is the whole point of digit shortcuts; gating them
+would force the user to scroll to the block first.
 
 ### Cursor placement
 
 On every block-focus transition, `_jump_cursor_to(tool_call_id)`:
 
 1. Resolves the block's `end_row` via its range extmark.
-2. Resolves the first button's start column via
-   `MessageWriter:get_button_col(id, 1)`.
-3. Sets cursor to `(end_row + 1, first_button_col)` and `zb` anchors row
-   N at the window bottom (matches chat auto-scroll convention, see
-   ADR 0001).
+2. Resolves the first button row via
+   `MessageWriter:get_button_row(id, 1)`.
+3. Sets cursor to `(button_row + 1, 0)` (or `end_row + 1` if no buttons
+   are rendered) and `zb` anchors the row at the window bottom.
 
-Single-pending case: `cycle_next` lands on the same `focused_id`. Instead of
-no-op'ing in `_set_focus` (early return on same id), `_cycle_focus` detects
-this and calls `_jump_cursor_to` directly, so the user can recall the focused
-row even with one pending block.
+On every cycle (`h`/`j`/etc.), `_jump_cursor_to_button(id, idx)` moves cursor
+to the focused button's row with the same `zb` anchor.
 
 ### Auto-scroll suppression
 
 `MessageWriter:_check_auto_scroll` stops following new output when the cursor
-row contains a permission-button extmark in `NS_STATUS`. The check uses
-rendered state, not `PermissionManager` focus state, so `MessageWriter` stays
-decoupled from permission ownership and row shifts remain correct after block
-rewrites.
+row contains a permission-button extmark in `NS_STATUS` OR matches the status
+row of any block whose `tracker.permission` is non-nil. The dual check covers
+both axes: button rows (highlight extmark) and the pending status row (no
+button hl on the status word itself). The tracker scan short-circuits on
+`tracker.permission`, so resolved blocks skip the extmark lookup.
 
 ### Highlight groups
 
@@ -154,77 +169,77 @@ AgenticPermissionButtonReject   bg = #7a2d2d (status_failed_bg),    bold
 AgenticPermissionButtonInactive bg = #3a3a3a
 ```
 
-Greens / reds reuse the existing status-pill palette
+Each button row gets one full-row segment covering byte cols
+`[0, #line)`. Greens / reds reuse the existing status-pill palette
 (`COLORS.status_completed_bg` / `COLORS.status_failed_bg`) for visual
 consistency with the `pending` / `completed` / `failed` pills.
 
-Button text is `" 1 ✓ Allow "` (leading + trailing space inside the
-highlighted span). No bracket wrappers — the bg fill alone reads as a button.
-
 ### Fold interaction
 
-Row N stays OUTSIDE the manual fold range. `Fold.close_range` is called with
-`(start_row + 2, end_row)` (1-indexed inclusive), which folds 0-indexed
-`top_pad..bottom_pad`. Row N (trailing / status) at 0-indexed `end_row` is
-not in the fold. Buttons always visible regardless of fold state.
+Button rows live BELOW bottom_pad and BELOW the fold end. `Fold.close_range`
+folds 0-indexed `top_pad..bottom_pad`. Button rows and the status row are
+outside the fold. Buttons always visible regardless of fold state.
 
 No change to ADR 0001's manual-fold contract or anchor-pad invariants.
 
 ## Consequences
 
-- `MessageWriter:_with_modifiable_and_notify_permission_reanchor`,
-  `set_permission_reanchor_callback`, `_on_permission_reanchor`,
-  `display_permission_buttons`, `remove_permission_buttons`,
-  `_apply_status_footer` deleted. Six call sites migrated to plain
-  `BufHelpers.with_modifiable`.
-- `PermissionManager.queue` (array) + `current_request` (single ref) replaced
-  by `pending` map. `_reanchoring` recursion guard gone.
-- `tracker.permission: PermissionState` is the single source of truth for
-  what row N renders. `MessageWriter:repaint_status_row(id)` rebuilds the
-  line from the tracker; called by both update paths
-  (`update_tool_call_block`, body refresh) and `PermissionManager` state
-  changes.
-- Auto-scroll suppression is driven by `NS_STATUS` permission-button extmarks
-  on the cursor row. No focus-row callback from `PermissionManager` to
-  `MessageWriter` is needed.
-- `<CR>` consumed on row N of focused block. Read-only buffer default
-  (next-line) was rarely useful there.
-- Sticky-reading regression on focus jump: user reading farther up the
-  chat gets yanked to row N on every focus transition. Accepted; the
-  alternative (silent focus change) loses the visual anchor.
-- Tall edit-kind diffs may scroll row N offscreen at initial render.
-  `<C-n>` recovers focus + cursor.
+- `MessageWriter:_build_permission_section` and
+  `_render_permission_section` own the per-row rendering; the older
+  `_build_status_row` is deleted in the same refactor (Task 7 of the
+  implementation plan).
+- `MessageWriter:get_button_row(id, index)` replaces `get_button_col(id, index)`
+  for cursor placement. Buttons are real text at col 0 on their own row;
+  cursor lands at `(row + 1, 0)`.
+- `tracker._rendered_button_count` lags the rendered state by one
+  `repaint_status_row` tick. Do not read it outside the render path.
+- `_check_auto_scroll` cost: O(N_blocks) in the worst case (one extmark
+  lookup per pending block). The tracker scan short-circuits on
+  `tracker.permission` so resolved blocks cost nothing; typically only one
+  block is pending at any time.
+- Wrap behaviour: long labels wrap to multiple visual rows within their own
+  buffer line. No truncation. If a single provider label is genuinely too
+  long for the window width, the user sees a soft-wrapped multi-row button.
+- `'breakat'` left at its global default; the project does not mutate it.
+  The earlier NBSP-join workaround is removed because per-row stacking
+  obviates it.
 - ADR 0001 (manual folds) and ADR 0002 (statuscolumn fences) unchanged.
 
 ## Rejected / superseded alternatives
 
-| Option                                                              | Reason rejected                                                                                                                             |
-| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Sequential queue at chat bottom (previous behavior)                 | Visual disconnect on multi-block, truncated header, reanchor recursion guard.                                                               |
-| Keep bottom prompt + add inline alongside                           | Two UIs, double bookkeeping, ambiguous focus model.                                                                                         |
-| Click / mouse buttons                                               | Pure keyboard fits Vim; mouse handling adds OS-dependent quirks.                                                                            |
-| Single focus level (block OR button)                                | Block-only loses fast direct dispatch via digits; button-only forces manual scrolling to find the right block.                              |
-| Always-on `h` / `l` buffer-local keymaps                            | Hijacks normal cursor navigation while a permission is pending.                                                                             |
-| Autocmd `CursorMoved` install / uninstall keymaps                   | Complex lifecycle (install/uninstall on every move); `expr=true` fall-through is a one-line equivalent.                                     |
-| Snap cursor back to row N (popup-style)                             | Prevents chat scrolling while a prompt is active.                                                                                           |
-| Render agent-supplied `option.name`                                 | Provider inconsistency (Claude / Gemini / Codex send different text for same kind); layout jitter on provider switch.                       |
-| Bracket wrappers `[ Allow ]`                                        | Visual noise next to bg fill; user feedback during iteration.                                                                               |
-| `link = "DiagnosticOk" / "DiagnosticError" / "Comment"` (fg-only)   | Reads as colored text, not buttons. User asked for bg fill.                                                                                 |
-| Light-bg / dark-fg button palette                                   | User chose existing dark green / red palette (`status_completed_bg`, `status_failed_bg`) for plugin-wide consistency.                       |
-| `]p` / `[p` block cycle keys                                        | Both right-hand pinky, two-key sequence, awkward; user requested ergonomic alternatives.                                                    |
-| `]p` / `[p` no-op when target equals current focus (single pending) | Cursor recall use case: user wants `<C-n>` to jump back to row N even with one pending. Fixed by explicit `_jump_cursor_to` in that branch. |
-| Customizable digits / `h` / `l` / `<Left>` / `<Right>` / `<CR>`     | YAGNI; only `cycle_next` / `cycle_prev` are config'd. Per-block keys are conventions.                                                       |
-| Original plan's `Fold.close_range(..., end_row - 1)`                | Off-by-one in plan; existing 1-indexed `end_row` already excludes row N from the fold. Changing would shrink the fold past `bottom_pad`.    |
-| Fold range INCLUDES row N                                           | Buttons hidden when block folded — opposite of the goal.                                                                                    |
-| Sticky cursor (no jump on focus change)                             | Loses visual anchor; user might press a digit thinking the wrong block is focused.                                                          |
+| Option                                                                | Reason rejected                                                                                                                                             |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Inline buttons on row N with NBSP join (this ADR's previous decision) | Long provider labels broke mid-text at `breakat` chars (`/`, `.`, `-`). NBSP only fixed spaces. `breakat` is global so cannot be scoped to the chat window. |
+| Set `breakat = " "` globally on chat window setup                     | `breakat` is a global option; setting it from the plugin would affect every other Neovim window in the user's session.                                      |
+| Render labels via `virt_text` extmarks                                | Cursor cannot land on a virtual line; loses the cursor-jumps-to-focused-button UX users rely on for selection. Also breaks copy/yank of button text.        |
+| Truncate provider labels with ellipsis                                | Loses information; "Always allow bash(...)" truncated to 30 chars tells the user nothing useful. Deferred until a real user issue surfaces.                 |
+| Static label map (this ADR's previous decision)                       | Discarded provider intent; identical text regardless of provider; non-English users could not see localised labels their provider already supplied.         |
+| `virt_lines` rendering above the status row                           | Same cursor-cannot-land-here problem as `virt_text`; user navigation via `h`/`l`/`<CR>` requires real lines.                                                |
+| Hybrid: inline when labels are short, stacked when long               | Layout shifts based on content; unpredictable; tests harder to write. Zed uses an always-stacked flat mode for similar reasons.                             |
+| Sequential queue at chat bottom (the pre-ADR-0003 behavior)           | Visual disconnect on multi-block, truncated header, reanchor recursion guard.                                                                               |
+| Keep bottom prompt + add inline alongside                             | Two UIs, double bookkeeping, ambiguous focus model.                                                                                                         |
+| Click / mouse buttons                                                 | Pure keyboard fits Vim; mouse handling adds OS-dependent quirks.                                                                                            |
+| Single focus level (block OR button)                                  | Block-only loses fast direct dispatch via digits; button-only forces manual scrolling to find the right block.                                              |
+| Always-on `h` / `l` buffer-local keymaps                              | Hijacks normal cursor navigation while a permission is pending.                                                                                             |
+| Autocmd `CursorMoved` install / uninstall keymaps                     | Complex lifecycle; `expr=true` fall-through is a one-line equivalent.                                                                                       |
+| Snap cursor back to row N (popup-style)                               | Prevents chat scrolling while a prompt is active.                                                                                                           |
+| Bracket wrappers `[ Allow ]`                                          | Visual noise next to bg fill; user feedback during iteration.                                                                                               |
+| `link = "DiagnosticOk" / "DiagnosticError" / "Comment"` (fg-only)     | Reads as colored text, not buttons. User asked for bg fill.                                                                                                 |
+| Light-bg / dark-fg button palette                                     | User chose existing dark green / red palette for plugin-wide consistency.                                                                                   |
+| `]p` / `[p` block cycle keys                                          | Both right-hand pinky, two-key sequence, awkward.                                                                                                           |
+| Customizable digits / cycle keys / `<CR>`                             | YAGNI; only `cycle_next` / `cycle_prev` are config'd.                                                                                                       |
+| Original plan's `Fold.close_range(..., end_row - 1)`                  | Off-by-one in plan; existing 1-indexed `end_row` already excludes row N from the fold.                                                                      |
+| Fold range INCLUDES row N                                             | Buttons hidden when block folded.                                                                                                                           |
+| Sticky cursor (no jump on focus change)                               | Loses visual anchor; user might press a digit thinking the wrong block is focused.                                                                          |
 
 ## Changelog
 
-| Date       | Commit  | Change                                                                                                                                           |
-| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 2026-05-13 | initial | Initial implementation per `docs/superpowers/inline-permission-buttons.md`. Concurrent map, head-tracking focus, row N text.                     |
-| 2026-05-13 | -       | Two-level focus added: `h` / `l` / `<CR>` for buttons; digits kept; static label map; bg-only highlights, brackets removed.                      |
-| 2026-05-13 | -       | Row-gated `expr=true` keymaps; cursor positions on first button column.                                                                          |
-| 2026-05-13 | -       | `<C-n>` / `<C-p>` replace `]p` / `[p`; `Config.keymaps.permission.cycle_next` / `cycle_prev` made configurable.                                  |
-| 2026-05-13 | -       | Digits `1`..`4` ungated (fire from anywhere in the chat buffer); only motion / submit keys (`h`/`l`/`<Left>`/`<Right>`/`<CR>`) remain row-gated. |
-| 2026-05-14 | -       | Auto-scroll suppresses follow mode on `NS_STATUS` permission-button rows; no `PermissionManager` focus-row callback.                             |
+| Date       | Commit  | Change                                                                                                                                                                                         |
+| ---------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-13 | initial | Initial implementation per `docs/superpowers/inline-permission-buttons.md`. Concurrent map, head-tracking focus, row N text.                                                                   |
+| 2026-05-13 | -       | Two-level focus added: `h` / `l` / `<CR>` for buttons; digits kept; static label map; bg-only highlights, brackets removed.                                                                    |
+| 2026-05-13 | -       | Row-gated `expr=true` keymaps; cursor positions on first button column.                                                                                                                        |
+| 2026-05-13 | -       | `<C-n>` / `<C-p>` replace `]p` / `[p`; `Config.keymaps.permission.cycle_next` / `cycle_prev` made configurable.                                                                                |
+| 2026-05-13 | -       | Digits `1`..`4` ungated (fire from anywhere in the chat buffer); only motion / submit keys (`h`/`l`/`<Left>`/`<Right>`/`<CR>`) remain row-gated.                                               |
+| 2026-05-14 | -       | Auto-scroll suppresses follow mode on `NS_STATUS` permission-button rows; no `PermissionManager` focus-row callback.                                                                           |
+| 2026-05-27 | -       | Stacked one-per-row buttons supersede inline row N rendering. Provider `option.name` used verbatim. Eight cycle keys (h/j/k/l + arrows). Block focus lands on button row 1. NBSP join removed. |

--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -30,8 +30,9 @@ SessionManager (per tab)
         │                       (lives in agentic.utils, not ui)
         ├── ToolBlockBorder     ╭ │ ╰ fence glyphs via statuscolumn — ADR 0002
         └── PermissionManager   pending map + focus state; rebinds per-block
-                                keymaps on focus transition. Row N rendering
-                                owned by MessageWriter (repaint_status_row)
+                                keymaps on focus transition. Button row +
+                                status row rendering owned by MessageWriter
+                                (repaint_status_row -> _render_permission_section)
 ```
 
 ## Lifecycle
@@ -127,11 +128,13 @@ or in the linked ADR — failures are not inlined here to avoid duplication.
   (self-assign cache invalidation, `BufEnter` reapply, etc.), read the
   rejected-alternatives table in ADR 0001 — every obvious workaround has been
   tried and documented.
-- Permission buttons live on row N (status line) of each pending block; row N
-  is outside the fold range, and digit keymaps are bound only while a block is
-  focused. Buttons are rendered as real text via
-  `MessageWriter:_render_status_row`; status word + button labels are
-  highlighted via extmark column ranges in `NS_STATUS`.
+- Permission buttons live one-per-row between `bottom_pad` and the status row
+  of each pending block; those button rows are outside the fold range
+  alongside the status row, and digit keymaps are bound only while a block is
+  focused. Button rows and the status row are rendered together as real text
+  via `MessageWriter:repaint_status_row` ->
+  `MessageWriter:_render_permission_section`; the status word and each button
+  label get full-row `hl_group` segments in `NS_STATUS`.
 - Foreign buffers in widget windows are redirected via `BufferGuard`
   (`lua/agentic/ui/buffer_guard.lua`) to a non-widget window in the same
   tabpage.
@@ -145,16 +148,23 @@ or in the linked ADR — failures are not inlined here to avoid duplication.
 ## Tool-call block layout
 
 ```text
-row 0    header           rewritten on every update, NOT folded
-row 1    "" top_pad       fold start anchor
-row 2..  body             replaced on every update
-row N-1  "" bottom_pad    fold end anchor
-row N    status + buttons real text, outside fold, written by
-                          MessageWriter:_render_status_row
+row 0          header         rewritten on every update, NOT folded
+row 1          "" top_pad     fold start anchor
+row 2..M-1     body           replaced on every update
+row M          "" bottom_pad  fold end anchor
+row M+1..M+K   button rows    one per pending permission option (K rows;
+                              K = 0 when no permission is pending). Outside
+                              the fold. Rendered by
+                              MessageWriter:_render_permission_section
+row M+K+1      status row     real text, outside fold, rendered together
+                              with the button rows by
+                              MessageWriter:_render_permission_section
 ```
 
 Pads are unconditional. Header is rewritten unconditionally because providers
-send placeholder titles before the real one.
+send placeholder titles before the real one. Button rows only appear while a
+permission request is pending on the block; otherwise K = 0 and the status
+row sits directly below `bottom_pad`.
 
 ## Special write paths
 
@@ -251,12 +261,15 @@ adding a new `sessionUpdate` type.
   - `vim.t` returns copies; nested edits do not persist. Read via
     `WindowDecoration.get_headers_state`, mutate, write back via
     `set_headers_state`.
-- Overwriting row N while a permission request is pending
+- Overwriting the status row or button rows while a permission request is
+  pending
   - `MessageWriter:update_tool_call_block` ends up calling
-    `repaint_status_row(tracker.tool_call_id)`. The repaint reads
-    `tracker.permission` (the state stored by `PermissionManager`), so updates
-    that arrive while buttons are visible re-render the buttons rather than
-    wipe them. If you bypass `repaint_status_row` and write to row N directly,
+    `repaint_status_row(tracker.tool_call_id)`, which delegates to
+    `_render_permission_section`. The renderer reads `tracker.permission`
+    (the state stored by `PermissionManager`) and rewrites the K button rows
+    plus the status row in one transaction, so updates that arrive while
+    buttons are visible re-render the buttons rather than wipe them. If you
+    bypass `_render_permission_section` and write to those rows directly,
     buttons disappear until the next focus event triggers a repaint.
 - Direct `nvim_buf_set_name` for widget buffers
   - Session restore (e.g. `mksession` with `blank` in `sessionoptions`)
@@ -278,8 +291,8 @@ change.
   `tool_call_fold.test.lua::should_fold::"folds a single buffer line that wraps past the threshold"`.
 - Row N is real text rendered per state —
   `message_writer.test.lua::status row::"writes the status word as real text at row N for non-pending blocks"`,
-  `..::"renders inline buttons for pending non-focused permission state"`,
-  `..::"renders inline buttons with digit prefixes when focused"`.
+  `..::"renders buttons one per row for pending non-focused permission state"`,
+  `..::"renders buttons one per row with digit prefixes when focused"`.
 - Focus transition triggers exactly 2 status-row repaints (old + new) —
   `permission_manager.test.lua::bracket cycle::"focus transition triggers exactly 2 status-row repaints"`.
 - Digit keymap dispatches the focused block's option —

--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -129,12 +129,17 @@ or in the linked ADR — failures are not inlined here to avoid duplication.
   rejected-alternatives table in ADR 0001 — every obvious workaround has been
   tried and documented.
 - Permission buttons live one-per-row between `bottom_pad` and the status row
-  of each pending block; those button rows are outside the fold range
-  alongside the status row, and digit keymaps are bound only while a block is
-  focused. Button rows and the status row are rendered together as real text
-  via `MessageWriter:repaint_status_row` ->
-  `MessageWriter:_render_permission_section`; the status word and each button
-  label get full-row `hl_group` segments in `NS_STATUS`.
+  of each pending block, with empty spacer rows between buttons and one
+  trailing spacer above the status row (`K = 2 * N` rendered rows for N
+  options). Those rows are outside the fold range alongside the status row,
+  and digit keymaps are bound only while a block is focused
+  (`permission_manager.test.lua::digit keymap lifecycle::"rebinds digit keymaps with new mapping after focus transition"`).
+- Cycle keys (`h`/`l`/`j`/`k`/arrows) and `<CR>` are row-gated: they fire
+  only when the cursor sits on a button row or on the status row of the
+  focused block. Spacer rows fall through to default motion.
+- `tracker._rendered_button_count` lags the rendered state by one
+  `repaint_status_row` tick. Read it ONLY from the render path (the writer
+  itself, never from `PermissionManager` or external code).
 - Foreign buffers in widget windows are redirected via `BufferGuard`
   (`lua/agentic/ui/buffer_guard.lua`) to a non-widget window in the same
   tabpage.
@@ -152,19 +157,20 @@ row 0          header         rewritten on every update, NOT folded
 row 1          "" top_pad     fold start anchor
 row 2..M-1     body           replaced on every update
 row M          "" bottom_pad  fold end anchor
-row M+1..M+K   button rows    one per pending permission option (K rows;
-                              K = 0 when no permission is pending). Outside
-                              the fold. Rendered by
-                              MessageWriter:_render_permission_section
-row M+K+1      status row     real text, outside fold, rendered together
-                              with the button rows by
-                              MessageWriter:_render_permission_section
+row M+1..M+K   permission     K rows: N button rows + N empty spacer rows
+                              (interleaved; trailing spacer above the
+                              status row). K = 0 when no permission is
+                              pending. Outside the fold.
+row M+K+1      status row     real text, outside the fold.
 ```
 
+`K` counts rows, not buttons (`K = 2 * N` for N options). All of `M+1..M+K+1`
+is rendered together by `MessageWriter:_render_permission_section`.
+
 Pads are unconditional. Header is rewritten unconditionally because providers
-send placeholder titles before the real one. Button rows only appear while a
-permission request is pending on the block; otherwise K = 0 and the status
-row sits directly below `bottom_pad`.
+send placeholder titles before the real one. Permission rows only appear
+while a request is pending on the block; otherwise K = 0 and the status row
+sits directly below `bottom_pad`.
 
 ## Special write paths
 
@@ -262,11 +268,11 @@ adding a new `sessionUpdate` type.
     `WindowDecoration.get_headers_state`, mutate, write back via
     `set_headers_state`.
 - Overwriting the status row or button rows while a permission request is
-  pending
+  pending (K = rendered permission rows, see "Tool-call block layout")
   - `MessageWriter:update_tool_call_block` ends up calling
     `repaint_status_row(tracker.tool_call_id)`, which delegates to
     `_render_permission_section`. The renderer reads `tracker.permission`
-    (the state stored by `PermissionManager`) and rewrites the K button rows
+    (the state stored by `PermissionManager`) and rewrites the K rows
     plus the status row in one transaction, so updates that arrive while
     buttons are visible re-render the buttons rather than wipe them. If you
     bypass `_render_permission_section` and write to those rows directly,
@@ -289,14 +295,17 @@ change.
   `tool_call_fold.test.lua::should_fold::"folds when screen-row count exceeds threshold"`.
 - Fold counts wrapped rows, not buffer lines (one mega-line still folds) —
   `tool_call_fold.test.lua::should_fold::"folds a single buffer line that wraps past the threshold"`.
-- Row N is real text rendered per state —
+- Status row + permission rows are real text rendered per state —
   `message_writer.test.lua::status row::"writes the status word as real text at row N for non-pending blocks"`,
   `..::"renders buttons one per row for pending non-focused permission state"`,
   `..::"renders buttons one per row with digit prefixes when focused"`.
+- Block range extmark grows by K on permission render
+  (`end_right_gravity = true` regression) —
+  `message_writer.test.lua::status row::_build_permission_section button rows::"extmark end_row grows by K on permission render (end_right_gravity regression)"`.
 - Focus transition triggers exactly 2 status-row repaints (old + new) —
   `permission_manager.test.lua::bracket cycle::"focus transition triggers exactly 2 status-row repaints"`.
 - Digit keymap dispatches the focused block's option —
-  `permission_manager.test.lua::digit keymap lifecycle::"digit 1 resolves the focused block's option 1"`,
+  `permission_manager.test.lua::digit keymap lifecycle::"digit 2 submits option 2"`,
   `..::"rebinds digit keymaps with new mapping after focus transition"`.
 - Bracket cycle wraps and no-ops when pending is empty —
   `permission_manager.test.lua::bracket cycle::"forward cycle wraps to first"`,

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -1186,13 +1186,14 @@ end
 --- @field status_segments agentic.ui.MessageWriter.StatusSegment[]
 
 --- Build the permission section (button rows + status row) for a block.
---- Task 1 stub: delegates to `_build_status_row` and returns the no-row
---- shape (`button_lines = {}`, `button_segments_per_line = {}`). Later
---- tasks replace the inline-button build with per-row construction.
+--- `status_text` carries only the status word; button text lives on
+--- `button_lines`, one entry per option. Each row has a single full-row
+--- highlight segment in `button_segments_per_line[i]`.
 --- @param tracker agentic.ui.MessageWriter.ToolCallBlock
 --- @return agentic.ui.MessageWriter.PermissionSection section
 function MessageWriter:_build_permission_section(tracker)
-    local status_text, status_segments = self:_build_status_row(tracker)
+    local status_text, status_segments = self:_build_status_word(tracker)
+
     --- @type agentic.ui.MessageWriter.PermissionSection
     local section = {
         button_lines = {},
@@ -1200,7 +1201,79 @@ function MessageWriter:_build_permission_section(tracker)
         status_text = status_text,
         status_segments = status_segments,
     }
+
+    local perm = tracker.permission
+    if not perm then
+        return section
+    end
+
+    local permission_icons = Config.permission_icons or {}
+    local focused_btn = perm.focused_button_index
+
+    for i, option in ipairs(perm.sorted_options) do
+        local label = option.name
+        if not label or label == "" then
+            label = PERMISSION_OPTION_LABELS[option.kind] or option.kind
+        end
+
+        local btn_icon = permission_icons[option.kind] or ""
+
+        --- @type string[]
+        local tokens = {}
+        if perm.is_focused then
+            table.insert(tokens, tostring(i))
+        end
+        if btn_icon ~= "" then
+            table.insert(tokens, btn_icon)
+        end
+        table.insert(tokens, label)
+
+        local line = table.concat(tokens, " ")
+
+        local hl_group
+        local is_button_focused = perm.is_focused and i == focused_btn
+        if not is_button_focused then
+            hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_INACTIVE
+        elseif option.kind == "allow_once" or option.kind == "allow_always" then
+            hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_ALLOW
+        else
+            hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_REJECT
+        end
+
+        table.insert(section.button_lines, line)
+        table.insert(
+            section.button_segments_per_line,
+            { { 0, #line, hl_group } }
+        )
+    end
+
     return section
+end
+
+--- Build the bare status-word text + single highlight segment for a block.
+--- Used by `_build_permission_section`; the legacy `_build_status_row`
+--- composes the same word inline with the buttons and is removed in Task 7.
+--- @param tracker agentic.ui.MessageWriter.ToolCallBlock
+--- @return string text
+--- @return agentic.ui.MessageWriter.StatusSegment[] segments
+function MessageWriter:_build_status_word(tracker)
+    local status = tracker.status
+
+    if not status or status == "" then
+        return "", {}
+    end
+
+    local icons = Config.status_icons or {}
+    local icon = icons[status] or ""
+    local status_label = icon ~= "" and (icon .. " " .. status) or status
+    local text = " " .. status_label .. " "
+
+    --- @type agentic.ui.MessageWriter.StatusSegment[]
+    local segments = {
+        { 0, #text, Theme.get_status_hl_group(status) },
+    }
+
+    return text, segments
 end
 
 --- Build the text + highlight segments for the status row (row N) of a block.

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -615,16 +615,28 @@ function MessageWriter:update_tool_call_block(tool_call_block)
 
         local new_lines, highlight_ranges = self:_prepare_block_lines(tracker)
 
+        -- Buttons (if any) live BETWEEN bottom_pad and the status row. The
+        -- body slice must end at bottom_pad to leave bottom_pad + buttons +
+        -- status untouched. Pre-permission `old_end_row - 1` was bottom_pad;
+        -- with K rendered button rows it shifts up by K.
+        --- @diagnostic disable-next-line: invisible
+        local k_buttons = tracker._rendered_button_count or 0
+        local bottom_pad_row = old_end_row - k_buttons - 1
+
         local body_lines = vim.list_slice(new_lines, 3, #new_lines - 2)
         vim.api.nvim_buf_set_lines(
             bufnr,
             start_row + ToolCallBlocks.HEADER_HEIGHT,
-            old_end_row - 1,
+            bottom_pad_row,
             false,
             body_lines
         )
 
-        local new_end_row = start_row + #new_lines - 1
+        -- After the slice, the buffer holds: header + new_body + bottom_pad +
+        -- K_buttons rendered button rows + status. `#new_lines` accounts for
+        -- header + body + 2 pads (bottom_pad + status); add K_buttons for the
+        -- preserved button section.
+        local new_end_row = start_row + #new_lines - 1 + k_buttons
 
         pcall(
             vim.api.nvim_buf_clear_namespace,
@@ -982,9 +994,10 @@ function MessageWriter:get_button_row(tool_call_id, index)
         return nil
     end
 
-    -- K rendered rows = N buttons + (N - 1) spacers = 2N - 1 -> N = (K + 1) / 2.
+    -- K rendered rows = N buttons + N spacers (one between each pair + one
+    -- trailing before the status row) = 2N -> N = K / 2.
     -- Button N maps to row offset (N - 1) * 2 from the first button row.
-    local n_buttons = math.floor((k + 1) / 2)
+    local n_buttons = math.floor(k / 2)
     if index < 1 or index > n_buttons then
         return nil
     end
@@ -1293,6 +1306,12 @@ function MessageWriter:_build_permission_section(tracker)
             section.button_segments_per_line,
             { { 0, #line, hl_group } }
         )
+    end
+
+    -- Trailing spacer between the last button and the status row.
+    if #section.button_lines > 0 then
+        table.insert(section.button_lines, "")
+        table.insert(section.button_segments_per_line, {})
     end
 
     return section

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -950,6 +950,16 @@ function MessageWriter:get_button_col(tool_call_id, index)
     return seg[1]
 end
 
+--- 0-indexed buffer row of the Nth permission button for the given block.
+--- Task 1 stub: always returns nil. Task 4 implements row resolution from
+--- the rendered button count.
+--- @param _tool_call_id string
+--- @param _index integer 1-indexed button position
+--- @return integer|nil row 0-indexed buffer row of the Nth permission button, or nil
+function MessageWriter:get_button_row(_tool_call_id, _index)
+    return nil
+end
+
 --- Recompute and write the status row (row N) for the given tool call block.
 --- Used by both the writer itself (initial render / updates) and the
 --- PermissionManager when toggling buttons / focus.
@@ -1168,6 +1178,30 @@ end
 --- @field [1] integer start_col 0-indexed inclusive
 --- @field [2] integer end_col 0-indexed exclusive
 --- @field [3] string hl_group
+
+--- @class agentic.ui.MessageWriter.PermissionSection
+--- @field button_lines string[]
+--- @field button_segments_per_line agentic.ui.MessageWriter.StatusSegment[][]
+--- @field status_text string
+--- @field status_segments agentic.ui.MessageWriter.StatusSegment[]
+
+--- Build the permission section (button rows + status row) for a block.
+--- Task 1 stub: delegates to `_build_status_row` and returns the no-row
+--- shape (`button_lines = {}`, `button_segments_per_line = {}`). Later
+--- tasks replace the inline-button build with per-row construction.
+--- @param tracker agentic.ui.MessageWriter.ToolCallBlock
+--- @return agentic.ui.MessageWriter.PermissionSection section
+function MessageWriter:_build_permission_section(tracker)
+    local status_text, status_segments = self:_build_status_row(tracker)
+    --- @type agentic.ui.MessageWriter.PermissionSection
+    local section = {
+        button_lines = {},
+        button_segments_per_line = {},
+        status_text = status_text,
+        status_segments = status_segments,
+    }
+    return section
+end
 
 --- Build the text + highlight segments for the status row (row N) of a block.
 --- Blocks with an attached PermissionState include inline buttons.

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -52,6 +52,7 @@ local TITLE_FENCE = "`````"
 --- @field diff? agentic.ui.MessageWriter.ToolCallDiff
 --- @field has_fold? boolean
 --- @field permission? agentic.ui.MessageWriter.PermissionState
+--- @field _rendered_button_count? integer Count of button rows currently rendered between bottom_pad and status row. Nil treated as 0. Only written by `_render_permission_section` after the buffer mutation; do not read outside the render path (it lags `permission` state until the next `repaint_status_row`).
 
 --- @class agentic.ui.MessageWriter
 --- @field bufnr integer
@@ -456,6 +457,7 @@ function MessageWriter:write_tool_call_block(tool_call_block)
                 id = tool_call_block.extmark_id,
                 end_row = end_row,
                 right_gravity = false,
+                end_right_gravity = true,
             })
 
         self.tool_call_blocks[tool_call_block.tool_call_id] = tool_call_block
@@ -615,6 +617,7 @@ function MessageWriter:update_tool_call_block(tool_call_block)
             id = tracker.extmark_id,
             end_row = new_end_row,
             right_gravity = false,
+            end_right_gravity = true,
         })
 
         self:_apply_status_highlights_if_present(tracker)
@@ -960,9 +963,10 @@ function MessageWriter:get_button_row(_tool_call_id, _index)
     return nil
 end
 
---- Recompute and write the status row (row N) for the given tool call block.
---- Used by both the writer itself (initial render / updates) and the
---- PermissionManager when toggling buttons / focus.
+--- Recompute and write the permission section (button rows + status row)
+--- for the given tool call block. Used by both the writer itself (initial
+--- render / updates) and the PermissionManager when toggling buttons /
+--- focus.
 --- @param tool_call_id string
 function MessageWriter:repaint_status_row(tool_call_id)
     local tracker = self.tool_call_blocks[tool_call_id]
@@ -977,8 +981,8 @@ function MessageWriter:repaint_status_row(tool_call_id)
         return
     end
 
-    local text, hl_segments = self:_build_status_row(tracker)
-    self:_render_status_row(end_row, text, hl_segments)
+    local section = self:_build_permission_section(tracker)
+    self:_render_permission_section(tracker, end_row, section)
 end
 
 --- Return the 0-indexed last row of the block, or nil when no block tracker
@@ -1375,6 +1379,141 @@ function MessageWriter:_render_status_row(row, text, hl_segments)
             hl_group = seg[3],
         })
     end
+end
+
+--- Render a permission section (button rows + status row) into the buffer.
+--- Maintains the block's `_rendered_button_count` so the next repaint can
+--- delete the previously rendered rows before inserting the new set.
+--- `end_right_gravity = true` on the block extmark keeps `end_row`
+--- attached to the status row when buttons are inserted at
+--- `bottom_pad_row + 1`; the delete path shrinks the range because the
+--- removed rows fall inside the extmark span, gravity does not affect
+--- that side of the operation.
+--- @param tracker agentic.ui.MessageWriter.ToolCallBlock
+--- @param end_row integer 0-indexed status row before this repaint
+--- @param section agentic.ui.MessageWriter.PermissionSection
+function MessageWriter:_render_permission_section(tracker, end_row, section)
+    if not vim.api.nvim_buf_is_valid(self.bufnr) then
+        return
+    end
+
+    --- @diagnostic disable-next-line: invisible
+    local k_old = tracker._rendered_button_count or 0
+    local k_new = #section.button_lines
+    local bottom_pad_row = end_row - k_old - 1
+
+    local block_start_row = self:_get_block_start_row(tracker.tool_call_id)
+    -- Floor at header + top_pad = start_row + 2. If the computed
+    -- bottom_pad_row falls into header / top_pad / body, _rendered_button_count
+    -- is stale (mid-resize race) and the delete/insert would corrupt the
+    -- block. Bail without touching the buffer.
+    local min_bottom_pad_row = (block_start_row or 0)
+        + ToolCallBlocks.HEADER_HEIGHT
+    if bottom_pad_row < min_bottom_pad_row then
+        Logger.debug(
+            "Permission section: bottom_pad_row inside block body; skip",
+            {
+                end_row = end_row,
+                k_old = k_old,
+                bottom_pad_row = bottom_pad_row,
+                min_bottom_pad_row = min_bottom_pad_row,
+            }
+        )
+        return
+    end
+
+    -- Clear NS_STATUS over the prior section range BEFORE line operations.
+    -- NS_STATUS extmarks on the prior button rows + status row use default
+    -- gravity and would otherwise be dragged into the new layout by the
+    -- subsequent insert / delete.
+    pcall(
+        vim.api.nvim_buf_clear_namespace,
+        self.bufnr,
+        NS_STATUS,
+        bottom_pad_row + 1,
+        end_row + 1
+    )
+
+    local new_status_row = bottom_pad_row + k_new + 1
+
+    BufHelpers.with_modifiable(self.bufnr, function(bufnr)
+        if k_old > 0 then
+            pcall(
+                vim.api.nvim_buf_set_lines,
+                bufnr,
+                bottom_pad_row + 1,
+                bottom_pad_row + 1 + k_old,
+                false,
+                {}
+            )
+        end
+
+        if k_new > 0 then
+            pcall(
+                vim.api.nvim_buf_set_lines,
+                bufnr,
+                bottom_pad_row + 1,
+                bottom_pad_row + 1,
+                false,
+                section.button_lines
+            )
+        end
+
+        -- Use set_text (not set_lines) for the status row so any NS_STATUS
+        -- extmarks anchored on the status row by mid-line column are not
+        -- redrawn by a full-line replace.
+        local existing = vim.api.nvim_buf_get_lines(
+            bufnr,
+            new_status_row,
+            new_status_row + 1,
+            false
+        )[1] or ""
+        pcall(
+            vim.api.nvim_buf_set_text,
+            bufnr,
+            new_status_row,
+            0,
+            new_status_row,
+            #existing,
+            { section.status_text }
+        )
+    end)
+
+    if not vim.api.nvim_buf_is_valid(self.bufnr) then
+        return
+    end
+
+    for i, line_segments in ipairs(section.button_segments_per_line) do
+        local btn_row = bottom_pad_row + i
+        for _, seg in ipairs(line_segments) do
+            vim.api.nvim_buf_set_extmark(
+                self.bufnr,
+                NS_STATUS,
+                btn_row,
+                seg[1],
+                {
+                    end_col = seg[2],
+                    hl_group = seg[3],
+                }
+            )
+        end
+    end
+
+    for _, seg in ipairs(section.status_segments) do
+        vim.api.nvim_buf_set_extmark(
+            self.bufnr,
+            NS_STATUS,
+            new_status_row,
+            seg[1],
+            {
+                end_col = seg[2],
+                hl_group = seg[3],
+            }
+        )
+    end
+
+    --- @diagnostic disable-next-line: invisible
+    tracker._rendered_button_count = k_new
 end
 
 --- Sets or updates a thinking highlight extmark over the given line range.

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -954,13 +954,30 @@ function MessageWriter:get_button_col(tool_call_id, index)
 end
 
 --- 0-indexed buffer row of the Nth permission button for the given block.
---- Task 1 stub: always returns nil. Task 4 implements row resolution from
---- the rendered button count.
---- @param _tool_call_id string
---- @param _index integer 1-indexed button position
+--- Buttons live between `bottom_pad` and the status row, one per line, in
+--- the same order as `permission.sorted_options`. `K` is the rendered
+--- button count tracked by `_render_permission_section`.
+--- @param tool_call_id string
+--- @param index integer 1-indexed button position
 --- @return integer|nil row 0-indexed buffer row of the Nth permission button, or nil
-function MessageWriter:get_button_row(_tool_call_id, _index)
-    return nil
+function MessageWriter:get_button_row(tool_call_id, index)
+    local tracker = self.tool_call_blocks[tool_call_id]
+    if not tracker or not tracker.permission then
+        return nil
+    end
+
+    --- @diagnostic disable-next-line: invisible
+    local k = tracker._rendered_button_count or 0
+    if k == 0 or index < 1 or index > k then
+        return nil
+    end
+
+    local end_row = self:get_block_end_row(tool_call_id)
+    if not end_row then
+        return nil
+    end
+
+    return (end_row - k - 1) + index
 end
 
 --- Recompute and write the permission section (button rows + status row)

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -329,6 +329,11 @@ function MessageWriter:_append_lines(lines)
     end
 end
 
+--- True when `cursor_line` sits on any row of a pending permission section
+--- (the K stacked button rows OR the status row that owns those buttons).
+--- Button rows carry `PERMISSION_BUTTON_*` extmarks in `NS_STATUS`; the
+--- status row of a pending block carries the status-word hl instead, so a
+--- per-tracker lookup covers it.
 --- @param cursor_line integer 1-indexed window cursor row
 --- @return boolean
 function MessageWriter:_cursor_on_permission_button_row(cursor_line)
@@ -354,6 +359,24 @@ function MessageWriter:_cursor_on_permission_button_row(cursor_line)
         end
     end
 
+    -- Status row of a pending block: no `PERMISSION_BUTTON_*` hl on the
+    -- status word itself, so scan trackers for any block whose status row
+    -- equals `row` AND which currently has rendered button rows above it.
+    -- Short-circuit on `tracker.permission` so resolved/non-pending blocks
+    -- skip the extmark lookup in `get_block_end_row`.
+    for tool_call_id, tracker in pairs(self.tool_call_blocks) do
+        if tracker.permission then
+            --- @diagnostic disable-next-line: invisible
+            local rendered = tracker._rendered_button_count or 0
+            if rendered > 0 then
+                local end_row = self:get_block_end_row(tool_call_id)
+                if end_row == row then
+                    return true
+                end
+            end
+        end
+    end
+
     return false
 end
 
@@ -373,6 +396,12 @@ function MessageWriter:_check_auto_scroll(bufnr)
 
     local cursor_line = vim.api.nvim_win_get_cursor(winid)[1]
 
+    -- Permission rows (status row + each rendered button row) all carry
+    -- NS_STATUS extmarks with PERMISSION_BUTTON_* highlight groups. Treat
+    -- any of them as a sticky-cursor anchor so a streaming agent update
+    -- below does not yank focus away from the user mid-decision. With the
+    -- stacked-row layout from `_render_permission_section`, button rows
+    -- are first-class permission rows -- not just the status row.
     if self:_cursor_on_permission_button_row(cursor_line) then
         return false
     end

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -353,12 +353,13 @@ function MessageWriter:_cursor_on_permission_button_row(cursor_line)
     end
 
     for tool_call_id, tracker in pairs(self.tool_call_blocks) do
-        if tracker.permission then
-            --- @diagnostic disable-next-line: invisible
-            local rendered = tracker._rendered_button_count or 0
-            if rendered > 0 then
-                local end_row = self:get_block_end_row(tool_call_id)
-                if end_row == row then
+        --- @diagnostic disable-next-line: invisible
+        local rendered = tracker._rendered_button_count or 0
+        if rendered > 0 then
+            local end_row = self:get_block_end_row(tool_call_id)
+            if end_row then
+                local first = end_row - rendered
+                if row >= first and row <= end_row then
                     return true
                 end
             end
@@ -598,6 +599,10 @@ function MessageWriter:update_tool_call_block(tool_call_block)
         local new_lines, highlight_ranges = self:_prepare_block_lines(tracker)
 
         -- Slice ends at bottom_pad so buttons + status row stay put.
+        -- INVARIANT: k_buttons must match the number of rendered rows between
+        -- bottom_pad_row and old_end_row. Only _render_permission_section
+        -- writes inside that range; if any other path inserts/deletes rows
+        -- there, this slice corrupts the block.
         --- @diagnostic disable-next-line: invisible
         local k_buttons = tracker._rendered_button_count or 0
         local bottom_pad_row = old_end_row - k_buttons - 1
@@ -971,6 +976,13 @@ function MessageWriter:get_button_row(tool_call_id, index)
         return nil
     end
 
+    -- Rendered K rows = N buttons + N spacers = 2 * N. When k disagrees with
+    -- 2 * n_buttons, state is mid-resize (sorted_options updated but no
+    -- repaint yet). Bail rather than land on a spacer or the status row.
+    if k ~= 2 * n_buttons then
+        return nil
+    end
+
     local end_row = self:get_block_end_row(tool_call_id)
     if not end_row then
         return nil
@@ -1248,6 +1260,9 @@ function MessageWriter:_build_permission_section(tracker)
         if not label or label == "" then
             label = PERMISSION_OPTION_LABELS[option.kind] or option.kind
         end
+        -- Provider-supplied name: strip newlines so set_lines does not throw
+        -- and the row still reads as a single button.
+        label = label:gsub("[\r\n]", " ")
 
         local btn_icon = permission_icons[option.kind] or ""
 
@@ -1339,6 +1354,10 @@ function MessageWriter:_render_permission_section(tracker, end_row, section)
                 min_bottom_pad_row = min_bottom_pad_row,
             }
         )
+        -- Stale k_old vs buffer state: reset so the next repaint recomputes
+        -- bottom_pad_row from scratch instead of compounding the error.
+        --- @diagnostic disable-next-line: invisible
+        tracker._rendered_button_count = 0
         return
     end
 
@@ -1356,9 +1375,10 @@ function MessageWriter:_render_permission_section(tracker, end_row, section)
 
     local new_status_row = bottom_pad_row + k_new + 1
 
+    local mutation_ok = true
     BufHelpers.with_modifiable(self.bufnr, function(bufnr)
         if k_old > 0 then
-            pcall(
+            local ok = pcall(
                 vim.api.nvim_buf_set_lines,
                 bufnr,
                 bottom_pad_row + 1,
@@ -1366,10 +1386,14 @@ function MessageWriter:_render_permission_section(tracker, end_row, section)
                 false,
                 {}
             )
+            if not ok then
+                mutation_ok = false
+                return
+            end
         end
 
         if k_new > 0 then
-            pcall(
+            local ok = pcall(
                 vim.api.nvim_buf_set_lines,
                 bufnr,
                 bottom_pad_row + 1,
@@ -1377,6 +1401,10 @@ function MessageWriter:_render_permission_section(tracker, end_row, section)
                 false,
                 section.button_lines
             )
+            if not ok then
+                mutation_ok = false
+                return
+            end
         end
 
         -- Use set_text (not set_lines) for the status row so any NS_STATUS
@@ -1388,7 +1416,7 @@ function MessageWriter:_render_permission_section(tracker, end_row, section)
             new_status_row + 1,
             false
         )[1] or ""
-        pcall(
+        local ok = pcall(
             vim.api.nvim_buf_set_text,
             bufnr,
             new_status_row,
@@ -1397,7 +1425,16 @@ function MessageWriter:_render_permission_section(tracker, end_row, section)
             #existing,
             { section.status_text }
         )
+        if not ok then
+            mutation_ok = false
+        end
     end)
+
+    if not mutation_ok then
+        -- Half-applied edit: skip the count update so the next repaint
+        -- recomputes from a known-stale baseline rather than from k_new.
+        return
+    end
 
     if not vim.api.nvim_buf_is_valid(self.bufnr) then
         return

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -978,7 +978,14 @@ function MessageWriter:get_button_row(tool_call_id, index)
 
     --- @diagnostic disable-next-line: invisible
     local k = tracker._rendered_button_count or 0
-    if k == 0 or index < 1 or index > k then
+    if k == 0 then
+        return nil
+    end
+
+    -- K rendered rows = N buttons + (N - 1) spacers = 2N - 1 -> N = (K + 1) / 2.
+    -- Button N maps to row offset (N - 1) * 2 from the first button row.
+    local n_buttons = math.floor((k + 1) / 2)
+    if index < 1 or index > n_buttons then
         return nil
     end
 
@@ -987,7 +994,8 @@ function MessageWriter:get_button_row(tool_call_id, index)
         return nil
     end
 
-    return (end_row - k - 1) + index
+    local first_button_row = end_row - k
+    return first_button_row + (index - 1) * 2
 end
 
 --- Recompute and write the permission section (button rows + status row)
@@ -1242,6 +1250,13 @@ function MessageWriter:_build_permission_section(tracker)
     local focused_btn = perm.focused_button_index
 
     for i, option in ipairs(perm.sorted_options) do
+        -- Empty spacer row between buttons for visual separation. The spacer
+        -- carries no highlight segment so the bg fill ends at the button row.
+        if i > 1 then
+            table.insert(section.button_lines, "")
+            table.insert(section.button_segments_per_line, {})
+        end
+
         local label = option.name
         if not label or label == "" then
             label = PERMISSION_OPTION_LABELS[option.kind] or option.kind
@@ -1259,7 +1274,9 @@ function MessageWriter:_build_permission_section(tracker)
         end
         table.insert(tokens, label)
 
-        local line = table.concat(tokens, " ")
+        -- Leading + trailing space inside the highlighted span so the bg
+        -- fill reads as a button, not as colored text.
+        local line = " " .. table.concat(tokens, " ") .. " "
 
         local hl_group
         local is_button_focused = perm.is_focused and i == focused_btn
@@ -1304,29 +1321,6 @@ function MessageWriter:_build_status_word(tracker)
     }
 
     return text, segments
-end
-
---- Write text and apply highlight segments at the given row in NS_STATUS.
---- @param row integer 0-indexed row
---- @param text string
---- @param hl_segments agentic.ui.MessageWriter.StatusSegment[]
-function MessageWriter:_render_status_row(row, text, hl_segments)
-    if not vim.api.nvim_buf_is_valid(self.bufnr) then
-        return
-    end
-
-    BufHelpers.with_modifiable(self.bufnr, function(bufnr)
-        pcall(vim.api.nvim_buf_set_lines, bufnr, row, row + 1, false, { text })
-    end)
-
-    pcall(vim.api.nvim_buf_clear_namespace, self.bufnr, NS_STATUS, row, row + 1)
-
-    for _, seg in ipairs(hl_segments) do
-        vim.api.nvim_buf_set_extmark(self.bufnr, NS_STATUS, row, seg[1], {
-            end_col = seg[2],
-            hl_group = seg[3],
-        })
-    end
 end
 
 --- Render a permission section (button rows + status row) into the buffer.

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -14,8 +14,8 @@ local NS_DIFF_HIGHLIGHTS =
 local NS_STATUS = vim.api.nvim_create_namespace("agentic_status_footer")
 local NS_THINKING = vim.api.nvim_create_namespace("agentic_thinking")
 
--- Static label map keyed by PermissionOptionKind
--- Agent-supplied option.name is intentionally discarded
+-- Fallback labels keyed by PermissionOptionKind. Used when the agent does
+-- not supply option.name (nil or empty).
 local PERMISSION_OPTION_LABELS = {
     allow_once = "Allow",
     allow_always = "Allow Always",
@@ -1200,18 +1200,31 @@ function MessageWriter:_build_status_row(tracker)
     local permission_icons = Config.permission_icons or {}
     local focused_btn = perm.focused_button_index
 
+    -- U+00A0 NBSP. Used inside button text so 'linebreak' won't split a
+    -- button across two visual rows. The inter-button separator stays a
+    -- regular space, which remains the only allowed break point.
+    local NBSP = "\194\160"
+    --- @param s string
+    local function nbsp(s)
+        return (s:gsub(" ", NBSP))
+    end
+
     for i, option in ipairs(perm.sorted_options) do
-        local label = PERMISSION_OPTION_LABELS[option.kind] or option.kind
+        local provider_name = option.name
+        if not provider_name or provider_name == "" then
+            provider_name = PERMISSION_OPTION_LABELS[option.kind] or option.kind
+        end
+        local label = nbsp(provider_name)
         local btn_icon = permission_icons[option.kind] or ""
         local body = ""
 
         if perm.is_focused then
-            body = string.format("%d %s %s", i, btn_icon, label)
+            body = i .. NBSP .. btn_icon .. NBSP .. label
         else
-            body = string.format("%s %s", btn_icon, label)
+            body = btn_icon .. NBSP .. label
         end
 
-        local btn = " " .. body .. " "
+        local btn = NBSP .. body .. NBSP
 
         text = text .. "  "
         local start_col = #text

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -14,8 +14,6 @@ local NS_DIFF_HIGHLIGHTS =
 local NS_STATUS = vim.api.nvim_create_namespace("agentic_status_footer")
 local NS_THINKING = vim.api.nvim_create_namespace("agentic_thinking")
 
--- Fallback labels keyed by PermissionOptionKind. Used when the agent does
--- not supply option.name (nil or empty).
 local PERMISSION_OPTION_LABELS = {
     allow_once = "Allow",
     allow_always = "Allow Always",
@@ -52,7 +50,7 @@ local TITLE_FENCE = "`````"
 --- @field diff? agentic.ui.MessageWriter.ToolCallDiff
 --- @field has_fold? boolean
 --- @field permission? agentic.ui.MessageWriter.PermissionState
---- @field _rendered_button_count? integer Count of button rows currently rendered between bottom_pad and status row. Nil treated as 0. Only written by `_render_permission_section` after the buffer mutation; do not read outside the render path (it lags `permission` state until the next `repaint_status_row`).
+--- @field _rendered_button_count? integer Rendered button-row count; lags `permission` state until the next `repaint_status_row`.
 
 --- @class agentic.ui.MessageWriter
 --- @field bufnr integer
@@ -329,11 +327,6 @@ function MessageWriter:_append_lines(lines)
     end
 end
 
---- True when `cursor_line` sits on any row of a pending permission section
---- (the K stacked button rows OR the status row that owns those buttons).
---- Button rows carry `PERMISSION_BUTTON_*` extmarks in `NS_STATUS`; the
---- status row of a pending block carries the status-word hl instead, so a
---- per-tracker lookup covers it.
 --- @param cursor_line integer 1-indexed window cursor row
 --- @return boolean
 function MessageWriter:_cursor_on_permission_button_row(cursor_line)
@@ -359,11 +352,6 @@ function MessageWriter:_cursor_on_permission_button_row(cursor_line)
         end
     end
 
-    -- Status row of a pending block: no `PERMISSION_BUTTON_*` hl on the
-    -- status word itself, so scan trackers for any block whose status row
-    -- equals `row` AND which currently has rendered button rows above it.
-    -- Short-circuit on `tracker.permission` so resolved/non-pending blocks
-    -- skip the extmark lookup in `get_block_end_row`.
     for tool_call_id, tracker in pairs(self.tool_call_blocks) do
         if tracker.permission then
             --- @diagnostic disable-next-line: invisible
@@ -396,12 +384,6 @@ function MessageWriter:_check_auto_scroll(bufnr)
 
     local cursor_line = vim.api.nvim_win_get_cursor(winid)[1]
 
-    -- Permission rows (status row + each rendered button row) all carry
-    -- NS_STATUS extmarks with PERMISSION_BUTTON_* highlight groups. Treat
-    -- any of them as a sticky-cursor anchor so a streaming agent update
-    -- below does not yank focus away from the user mid-decision. With the
-    -- stacked-row layout from `_render_permission_section`, button rows
-    -- are first-class permission rows -- not just the status row.
     if self:_cursor_on_permission_button_row(cursor_line) then
         return false
     end
@@ -615,10 +597,7 @@ function MessageWriter:update_tool_call_block(tool_call_block)
 
         local new_lines, highlight_ranges = self:_prepare_block_lines(tracker)
 
-        -- Buttons (if any) live BETWEEN bottom_pad and the status row. The
-        -- body slice must end at bottom_pad to leave bottom_pad + buttons +
-        -- status untouched. Pre-permission `old_end_row - 1` was bottom_pad;
-        -- with K rendered button rows it shifts up by K.
+        -- Slice ends at bottom_pad so buttons + status row stay put.
         --- @diagnostic disable-next-line: invisible
         local k_buttons = tracker._rendered_button_count or 0
         local bottom_pad_row = old_end_row - k_buttons - 1
@@ -632,10 +611,6 @@ function MessageWriter:update_tool_call_block(tool_call_block)
             body_lines
         )
 
-        -- After the slice, the buffer holds: header + new_body + bottom_pad +
-        -- K_buttons rendered button rows + status. `#new_lines` accounts for
-        -- header + body + 2 pads (bottom_pad + status); add K_buttons for the
-        -- preserved button section.
         local new_end_row = start_row + #new_lines - 1 + k_buttons
 
         pcall(
@@ -976,9 +951,6 @@ function MessageWriter:get_focused_button_index(tool_call_id)
 end
 
 --- 0-indexed buffer row of the Nth permission button for the given block.
---- Buttons live between `bottom_pad` and the status row, one per line, in
---- the same order as `permission.sorted_options`. `K` is the rendered
---- button count tracked by `_render_permission_section`.
 --- @param tool_call_id string
 --- @param index integer 1-indexed button position
 --- @return integer|nil row 0-indexed buffer row of the Nth permission button, or nil
@@ -994,10 +966,7 @@ function MessageWriter:get_button_row(tool_call_id, index)
         return nil
     end
 
-    -- K rendered rows = N buttons + N spacers (one between each pair + one
-    -- trailing before the status row) = 2N -> N = K / 2.
-    -- Button N maps to row offset (N - 1) * 2 from the first button row.
-    local n_buttons = math.floor(k / 2)
+    local n_buttons = #tracker.permission.sorted_options
     if index < 1 or index > n_buttons then
         return nil
     end
@@ -1237,10 +1206,6 @@ end
 --- @field status_text string
 --- @field status_segments agentic.ui.MessageWriter.StatusSegment[]
 
---- Build the permission section (button rows + status row) for a block.
---- `status_text` carries only the status word; button text lives on
---- `button_lines`, one entry per option. Each row has a single full-row
---- highlight segment in `button_segments_per_line[i]`.
 --- @param tracker agentic.ui.MessageWriter.ToolCallBlock
 --- @return agentic.ui.MessageWriter.PermissionSection section
 function MessageWriter:_build_permission_section(tracker)
@@ -1259,15 +1224,24 @@ function MessageWriter:_build_permission_section(tracker)
         return section
     end
 
+    local function push_spacer()
+        table.insert(section.button_lines, "")
+        table.insert(section.button_segments_per_line, {})
+    end
+
+    --- @param line string
+    --- @param segments agentic.ui.MessageWriter.StatusSegment[]
+    local function push_button(line, segments)
+        table.insert(section.button_lines, line)
+        table.insert(section.button_segments_per_line, segments)
+    end
+
     local permission_icons = Config.permission_icons or {}
     local focused_btn = perm.focused_button_index
 
     for i, option in ipairs(perm.sorted_options) do
-        -- Empty spacer row between buttons for visual separation. The spacer
-        -- carries no highlight segment so the bg fill ends at the button row.
         if i > 1 then
-            table.insert(section.button_lines, "")
-            table.insert(section.button_segments_per_line, {})
+            push_spacer()
         end
 
         local label = option.name
@@ -1287,8 +1261,7 @@ function MessageWriter:_build_permission_section(tracker)
         end
         table.insert(tokens, label)
 
-        -- Leading + trailing space inside the highlighted span so the bg
-        -- fill reads as a button, not as colored text.
+        -- Padding spaces extend the bg fill so the row reads as a button.
         local line = " " .. table.concat(tokens, " ") .. " "
 
         local hl_group
@@ -1301,17 +1274,11 @@ function MessageWriter:_build_permission_section(tracker)
             hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_REJECT
         end
 
-        table.insert(section.button_lines, line)
-        table.insert(
-            section.button_segments_per_line,
-            { { 0, #line, hl_group } }
-        )
+        push_button(line, { { 0, #line, hl_group } })
     end
 
-    -- Trailing spacer between the last button and the status row.
     if #section.button_lines > 0 then
-        table.insert(section.button_lines, "")
-        table.insert(section.button_segments_per_line, {})
+        push_spacer()
     end
 
     return section
@@ -1342,14 +1309,6 @@ function MessageWriter:_build_status_word(tracker)
     return text, segments
 end
 
---- Render a permission section (button rows + status row) into the buffer.
---- Maintains the block's `_rendered_button_count` so the next repaint can
---- delete the previously rendered rows before inserting the new set.
---- `end_right_gravity = true` on the block extmark keeps `end_row`
---- attached to the status row when buttons are inserted at
---- `bottom_pad_row + 1`; the delete path shrinks the range because the
---- removed rows fall inside the extmark span, gravity does not affect
---- that side of the operation.
 --- @param tracker agentic.ui.MessageWriter.ToolCallBlock
 --- @param end_row integer 0-indexed status row before this repaint
 --- @param section agentic.ui.MessageWriter.PermissionSection

--- a/lua/agentic/ui/message_writer.lua
+++ b/lua/agentic/ui/message_writer.lua
@@ -963,25 +963,6 @@ function MessageWriter:get_focused_button_index(tool_call_id)
     return tracker.permission.focused_button_index
 end
 
---- @param tool_call_id string
---- @param index integer 1-indexed button position
---- @return integer|nil col 0-indexed start column of the Nth permission button, or nil
-function MessageWriter:get_button_col(tool_call_id, index)
-    local tracker = self.tool_call_blocks[tool_call_id]
-    if not tracker or not tracker.permission then
-        return nil
-    end
-
-    local _, segments = self:_build_status_row(tracker)
-    -- segments[1] is the status word; segments[1 + i] is the i-th button.
-    local seg = segments[1 + index]
-    if not seg then
-        return nil
-    end
-
-    return seg[1]
-end
-
 --- 0-indexed buffer row of the Nth permission button for the given block.
 --- Buttons live between `bottom_pad` and the status row, one per line, in
 --- the same order as `permission.sorted_options`. `K` is the rendered
@@ -1301,8 +1282,7 @@ function MessageWriter:_build_permission_section(tracker)
 end
 
 --- Build the bare status-word text + single highlight segment for a block.
---- Used by `_build_permission_section`; the legacy `_build_status_row`
---- composes the same word inline with the buttons and is removed in Task 7.
+--- Used by `_build_permission_section` to compose the status row.
 --- @param tracker agentic.ui.MessageWriter.ToolCallBlock
 --- @return string text
 --- @return agentic.ui.MessageWriter.StatusSegment[] segments
@@ -1322,84 +1302,6 @@ function MessageWriter:_build_status_word(tracker)
     local segments = {
         { 0, #text, Theme.get_status_hl_group(status) },
     }
-
-    return text, segments
-end
-
---- Build the text + highlight segments for the status row (row N) of a block.
---- Blocks with an attached PermissionState include inline buttons.
---- @param tracker agentic.ui.MessageWriter.ToolCallBlock
---- @return string text
---- @return agentic.ui.MessageWriter.StatusSegment[] segments
-function MessageWriter:_build_status_row(tracker)
-    local status = tracker.status
-
-    if not status or status == "" then
-        return "", {}
-    end
-
-    local icons = Config.status_icons or {}
-    local icon = icons[status] or ""
-    local status_label = icon ~= "" and (icon .. " " .. status) or status
-
-    local text = " " .. status_label .. " "
-    --- @type agentic.ui.MessageWriter.StatusSegment[]
-    local segments = {
-        { 0, #text, Theme.get_status_hl_group(status) },
-    }
-
-    local perm = tracker.permission
-
-    if not perm then
-        return text, segments
-    end
-
-    local permission_icons = Config.permission_icons or {}
-    local focused_btn = perm.focused_button_index
-
-    -- U+00A0 NBSP. Used inside button text so 'linebreak' won't split a
-    -- button across two visual rows. The inter-button separator stays a
-    -- regular space, which remains the only allowed break point.
-    local NBSP = "\194\160"
-    --- @param s string
-    local function nbsp(s)
-        return (s:gsub(" ", NBSP))
-    end
-
-    for i, option in ipairs(perm.sorted_options) do
-        local provider_name = option.name
-        if not provider_name or provider_name == "" then
-            provider_name = PERMISSION_OPTION_LABELS[option.kind] or option.kind
-        end
-        local label = nbsp(provider_name)
-        local btn_icon = permission_icons[option.kind] or ""
-        local body = ""
-
-        if perm.is_focused then
-            body = i .. NBSP .. btn_icon .. NBSP .. label
-        else
-            body = btn_icon .. NBSP .. label
-        end
-
-        local btn = NBSP .. body .. NBSP
-
-        text = text .. "  "
-        local start_col = #text
-        text = text .. btn
-        local end_col = #text
-
-        local is_button_focused = perm.is_focused and i == focused_btn
-        local hl_group
-
-        if not is_button_focused then
-            hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_INACTIVE
-        elseif option.kind == "allow_once" or option.kind == "allow_always" then
-            hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_ALLOW
-        else
-            hl_group = Theme.HL_GROUPS.PERMISSION_BUTTON_REJECT
-        end
-        table.insert(segments, { start_col, end_col, hl_group })
-    end
 
     return text, segments
 end

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -269,8 +269,16 @@ describe("agentic.ui.MessageWriter", function()
                 setup_permission_block("auto-scroll-permission-row", {
                     is_focused = false,
                 })
+                local tracker =
+                    writer.tool_call_blocks["auto-scroll-permission-row"]
+                --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                local k = tracker._rendered_button_count or 0
+                assert.is_true(k > 0)
+                local end_row = block_end_row("auto-scroll-permission-row")
+                local first_button_row = end_row - k
+                -- Park cursor on the first button row (1-indexed for the API).
                 vim.api.nvim_win_set_cursor(winid, {
-                    block_end_row("auto-scroll-permission-row") + 1,
+                    first_button_row + 1,
                     0,
                 })
 
@@ -303,16 +311,26 @@ describe("agentic.ui.MessageWriter", function()
                 or ""
         end
 
+        --- All NS_STATUS extmarks on the button rows of the block.
+        --- Uses `{last_btn_row, -1}` as the inclusive end so the query does
+        --- not bleed into the status row's marks below.
         --- @param tool_call_id string
         --- @return vim.api.keyset.get_extmark_item[]
-        local function status_marks(tool_call_id)
-            local row = block_end_row(tool_call_id)
+        local function button_row_marks(tool_call_id)
+            local tracker = writer.tool_call_blocks[tool_call_id]
+            --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+            local k = tracker._rendered_button_count or 0
+            if k == 0 then
+                return {}
+            end
+            local end_row = block_end_row(tool_call_id)
+            local bottom_pad_row = end_row - k - 1
             local ns = vim.api.nvim_create_namespace("agentic_status_footer")
             return vim.api.nvim_buf_get_extmarks(
                 bufnr,
                 ns,
-                { row, 0 },
-                { row + 1, 0 },
+                { bottom_pad_row + 1, 0 },
+                { bottom_pad_row + k, -1 },
                 { details = true }
             )
         end
@@ -368,34 +386,59 @@ describe("agentic.ui.MessageWriter", function()
             )
         end)
 
+        --- @param tool_call_id string
+        --- @return string[]
+        local function button_row_lines(tool_call_id)
+            local tracker = writer.tool_call_blocks[tool_call_id]
+            --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+            local k = tracker._rendered_button_count or 0
+            local end_row = block_end_row(tool_call_id)
+            local bottom_pad_row = end_row - k - 1
+            return vim.api.nvim_buf_get_lines(
+                bufnr,
+                bottom_pad_row + 1,
+                bottom_pad_row + 1 + k,
+                false
+            )
+        end
+
         it(
-            "renders inline buttons for pending non-focused permission state",
+            "renders one button row per option for pending non-focused permission state",
             function()
                 setup_permission_block("row-n-inactive", { is_focused = false })
 
-                local text = status_row_text("row-n-inactive")
-                assert.truthy(text:find("pending"))
-                assert.truthy(text:find("Allow"))
-                assert.truthy(text:find("Reject"))
+                local status_text = status_row_text("row-n-inactive")
+                assert.truthy(status_text:find("pending"))
+                assert.is_nil(status_text:find("Allow"))
+                assert.is_nil(status_text:find("Reject"))
+
+                local rows = button_row_lines("row-n-inactive")
+                assert.equal(2, #rows)
+                assert.truthy(rows[1]:find("Allow"))
+                assert.truthy(rows[2]:find("Reject"))
                 -- non-focused: no digit prefix
-                assert.is_nil(text:find("1 "))
+                assert.is_nil(rows[1]:find("^1 "))
+                assert.is_nil(rows[2]:find("^2 "))
             end
         )
 
-        it("renders inline buttons with digit prefixes when focused", function()
+        it("renders button rows with digit prefixes when focused", function()
             setup_permission_block("row-n-focused", { is_focused = true })
 
-            local text = status_row_text("row-n-focused")
-            -- Inside a button, tokens are NBSP-joined (see NBSP rationale in
-            -- _build_status_row). The digit prefix is followed by NBSP.
-            local NBSP = "\194\160"
-            assert.truthy(text:find("1" .. NBSP))
-            assert.truthy(text:find("2" .. NBSP))
-            assert.truthy(text:find("Allow"))
-            assert.truthy(text:find("Reject"))
+            local status_text = status_row_text("row-n-focused")
+            assert.truthy(status_text:find("pending"))
+            assert.is_nil(status_text:find("Allow"))
+            assert.is_nil(status_text:find("Reject"))
+
+            local rows = button_row_lines("row-n-focused")
+            assert.equal(2, #rows)
+            assert.truthy(rows[1]:find("^1 "))
+            assert.truthy(rows[2]:find("^2 "))
+            assert.truthy(rows[1]:find("Allow"))
+            assert.truthy(rows[2]:find("Reject"))
         end)
 
-        it("keeps inline buttons when an active update repaints", function()
+        it("keeps button rows when an active update repaints", function()
             setup_permission_block("row-n-active-update", { is_focused = true })
 
             writer:update_tool_call_block({
@@ -404,13 +447,15 @@ describe("agentic.ui.MessageWriter", function()
                 body = { "running" },
             })
 
-            local text = status_row_text("row-n-active-update")
-            local NBSP = "\194\160"
-            assert.truthy(text:find("in_progress"))
-            assert.truthy(text:find("1" .. NBSP))
-            assert.truthy(text:find("2" .. NBSP))
-            assert.truthy(text:find("Allow"))
-            assert.truthy(text:find("Reject"))
+            local status_text = status_row_text("row-n-active-update")
+            assert.truthy(status_text:find("in_progress"))
+
+            local rows = button_row_lines("row-n-active-update")
+            assert.equal(2, #rows)
+            assert.truthy(rows[1]:find("^1 "))
+            assert.truthy(rows[2]:find("^2 "))
+            assert.truthy(rows[1]:find("Allow"))
+            assert.truthy(rows[2]:find("Reject"))
         end)
 
         for _, case in ipairs({
@@ -432,7 +477,7 @@ describe("agentic.ui.MessageWriter", function()
                     .. case.label
                     .. " hl only on the focused "
                     .. case.label
-                    .. " button (focused_button_index = "
+                    .. " button row (focused_button_index = "
                     .. case.index
                     .. ")",
                 function()
@@ -442,7 +487,7 @@ describe("agentic.ui.MessageWriter", function()
                         focused_button_index = case.index,
                     })
 
-                    local marks = status_marks(id)
+                    local marks = button_row_marks(id)
                     assert.equal(1, count_hl_marks(marks, case.focused_hl))
                     assert.equal(0, count_hl_marks(marks, case.unfocused_hl))
                     -- The non-focused button stays inactive.
@@ -455,14 +500,14 @@ describe("agentic.ui.MessageWriter", function()
         end
 
         it(
-            "applies inactive highlight group for non-focused permission buttons",
+            "applies inactive highlight group on every button row when not focused",
             function()
                 setup_permission_block(
                     "row-n-hl-inactive",
                     { is_focused = false }
                 )
 
-                local marks = status_marks("row-n-hl-inactive")
+                local marks = button_row_marks("row-n-hl-inactive")
                 assert.equal(
                     2,
                     count_hl_marks(marks, "AgenticPermissionButtonInactive")
@@ -477,10 +522,11 @@ describe("agentic.ui.MessageWriter", function()
                 focused_button_index = 1,
             })
 
-            local text = status_row_text("row-n-nobracket")
-            assert.is_nil(text:find("%["))
-            assert.is_nil(text:find("%]"))
-            assert.truthy(text:find("Allow"))
+            local rows = button_row_lines("row-n-nobracket")
+            assert.equal(1, #rows)
+            assert.is_nil(rows[1]:find("%["))
+            assert.is_nil(rows[1]:find("%]"))
+            assert.truthy(rows[1]:find("Allow"))
         end)
 
         describe("_build_permission_section button rows", function()
@@ -751,20 +797,299 @@ describe("agentic.ui.MessageWriter", function()
                     )
                 end
             )
+
+            -- Task 3: render path + repaint_status_row wiring.
+
+            it(
+                "inserts K button rows between bottom_pad and the status row on first paint",
+                function()
+                    writer:write_tool_call_block(
+                        make_tool_call_block("render-first-paint", "pending")
+                    )
+                    local end_row_before = block_end_row("render-first-paint")
+
+                    writer:set_permission_state("render-first-paint", {
+                        sorted_options = ALLOW_REJECT_OPTIONS,
+                        is_focused = false,
+                    })
+                    writer:repaint_status_row("render-first-paint")
+
+                    local tracker =
+                        writer.tool_call_blocks["render-first-paint"]
+                    --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                    assert.equal(2, tracker._rendered_button_count)
+
+                    local end_row_after = block_end_row("render-first-paint")
+                    assert.equal(end_row_before + 2, end_row_after)
+
+                    local lines = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        end_row_after - 2,
+                        end_row_after + 1,
+                        false
+                    )
+                    assert.equal(3, #lines)
+                    assert.truthy(lines[1]:find("Allow"))
+                    assert.truthy(lines[2]:find("Reject"))
+                    assert.truthy(lines[3]:find("pending"))
+                end
+            )
+
+            it(
+                "renders status row with status word only and one NS_STATUS extmark per row",
+                function()
+                    setup_permission_block("render-extmarks", {
+                        is_focused = false,
+                    })
+
+                    local end_row = block_end_row("render-extmarks")
+                    local tracker = writer.tool_call_blocks["render-extmarks"]
+                    --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                    local k = tracker._rendered_button_count
+                    assert.equal(2, k)
+
+                    local status_text = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        end_row,
+                        end_row + 1,
+                        false
+                    )[1]
+                    assert.truthy(status_text:find("pending"))
+                    assert.is_nil(status_text:find("Allow"))
+                    assert.is_nil(status_text:find("Reject"))
+
+                    local ns =
+                        vim.api.nvim_create_namespace("agentic_status_footer")
+                    local marks_on_status = vim.api.nvim_buf_get_extmarks(
+                        bufnr,
+                        ns,
+                        { end_row, 0 },
+                        { end_row, -1 },
+                        { details = true }
+                    )
+                    assert.equal(1, #marks_on_status)
+
+                    local first_btn_row = end_row - k
+                    for i = 0, k - 1 do
+                        local btn_row = first_btn_row + i
+                        -- Use `{btn_row, -1}` as the end position so the
+                        -- inclusive `nvim_buf_get_extmarks` range does not
+                        -- bleed into the next row's marks.
+                        local marks = vim.api.nvim_buf_get_extmarks(
+                            bufnr,
+                            ns,
+                            { btn_row, 0 },
+                            { btn_row, -1 },
+                            { details = true }
+                        )
+                        assert.equal(1, #marks)
+                    end
+                end
+            )
+
+            it(
+                "extmark end_row grows by K on permission render (end_right_gravity regression)",
+                function()
+                    writer:write_tool_call_block(
+                        make_tool_call_block("render-gravity", "pending")
+                    )
+                    local before = block_end_row("render-gravity")
+
+                    writer:set_permission_state("render-gravity", {
+                        sorted_options = ALLOW_REJECT_OPTIONS,
+                        is_focused = false,
+                    })
+                    writer:repaint_status_row("render-gravity")
+
+                    local after = block_end_row("render-gravity")
+                    assert.equal(before + 2, after)
+
+                    -- end_row must be the new status row (the last line of the block).
+                    local lines = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        after,
+                        after + 1,
+                        false
+                    )
+                    assert.truthy(lines[1]:find("pending"))
+                end
+            )
+
+            it(
+                "rewrites button rows with digit prefix on switch to focused",
+                function()
+                    setup_permission_block("render-focus-switch", {
+                        is_focused = false,
+                    })
+
+                    local end_row = block_end_row("render-focus-switch")
+                    local rows_before = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        end_row - 2,
+                        end_row,
+                        false
+                    )
+                    assert.is_nil(rows_before[1]:find("^1 "))
+                    assert.is_nil(rows_before[2]:find("^2 "))
+
+                    writer:set_permission_state("render-focus-switch", {
+                        sorted_options = ALLOW_REJECT_OPTIONS,
+                        is_focused = true,
+                        focused_button_index = 1,
+                    })
+                    writer:repaint_status_row("render-focus-switch")
+
+                    end_row = block_end_row("render-focus-switch")
+                    local rows_after = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        end_row - 2,
+                        end_row,
+                        false
+                    )
+                    assert.truthy(rows_after[1]:find("^1 "))
+                    assert.truthy(rows_after[2]:find("^2 "))
+
+                    -- Status row still only has the status word.
+                    local status_text = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        end_row,
+                        end_row + 1,
+                        false
+                    )[1]
+                    assert.truthy(status_text:find("pending"))
+                    assert.is_nil(status_text:find("Allow"))
+                end
+            )
+
+            it(
+                "deletes button rows when permission state is cleared and shrinks block",
+                function()
+                    setup_permission_block("render-clear", {
+                        is_focused = true,
+                        focused_button_index = 1,
+                    })
+                    local end_row_with_buttons = block_end_row("render-clear")
+
+                    writer:set_permission_state("render-clear", nil)
+                    writer:repaint_status_row("render-clear")
+
+                    local tracker = writer.tool_call_blocks["render-clear"]
+                    --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                    assert.equal(0, tracker._rendered_button_count)
+
+                    local end_row_after = block_end_row("render-clear")
+                    assert.equal(end_row_with_buttons - 2, end_row_after)
+
+                    local status_text = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        end_row_after,
+                        end_row_after + 1,
+                        false
+                    )[1]
+                    assert.truthy(status_text:find("pending"))
+                    assert.is_nil(status_text:find("Allow"))
+                end
+            )
+
+            it(
+                "is idempotent when repainted twice with the same state",
+                function()
+                    setup_permission_block("render-idempotent", {
+                        is_focused = true,
+                        focused_button_index = 1,
+                    })
+
+                    local end_row_1 = block_end_row("render-idempotent")
+                    local lines_1 = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        end_row_1 - 2,
+                        end_row_1 + 1,
+                        false
+                    )
+
+                    writer:repaint_status_row("render-idempotent")
+
+                    local end_row_2 = block_end_row("render-idempotent")
+                    assert.equal(end_row_1, end_row_2)
+
+                    local lines_2 = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        end_row_2 - 2,
+                        end_row_2 + 1,
+                        false
+                    )
+                    assert.same(lines_1, lines_2)
+
+                    local tracker = writer.tool_call_blocks["render-idempotent"]
+                    --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                    assert.equal(2, tracker._rendered_button_count)
+                end
+            )
+
+            it(
+                "rendering one block does not displace another block's content",
+                function()
+                    writer:write_tool_call_block(
+                        make_tool_call_block("render-multi-a", "pending")
+                    )
+                    writer:write_tool_call_block(
+                        make_tool_call_block("render-multi-b", "pending")
+                    )
+
+                    local a_end_before = block_end_row("render-multi-a")
+                    local b_end_before = block_end_row("render-multi-b")
+                    assert.is_true(b_end_before > a_end_before)
+
+                    writer:set_permission_state("render-multi-a", {
+                        sorted_options = ALLOW_REJECT_OPTIONS,
+                        is_focused = false,
+                    })
+                    writer:repaint_status_row("render-multi-a")
+
+                    local a_end_after = block_end_row("render-multi-a")
+                    local b_end_after = block_end_row("render-multi-b")
+
+                    assert.equal(a_end_before + 2, a_end_after)
+                    assert.equal(b_end_before + 2, b_end_after)
+
+                    -- Block B unchanged: status row still carries the
+                    -- status word and no button text.
+                    local b_status = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        b_end_after,
+                        b_end_after + 1,
+                        false
+                    )[1]
+                    assert.truthy(b_status:find("pending"))
+                    assert.is_nil(b_status:find("Allow"))
+                end
+            )
         end)
 
         it(
-            "clears buttons when permission state is removed and repainted",
+            "clears button rows when permission state is removed and repainted",
             function()
                 setup_permission_block("row-n-clear", {
                     sorted_options = { ALLOW_REJECT_OPTIONS[1] },
                     is_focused = true,
                     focused_button_index = 1,
                 })
-                assert.truthy(status_row_text("row-n-clear"):find("Allow"))
+
+                local rows_before = button_row_lines("row-n-clear")
+                assert.equal(1, #rows_before)
+                assert.truthy(rows_before[1]:find("Allow"))
+                local end_row_before = block_end_row("row-n-clear")
 
                 writer:set_permission_state("row-n-clear", nil)
                 writer:repaint_status_row("row-n-clear")
+
+                local rows_after = button_row_lines("row-n-clear")
+                assert.equal(0, #rows_after)
+                local tracker = writer.tool_call_blocks["row-n-clear"]
+                --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                assert.equal(0, tracker._rendered_button_count)
+                -- Block shrinks back to its pre-permission end_row.
+                assert.equal(end_row_before - 1, block_end_row("row-n-clear"))
 
                 local text = status_row_text("row-n-clear")
                 assert.is_nil(text:find("Allow"))

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -719,13 +719,16 @@ describe("agentic.ui.MessageWriter", function()
                     --- @diagnostic disable-next-line: missing-fields
                     Config.permission_icons = {}
 
-                    local section = build_section("section-empty-icons", {
-                        sorted_options = { ALLOW_REJECT_OPTIONS[1] },
-                        is_focused = false,
-                    })
+                    local ok, section_or_err =
+                        pcall(build_section, "section-empty-icons", {
+                            sorted_options = { ALLOW_REJECT_OPTIONS[1] },
+                            is_focused = false,
+                        })
 
                     Config.permission_icons = original
 
+                    assert.is_true(ok)
+                    local section = section_or_err
                     assert.equal(1, #section.button_lines)
                     -- No icon means the label is the line content.
                     assert.equal("Allow once", section.button_lines[1])

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -264,7 +264,7 @@ describe("agentic.ui.MessageWriter", function()
         end)
 
         it(
-            "returns false when cursor is parked on a permission button row",
+            "returns false when cursor is on any permission row (button or status)",
             function()
                 setup_permission_block("auto-scroll-permission-row", {
                     is_focused = false,
@@ -283,6 +283,32 @@ describe("agentic.ui.MessageWriter", function()
                 })
 
                 assert.is_false(writer:_check_auto_scroll(bufnr))
+
+                -- Status row also carries an NS_STATUS extmark for the status
+                -- word, so parking there must also exempt from auto-scroll.
+                vim.api.nvim_win_set_cursor(winid, { end_row + 1, 0 })
+                assert.is_false(writer:_check_auto_scroll(bufnr))
+            end
+        )
+
+        it(
+            "returns true when cursor sits above the permission rows in the block body",
+            function()
+                setup_permission_block("auto-scroll-above-perm", {
+                    is_focused = false,
+                })
+                local tracker =
+                    writer.tool_call_blocks["auto-scroll-above-perm"]
+                --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                local k = tracker._rendered_button_count or 0
+                local end_row = block_end_row("auto-scroll-above-perm")
+                local bottom_pad_row = end_row - k - 1
+                -- Park cursor on the bottom_pad row (one above the first
+                -- button row). This row has no NS_STATUS extmarks and is
+                -- still within the auto-scroll threshold of the buffer end.
+                vim.api.nvim_win_set_cursor(winid, { bottom_pad_row, 0 })
+
+                assert.is_true(writer:_check_auto_scroll(bufnr))
             end
         )
 
@@ -403,7 +429,7 @@ describe("agentic.ui.MessageWriter", function()
         end
 
         it(
-            "renders one button row per option for pending non-focused permission state",
+            "renders buttons one per row for pending non-focused permission state",
             function()
                 setup_permission_block("row-n-inactive", { is_focused = false })
 
@@ -422,21 +448,24 @@ describe("agentic.ui.MessageWriter", function()
             end
         )
 
-        it("renders button rows with digit prefixes when focused", function()
-            setup_permission_block("row-n-focused", { is_focused = true })
+        it(
+            "renders buttons one per row with digit prefixes when focused",
+            function()
+                setup_permission_block("row-n-focused", { is_focused = true })
 
-            local status_text = status_row_text("row-n-focused")
-            assert.truthy(status_text:find("pending"))
-            assert.is_nil(status_text:find("Allow"))
-            assert.is_nil(status_text:find("Reject"))
+                local status_text = status_row_text("row-n-focused")
+                assert.truthy(status_text:find("pending"))
+                assert.is_nil(status_text:find("Allow"))
+                assert.is_nil(status_text:find("Reject"))
 
-            local rows = button_row_lines("row-n-focused")
-            assert.equal(2, #rows)
-            assert.truthy(rows[1]:find("^1 "))
-            assert.truthy(rows[2]:find("^2 "))
-            assert.truthy(rows[1]:find("Allow"))
-            assert.truthy(rows[2]:find("Reject"))
-        end)
+                local rows = button_row_lines("row-n-focused")
+                assert.equal(2, #rows)
+                assert.truthy(rows[1]:find("^1 "))
+                assert.truthy(rows[2]:find("^2 "))
+                assert.truthy(rows[1]:find("Allow"))
+                assert.truthy(rows[2]:find("Reject"))
+            end
+        )
 
         it("keeps button rows when an active update repaints", function()
             setup_permission_block("row-n-active-update", { is_focused = true })

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -386,8 +386,11 @@ describe("agentic.ui.MessageWriter", function()
             setup_permission_block("row-n-focused", { is_focused = true })
 
             local text = status_row_text("row-n-focused")
-            assert.truthy(text:find("1 "))
-            assert.truthy(text:find("2 "))
+            -- Inside a button, tokens are NBSP-joined (see NBSP rationale in
+            -- _build_status_row). The digit prefix is followed by NBSP.
+            local NBSP = "\194\160"
+            assert.truthy(text:find("1" .. NBSP))
+            assert.truthy(text:find("2" .. NBSP))
             assert.truthy(text:find("Allow"))
             assert.truthy(text:find("Reject"))
         end)
@@ -402,9 +405,10 @@ describe("agentic.ui.MessageWriter", function()
             })
 
             local text = status_row_text("row-n-active-update")
+            local NBSP = "\194\160"
             assert.truthy(text:find("in_progress"))
-            assert.truthy(text:find("1 "))
-            assert.truthy(text:find("2 "))
+            assert.truthy(text:find("1" .. NBSP))
+            assert.truthy(text:find("2" .. NBSP))
             assert.truthy(text:find("Allow"))
             assert.truthy(text:find("Reject"))
         end)
@@ -477,6 +481,167 @@ describe("agentic.ui.MessageWriter", function()
             assert.is_nil(text:find("%["))
             assert.is_nil(text:find("%]"))
             assert.truthy(text:find("Allow"))
+        end)
+
+        describe("button label wrapping (NBSP)", function()
+            -- U+00A0 NBSP, 2 bytes in UTF-8 (\xC2\xA0).
+            local NBSP = "\194\160"
+
+            it(
+                "uses provider option.name and joins internal spaces with NBSP",
+                function()
+                    setup_permission_block("row-n-nbsp-name", {
+                        sorted_options = {
+                            {
+                                optionId = "allow-always",
+                                name = "Allow Always",
+                                kind = "allow_always",
+                            },
+                        },
+                        is_focused = false,
+                    })
+
+                    local text = status_row_text("row-n-nbsp-name")
+                    assert.truthy(text:find("Allow" .. NBSP .. "Always"))
+                    assert.is_nil(text:find("Allow Always", 1, true))
+                end
+            )
+
+            it(
+                "joins index, icon, and label tokens with NBSP when focused",
+                function()
+                    setup_permission_block("row-n-nbsp-focused", {
+                        sorted_options = {
+                            {
+                                optionId = "allow-always",
+                                name = "Allow Always",
+                                kind = "allow_always",
+                            },
+                        },
+                        is_focused = true,
+                        focused_button_index = 1,
+                    })
+
+                    local text = status_row_text("row-n-nbsp-focused")
+                    -- "1<NBSP>...<NBSP>Allow<NBSP>Always"
+                    assert.truthy(text:find("1" .. NBSP))
+                    assert.truthy(
+                        text:find(NBSP .. "Allow" .. NBSP .. "Always")
+                    )
+                end
+            )
+
+            it("pads each button with NBSP, not regular spaces", function()
+                setup_permission_block("row-n-nbsp-pad", {
+                    sorted_options = {
+                        {
+                            optionId = "allow-once",
+                            name = "Allow",
+                            kind = "allow_once",
+                        },
+                    },
+                    is_focused = false,
+                })
+
+                local text = status_row_text("row-n-nbsp-pad")
+                -- Button is " <icon> Allow " with all spaces -> NBSP.
+                assert.truthy(text:find(NBSP .. "Allow" .. NBSP))
+            end)
+
+            it("keeps the inter-button separator as regular spaces", function()
+                setup_permission_block("row-n-nbsp-sep", {
+                    sorted_options = {
+                        {
+                            optionId = "allow-once",
+                            name = "Allow",
+                            kind = "allow_once",
+                        },
+                        {
+                            optionId = "reject-once",
+                            name = "Reject",
+                            kind = "reject_once",
+                        },
+                    },
+                    is_focused = false,
+                })
+
+                local text = status_row_text("row-n-nbsp-sep")
+                -- Two regular spaces between the two buttons must survive.
+                assert.truthy(text:find("  "))
+            end)
+
+            it("falls back to the static label when name is nil", function()
+                setup_permission_block("row-n-nbsp-nil", {
+                    sorted_options = {
+                        {
+                            optionId = "allow-always",
+                            name = nil,
+                            kind = "allow_always",
+                        },
+                    },
+                    is_focused = false,
+                })
+
+                local text = status_row_text("row-n-nbsp-nil")
+                assert.truthy(text:find("Allow" .. NBSP .. "Always"))
+            end)
+
+            it("falls back to the static label when name is empty", function()
+                setup_permission_block("row-n-nbsp-empty", {
+                    sorted_options = {
+                        {
+                            optionId = "reject-always",
+                            name = "",
+                            kind = "reject_always",
+                        },
+                    },
+                    is_focused = false,
+                })
+
+                local text = status_row_text("row-n-nbsp-empty")
+                assert.truthy(text:find("Reject" .. NBSP .. "Always"))
+            end)
+
+            it(
+                "get_button_col returns the byte col of the NBSP padding before the button",
+                function()
+                    setup_permission_block("row-n-nbsp-col", {
+                        sorted_options = {
+                            {
+                                optionId = "allow-once",
+                                name = "Allow",
+                                kind = "allow_once",
+                            },
+                            {
+                                optionId = "reject-once",
+                                name = "Reject",
+                                kind = "reject_once",
+                            },
+                        },
+                        is_focused = true,
+                        focused_button_index = 1,
+                    })
+
+                    local text = status_row_text("row-n-nbsp-col")
+                    local col_1 = writer:get_button_col("row-n-nbsp-col", 1)
+                    local col_2 = writer:get_button_col("row-n-nbsp-col", 2)
+                    assert.is_not_nil(col_1)
+                    assert.is_not_nil(col_2)
+
+                    -- Each focused button body starts with "<NBSP>1<NBSP>" / "<NBSP>2<NBSP>".
+                    -- get_button_col points at the leading NBSP of the button.
+                    --- @cast col_1 integer
+                    --- @cast col_2 integer
+                    assert.equal(
+                        NBSP .. "1" .. NBSP,
+                        text:sub(col_1 + 1, col_1 + #NBSP + 1 + #NBSP)
+                    )
+                    assert.equal(
+                        NBSP .. "2" .. NBSP,
+                        text:sub(col_2 + 1, col_2 + #NBSP + 1 + #NBSP)
+                    )
+                end
+            )
         end)
 
         it(

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -2,6 +2,7 @@
 local assert = require("tests.helpers.assert")
 local spy = require("tests.helpers.spy")
 local Config = require("agentic.config")
+local PermissionSection = require("tests.helpers.permission_section")
 
 local TITLE_FENCE = string.rep("`", 5)
 
@@ -332,9 +333,10 @@ describe("agentic.ui.MessageWriter", function()
         --- @param tool_call_id string
         --- @return string
         local function status_row_text(tool_call_id)
-            local row = block_end_row(tool_call_id)
-            return vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
-                or ""
+            return PermissionSection.status_row_text(
+                bufnr,
+                block_end_row(tool_call_id)
+            )
         end
 
         --- All NS_STATUS extmarks on the button rows of the block.
@@ -417,84 +419,76 @@ describe("agentic.ui.MessageWriter", function()
         local function button_row_lines(tool_call_id)
             local tracker = writer.tool_call_blocks[tool_call_id]
             --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
-            local k = tracker._rendered_button_count or 0
-            local end_row = block_end_row(tool_call_id)
-            local bottom_pad_row = end_row - k - 1
-            return vim.api.nvim_buf_get_lines(
+            return PermissionSection.button_row_lines(
                 bufnr,
-                bottom_pad_row + 1,
-                bottom_pad_row + 1 + k,
-                false
+                block_end_row(tool_call_id),
+                tracker._rendered_button_count or 0
             )
         end
 
-        it(
-            "renders buttons one per row for pending non-focused permission state",
-            function()
-                setup_permission_block("row-n-inactive", { is_focused = false })
+        for _, case in ipairs({
+            {
+                name = "renders buttons one per row for pending non-focused permission state",
+                id = "row-n-inactive",
+                is_focused = false,
+                status_pattern = "pending",
+                expect_digit_prefix = false,
+                post_action = nil,
+            },
+            {
+                name = "renders buttons one per row with digit prefixes when focused",
+                id = "row-n-focused",
+                is_focused = true,
+                status_pattern = "pending",
+                expect_digit_prefix = true,
+                post_action = nil,
+            },
+            {
+                name = "keeps button rows when an active update repaints",
+                id = "row-n-active-update",
+                is_focused = true,
+                status_pattern = "in_progress",
+                expect_digit_prefix = true,
+                post_action = function(id)
+                    writer:update_tool_call_block({
+                        tool_call_id = id,
+                        status = "in_progress",
+                        body = { "running" },
+                    })
+                end,
+            },
+        }) do
+            it(case.name, function()
+                setup_permission_block(
+                    case.id,
+                    { is_focused = case.is_focused }
+                )
 
-                local status_text = status_row_text("row-n-inactive")
-                assert.truthy(status_text:find("pending"))
-                assert.is_nil(status_text:find("Allow"))
-                assert.is_nil(status_text:find("Reject"))
+                if case.post_action then
+                    case.post_action(case.id)
+                end
 
-                -- 2 buttons + 1 spacer between them + 1 trailing spacer.
-                local rows = button_row_lines("row-n-inactive")
-                assert.equal(4, #rows)
-                assert.equal("", rows[2])
-                assert.equal("", rows[4])
-                assert.truthy(rows[1]:find("Allow"))
-                assert.truthy(rows[3]:find("Reject"))
-                -- non-focused: no digit prefix
-                assert.is_nil(rows[1]:find(" 1 "))
-                assert.is_nil(rows[3]:find(" 2 "))
-            end
-        )
-
-        it(
-            "renders buttons one per row with digit prefixes when focused",
-            function()
-                setup_permission_block("row-n-focused", { is_focused = true })
-
-                local status_text = status_row_text("row-n-focused")
-                assert.truthy(status_text:find("pending"))
+                local status_text = status_row_text(case.id)
+                assert.truthy(status_text:find(case.status_pattern))
                 assert.is_nil(status_text:find("Allow"))
                 assert.is_nil(status_text:find("Reject"))
 
                 -- 2 buttons + 1 inter-button spacer + 1 trailing spacer.
-                local rows = button_row_lines("row-n-focused")
+                local rows = button_row_lines(case.id)
                 assert.equal(4, #rows)
                 assert.equal("", rows[2])
                 assert.equal("", rows[4])
-                assert.truthy(rows[1]:find("^ 1 "))
-                assert.truthy(rows[3]:find("^ 2 "))
                 assert.truthy(rows[1]:find("Allow"))
                 assert.truthy(rows[3]:find("Reject"))
-            end
-        )
-
-        it("keeps button rows when an active update repaints", function()
-            setup_permission_block("row-n-active-update", { is_focused = true })
-
-            writer:update_tool_call_block({
-                tool_call_id = "row-n-active-update",
-                status = "in_progress",
-                body = { "running" },
-            })
-
-            local status_text = status_row_text("row-n-active-update")
-            assert.truthy(status_text:find("in_progress"))
-
-            -- 2 buttons + 1 inter-button spacer + 1 trailing spacer.
-            local rows = button_row_lines("row-n-active-update")
-            assert.equal(4, #rows)
-            assert.equal("", rows[2])
-            assert.equal("", rows[4])
-            assert.truthy(rows[1]:find("^ 1 "))
-            assert.truthy(rows[3]:find("^ 2 "))
-            assert.truthy(rows[1]:find("Allow"))
-            assert.truthy(rows[3]:find("Reject"))
-        end)
+                if case.expect_digit_prefix then
+                    assert.truthy(rows[1]:find("^ 1 "))
+                    assert.truthy(rows[3]:find("^ 2 "))
+                else
+                    assert.is_nil(rows[1]:find(" 1 "))
+                    assert.is_nil(rows[3]:find(" 2 "))
+                end
+            end)
+        end
 
         for _, case in ipairs({
             {
@@ -595,10 +589,6 @@ describe("agentic.ui.MessageWriter", function()
                         is_focused = false,
                     })
 
-                    -- 2 buttons + 2 spacers (one between, one trailing).
-                    assert.equal(4, #section.button_lines)
-                    assert.equal("", section.button_lines[2])
-                    assert.equal("", section.button_lines[4])
                     -- No digit prefix in non-focused state.
                     assert.is_nil(section.button_lines[1]:find(" 1 "))
                     assert.is_nil(section.button_lines[3]:find(" 2 "))
@@ -615,10 +605,6 @@ describe("agentic.ui.MessageWriter", function()
                         focused_button_index = 1,
                     })
 
-                    -- 2 buttons + 2 spacers (one between, one trailing).
-                    assert.equal(4, #section.button_lines)
-                    assert.equal("", section.button_lines[2])
-                    assert.equal("", section.button_lines[4])
                     -- Padded with leading + trailing space.
                     assert.truthy(section.button_lines[1]:find("^ 1 "))
                     assert.truthy(section.button_lines[3]:find("^ 2 "))
@@ -705,17 +691,39 @@ describe("agentic.ui.MessageWriter", function()
                 end
             )
 
-            it(
-                "writes the provider option.name verbatim on the button line",
-                function()
-                    local long_label =
-                        "Yes, and bypass permissions for this session"
-                    local section = build_section("section-long-label", {
+            for _, case in ipairs({
+                {
+                    name = "writes the provider option.name verbatim on the button line",
+                    id = "section-long-label",
+                    option_name = "Yes, and bypass permissions for this session",
+                    option_kind = "allow_always",
+                    option_id = "allow-always",
+                    expected_label = "Yes, and bypass permissions for this session",
+                },
+                {
+                    name = "falls back to the static label when option.name is nil",
+                    id = "section-fallback-nil",
+                    option_name = nil,
+                    option_kind = "allow_always",
+                    option_id = "allow-always",
+                    expected_label = "Allow Always",
+                },
+                {
+                    name = "falls back to the static label when option.name is empty",
+                    id = "section-fallback-empty",
+                    option_name = "",
+                    option_kind = "reject_always",
+                    option_id = "reject-always",
+                    expected_label = "Reject Always",
+                },
+            }) do
+                it(case.name, function()
+                    local section = build_section(case.id, {
                         sorted_options = {
                             {
-                                optionId = "allow-always",
-                                name = long_label,
-                                kind = "allow_always",
+                                optionId = case.option_id,
+                                name = case.option_name,
+                                kind = case.option_kind,
                             },
                         },
                         is_focused = false,
@@ -725,56 +733,14 @@ describe("agentic.ui.MessageWriter", function()
                     assert.equal(2, #section.button_lines)
                     assert.equal("", section.button_lines[2])
                     assert.truthy(
-                        section.button_lines[1]:find(long_label, 1, true)
+                        section.button_lines[1]:find(
+                            case.expected_label,
+                            1,
+                            true
+                        )
                     )
-                end
-            )
-
-            it(
-                "falls back to the static label when option.name is nil",
-                function()
-                    local section = build_section("section-fallback-nil", {
-                        sorted_options = {
-                            {
-                                optionId = "allow-always",
-                                name = nil,
-                                kind = "allow_always",
-                            },
-                        },
-                        is_focused = false,
-                    })
-
-                    -- 1 button + 1 trailing spacer.
-                    assert.equal(2, #section.button_lines)
-                    assert.equal("", section.button_lines[2])
-                    assert.truthy(
-                        section.button_lines[1]:find("Allow Always", 1, true)
-                    )
-                end
-            )
-
-            it(
-                "falls back to the static label when option.name is empty",
-                function()
-                    local section = build_section("section-fallback-empty", {
-                        sorted_options = {
-                            {
-                                optionId = "reject-always",
-                                name = "",
-                                kind = "reject_always",
-                            },
-                        },
-                        is_focused = false,
-                    })
-
-                    -- 1 button + 1 trailing spacer.
-                    assert.equal(2, #section.button_lines)
-                    assert.equal("", section.button_lines[2])
-                    assert.truthy(
-                        section.button_lines[1]:find("Reject Always", 1, true)
-                    )
-                end
-            )
+                end)
+            end
 
             it(
                 "produces one button line and a trailing spacer for a single option",
@@ -847,16 +813,13 @@ describe("agentic.ui.MessageWriter", function()
                     --- @diagnostic disable-next-line: missing-fields
                     Config.permission_icons = {}
 
-                    local ok, section_or_err =
-                        pcall(build_section, "section-empty-icons", {
-                            sorted_options = { ALLOW_REJECT_OPTIONS[1] },
-                            is_focused = false,
-                        })
+                    local section = build_section("section-empty-icons", {
+                        sorted_options = { ALLOW_REJECT_OPTIONS[1] },
+                        is_focused = false,
+                    })
 
                     Config.permission_icons = original
 
-                    assert.is_true(ok)
-                    local section = section_or_err
                     -- 1 button + 1 trailing spacer.
                     assert.equal(2, #section.button_lines)
                     -- No icon means label is wrapped in padding spaces.
@@ -970,16 +933,6 @@ describe("agentic.ui.MessageWriter", function()
                         )
                         assert.equal(1, #marks)
                     end
-
-                    -- Spacer row carries no segments.
-                    local spacer_marks = vim.api.nvim_buf_get_extmarks(
-                        bufnr,
-                        ns,
-                        { first_btn_row + 1, 0 },
-                        { first_btn_row + 1, -1 },
-                        { details = true }
-                    )
-                    assert.equal(0, #spacer_marks)
                 end
             )
 

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -438,10 +438,11 @@ describe("agentic.ui.MessageWriter", function()
                 assert.is_nil(status_text:find("Allow"))
                 assert.is_nil(status_text:find("Reject"))
 
-                -- 2 buttons + 1 spacer between them.
+                -- 2 buttons + 1 spacer between them + 1 trailing spacer.
                 local rows = button_row_lines("row-n-inactive")
-                assert.equal(3, #rows)
+                assert.equal(4, #rows)
                 assert.equal("", rows[2])
+                assert.equal("", rows[4])
                 assert.truthy(rows[1]:find("Allow"))
                 assert.truthy(rows[3]:find("Reject"))
                 -- non-focused: no digit prefix
@@ -460,9 +461,11 @@ describe("agentic.ui.MessageWriter", function()
                 assert.is_nil(status_text:find("Allow"))
                 assert.is_nil(status_text:find("Reject"))
 
+                -- 2 buttons + 1 inter-button spacer + 1 trailing spacer.
                 local rows = button_row_lines("row-n-focused")
-                assert.equal(3, #rows)
+                assert.equal(4, #rows)
                 assert.equal("", rows[2])
+                assert.equal("", rows[4])
                 assert.truthy(rows[1]:find("^ 1 "))
                 assert.truthy(rows[3]:find("^ 2 "))
                 assert.truthy(rows[1]:find("Allow"))
@@ -482,9 +485,11 @@ describe("agentic.ui.MessageWriter", function()
             local status_text = status_row_text("row-n-active-update")
             assert.truthy(status_text:find("in_progress"))
 
+            -- 2 buttons + 1 inter-button spacer + 1 trailing spacer.
             local rows = button_row_lines("row-n-active-update")
-            assert.equal(3, #rows)
+            assert.equal(4, #rows)
             assert.equal("", rows[2])
+            assert.equal("", rows[4])
             assert.truthy(rows[1]:find("^ 1 "))
             assert.truthy(rows[3]:find("^ 2 "))
             assert.truthy(rows[1]:find("Allow"))
@@ -555,8 +560,10 @@ describe("agentic.ui.MessageWriter", function()
                 focused_button_index = 1,
             })
 
+            -- 1 button + 1 trailing spacer.
             local rows = button_row_lines("row-n-nobracket")
-            assert.equal(1, #rows)
+            assert.equal(2, #rows)
+            assert.equal("", rows[2])
             assert.is_nil(rows[1]:find("%["))
             assert.is_nil(rows[1]:find("%]"))
             assert.truthy(rows[1]:find("Allow"))
@@ -588,9 +595,10 @@ describe("agentic.ui.MessageWriter", function()
                         is_focused = false,
                     })
 
-                    -- 2 buttons + 1 spacer between them.
-                    assert.equal(3, #section.button_lines)
+                    -- 2 buttons + 2 spacers (one between, one trailing).
+                    assert.equal(4, #section.button_lines)
                     assert.equal("", section.button_lines[2])
+                    assert.equal("", section.button_lines[4])
                     -- No digit prefix in non-focused state.
                     assert.is_nil(section.button_lines[1]:find(" 1 "))
                     assert.is_nil(section.button_lines[3]:find(" 2 "))
@@ -607,9 +615,10 @@ describe("agentic.ui.MessageWriter", function()
                         focused_button_index = 1,
                     })
 
-                    -- 2 buttons + 1 spacer between them.
-                    assert.equal(3, #section.button_lines)
+                    -- 2 buttons + 2 spacers (one between, one trailing).
+                    assert.equal(4, #section.button_lines)
                     assert.equal("", section.button_lines[2])
+                    assert.equal("", section.button_lines[4])
                     -- Padded with leading + trailing space.
                     assert.truthy(section.button_lines[1]:find("^ 1 "))
                     assert.truthy(section.button_lines[3]:find("^ 2 "))
@@ -643,10 +652,11 @@ describe("agentic.ui.MessageWriter", function()
                                 focused_button_index = case.index,
                             })
 
-                        -- 2 buttons + 1 spacer between them.
-                        assert.equal(3, #section.button_segments_per_line)
-                        -- Spacer at index 2 has no segments.
+                        -- 2 buttons + 2 spacers (between + trailing).
+                        assert.equal(4, #section.button_segments_per_line)
+                        -- Spacers at indices 2 and 4 have no segments.
                         assert.equal(0, #section.button_segments_per_line[2])
+                        assert.equal(0, #section.button_segments_per_line[4])
 
                         for _, i in ipairs({ 1, 3 }) do
                             local segs = section.button_segments_per_line[i]
@@ -678,10 +688,11 @@ describe("agentic.ui.MessageWriter", function()
                         is_focused = false,
                     })
 
-                    -- 2 buttons + 1 spacer between them.
-                    assert.equal(3, #section.button_segments_per_line)
-                    -- Spacer has no segments.
+                    -- 2 buttons + 2 spacers (between + trailing).
+                    assert.equal(4, #section.button_segments_per_line)
+                    -- Spacers at indices 2 and 4 have no segments.
                     assert.equal(0, #section.button_segments_per_line[2])
+                    assert.equal(0, #section.button_segments_per_line[4])
 
                     for _, i in ipairs({ 1, 3 }) do
                         local segs = section.button_segments_per_line[i]
@@ -710,7 +721,9 @@ describe("agentic.ui.MessageWriter", function()
                         is_focused = false,
                     })
 
-                    assert.equal(1, #section.button_lines)
+                    -- 1 button + 1 trailing spacer.
+                    assert.equal(2, #section.button_lines)
+                    assert.equal("", section.button_lines[2])
                     assert.truthy(
                         section.button_lines[1]:find(long_label, 1, true)
                     )
@@ -731,7 +744,9 @@ describe("agentic.ui.MessageWriter", function()
                         is_focused = false,
                     })
 
-                    assert.equal(1, #section.button_lines)
+                    -- 1 button + 1 trailing spacer.
+                    assert.equal(2, #section.button_lines)
+                    assert.equal("", section.button_lines[2])
                     assert.truthy(
                         section.button_lines[1]:find("Allow Always", 1, true)
                     )
@@ -752,22 +767,30 @@ describe("agentic.ui.MessageWriter", function()
                         is_focused = false,
                     })
 
-                    assert.equal(1, #section.button_lines)
+                    -- 1 button + 1 trailing spacer.
+                    assert.equal(2, #section.button_lines)
+                    assert.equal("", section.button_lines[2])
                     assert.truthy(
                         section.button_lines[1]:find("Reject Always", 1, true)
                     )
                 end
             )
 
-            it("produces one button line for a single option", function()
-                local section = build_section("section-single", {
-                    sorted_options = { ALLOW_REJECT_OPTIONS[1] },
-                    is_focused = false,
-                })
+            it(
+                "produces one button line and a trailing spacer for a single option",
+                function()
+                    local section = build_section("section-single", {
+                        sorted_options = { ALLOW_REJECT_OPTIONS[1] },
+                        is_focused = false,
+                    })
 
-                assert.equal(1, #section.button_lines)
-                assert.equal(1, #section.button_segments_per_line)
-            end)
+                    -- 1 button + 1 trailing spacer.
+                    assert.equal(2, #section.button_lines)
+                    assert.equal(2, #section.button_segments_per_line)
+                    assert.equal("", section.button_lines[2])
+                    assert.equal(0, #section.button_segments_per_line[2])
+                end
+            )
 
             it(
                 "produces one button line per option for four options",
@@ -799,10 +822,10 @@ describe("agentic.ui.MessageWriter", function()
                         focused_button_index = 3,
                     })
 
-                    -- 4 buttons + 3 spacers between them.
-                    assert.equal(7, #section.button_lines)
-                    assert.equal(7, #section.button_segments_per_line)
-                    -- Buttons at indices 1, 3, 5, 7; spacers at 2, 4, 6.
+                    -- 4 buttons + 4 spacers (between each pair + trailing).
+                    assert.equal(8, #section.button_lines)
+                    assert.equal(8, #section.button_segments_per_line)
+                    -- Buttons at indices 1, 3, 5, 7; spacers at 2, 4, 6, 8.
                     for i = 1, 4 do
                         local line_idx = (i - 1) * 2 + 1
                         assert.truthy(
@@ -811,7 +834,7 @@ describe("agentic.ui.MessageWriter", function()
                             )
                         )
                     end
-                    for _, spacer_idx in ipairs({ 2, 4, 6 }) do
+                    for _, spacer_idx in ipairs({ 2, 4, 6, 8 }) do
                         assert.equal("", section.button_lines[spacer_idx])
                     end
                 end
@@ -834,9 +857,11 @@ describe("agentic.ui.MessageWriter", function()
 
                     assert.is_true(ok)
                     local section = section_or_err
-                    assert.equal(1, #section.button_lines)
+                    -- 1 button + 1 trailing spacer.
+                    assert.equal(2, #section.button_lines)
                     -- No icon means label is wrapped in padding spaces.
                     assert.equal(" Allow once ", section.button_lines[1])
+                    assert.equal("", section.button_lines[2])
                 end
             )
 
@@ -876,23 +901,24 @@ describe("agentic.ui.MessageWriter", function()
                     local tracker =
                         writer.tool_call_blocks["render-first-paint"]
                     --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
-                    -- 2 buttons + 1 spacer between them.
-                    assert.equal(3, tracker._rendered_button_count)
+                    -- 2 buttons + 2 spacers (between + trailing).
+                    assert.equal(4, tracker._rendered_button_count)
 
                     local end_row_after = block_end_row("render-first-paint")
-                    assert.equal(end_row_before + 3, end_row_after)
+                    assert.equal(end_row_before + 4, end_row_after)
 
                     local lines = vim.api.nvim_buf_get_lines(
                         bufnr,
-                        end_row_after - 3,
+                        end_row_after - 4,
                         end_row_after + 1,
                         false
                     )
-                    assert.equal(4, #lines)
+                    assert.equal(5, #lines)
                     assert.truthy(lines[1]:find("Allow"))
                     assert.equal("", lines[2])
                     assert.truthy(lines[3]:find("Reject"))
-                    assert.truthy(lines[4]:find("pending"))
+                    assert.equal("", lines[4])
+                    assert.truthy(lines[5]:find("pending"))
                 end
             )
 
@@ -907,8 +933,8 @@ describe("agentic.ui.MessageWriter", function()
                     local tracker = writer.tool_call_blocks["render-extmarks"]
                     --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
                     local k = tracker._rendered_button_count
-                    -- 2 buttons + 1 spacer between them.
-                    assert.equal(3, k)
+                    -- 2 buttons + 2 spacers (between + trailing).
+                    assert.equal(4, k)
 
                     local status_text = vim.api.nvim_buf_get_lines(
                         bufnr,
@@ -972,8 +998,8 @@ describe("agentic.ui.MessageWriter", function()
                     writer:repaint_status_row("render-gravity")
 
                     local after = block_end_row("render-gravity")
-                    -- 2 buttons + 1 spacer between them.
-                    assert.equal(before + 3, after)
+                    -- 2 buttons + 1 inter-spacer + 1 trailing spacer.
+                    assert.equal(before + 4, after)
 
                     -- end_row must be the new status row (the last line of the block).
                     local lines = vim.api.nvim_buf_get_lines(
@@ -994,16 +1020,18 @@ describe("agentic.ui.MessageWriter", function()
                     })
 
                     local end_row = block_end_row("render-focus-switch")
-                    -- 2 buttons + 1 spacer: button rows at -3 and -1.
+                    -- 2 buttons + 1 inter-spacer + 1 trailing spacer:
+                    -- buttons at -4 and -2, spacers at -3 and -1.
                     local rows_before = vim.api.nvim_buf_get_lines(
                         bufnr,
-                        end_row - 3,
+                        end_row - 4,
                         end_row,
                         false
                     )
                     assert.is_nil(rows_before[1]:find(" 1 "))
                     assert.equal("", rows_before[2])
                     assert.is_nil(rows_before[3]:find(" 2 "))
+                    assert.equal("", rows_before[4])
 
                     writer:set_permission_state("render-focus-switch", {
                         sorted_options = ALLOW_REJECT_OPTIONS,
@@ -1015,13 +1043,14 @@ describe("agentic.ui.MessageWriter", function()
                     end_row = block_end_row("render-focus-switch")
                     local rows_after = vim.api.nvim_buf_get_lines(
                         bufnr,
-                        end_row - 3,
+                        end_row - 4,
                         end_row,
                         false
                     )
                     assert.truthy(rows_after[1]:find("^ 1 "))
                     assert.equal("", rows_after[2])
                     assert.truthy(rows_after[3]:find("^ 2 "))
+                    assert.equal("", rows_after[4])
 
                     -- Status row still only has the status word.
                     local status_text = vim.api.nvim_buf_get_lines(
@@ -1052,8 +1081,8 @@ describe("agentic.ui.MessageWriter", function()
                     assert.equal(0, tracker._rendered_button_count)
 
                     local end_row_after = block_end_row("render-clear")
-                    -- 2 buttons + 1 spacer removed.
-                    assert.equal(end_row_with_buttons - 3, end_row_after)
+                    -- 2 buttons + 1 inter-spacer + 1 trailing spacer removed.
+                    assert.equal(end_row_with_buttons - 4, end_row_after)
 
                     local status_text = vim.api.nvim_buf_get_lines(
                         bufnr,
@@ -1077,7 +1106,7 @@ describe("agentic.ui.MessageWriter", function()
                     local end_row_1 = block_end_row("render-idempotent")
                     local lines_1 = vim.api.nvim_buf_get_lines(
                         bufnr,
-                        end_row_1 - 3,
+                        end_row_1 - 4,
                         end_row_1 + 1,
                         false
                     )
@@ -1089,7 +1118,7 @@ describe("agentic.ui.MessageWriter", function()
 
                     local lines_2 = vim.api.nvim_buf_get_lines(
                         bufnr,
-                        end_row_2 - 3,
+                        end_row_2 - 4,
                         end_row_2 + 1,
                         false
                     )
@@ -1097,8 +1126,8 @@ describe("agentic.ui.MessageWriter", function()
 
                     local tracker = writer.tool_call_blocks["render-idempotent"]
                     --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
-                    -- 2 buttons + 1 spacer between them.
-                    assert.equal(3, tracker._rendered_button_count)
+                    -- 2 buttons + 1 inter-spacer + 1 trailing spacer.
+                    assert.equal(4, tracker._rendered_button_count)
                 end
             )
 
@@ -1125,9 +1154,9 @@ describe("agentic.ui.MessageWriter", function()
                     local a_end_after = block_end_row("render-multi-a")
                     local b_end_after = block_end_row("render-multi-b")
 
-                    -- 2 buttons + 1 spacer between them.
-                    assert.equal(a_end_before + 3, a_end_after)
-                    assert.equal(b_end_before + 3, b_end_after)
+                    -- 2 buttons + 1 inter-spacer + 1 trailing spacer.
+                    assert.equal(a_end_before + 4, a_end_after)
+                    assert.equal(b_end_before + 4, b_end_after)
 
                     -- Block B unchanged: status row still carries the
                     -- status word and no button text.
@@ -1152,9 +1181,11 @@ describe("agentic.ui.MessageWriter", function()
                     focused_button_index = 1,
                 })
 
+                -- 1 button + 1 trailing spacer.
                 local rows_before = button_row_lines("row-n-clear")
-                assert.equal(1, #rows_before)
+                assert.equal(2, #rows_before)
                 assert.truthy(rows_before[1]:find("Allow"))
+                assert.equal("", rows_before[2])
                 local end_row_before = block_end_row("row-n-clear")
 
                 writer:set_permission_state("row-n-clear", nil)
@@ -1166,7 +1197,7 @@ describe("agentic.ui.MessageWriter", function()
                 --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
                 assert.equal(0, tracker._rendered_button_count)
                 -- Block shrinks back to its pre-permission end_row.
-                assert.equal(end_row_before - 1, block_end_row("row-n-clear"))
+                assert.equal(end_row_before - 2, block_end_row("row-n-clear"))
 
                 local text = status_row_text("row-n-clear")
                 assert.is_nil(text:find("Allow"))
@@ -1240,10 +1271,11 @@ describe("agentic.ui.MessageWriter", function()
 
                     local end_row = block_end_row("get-row-two-options")
                     --- @cast end_row integer
-                    -- 2 buttons + 1 spacer between them = 3 rendered rows.
-                    local bottom_pad_row = end_row - 3 - 1
+                    -- 2 buttons + 1 inter-spacer + 1 trailing spacer = 4 rendered rows.
+                    local bottom_pad_row = end_row - 4 - 1
 
-                    -- Button 1 at offset +1; button 2 at offset +3 (spacer at +2).
+                    -- Button 1 at offset +1; button 2 at offset +3 (spacers
+                    -- at +2 and +4).
                     assert.equal(
                         bottom_pad_row + 1,
                         writer:get_button_row("get-row-two-options", 1)

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -1140,7 +1140,7 @@ describe("agentic.ui.MessageWriter", function()
             )
         end)
 
-        describe("get_button_row (Task 1 stub)", function()
+        describe("get_button_row", function()
             it("returns nil when the block has no permission state", function()
                 writer:write_tool_call_block(
                     make_tool_call_block("get-row-no-perm", "pending")
@@ -1152,6 +1152,35 @@ describe("agentic.ui.MessageWriter", function()
             it("returns nil for an unknown tool_call_id", function()
                 assert.is_nil(writer:get_button_row("does-not-exist", 1))
             end)
+
+            it(
+                "returns the buffer row of each rendered button after repaint",
+                function()
+                    setup_permission_block(
+                        "get-row-two-options",
+                        { is_focused = true }
+                    )
+
+                    local end_row = block_end_row("get-row-two-options")
+                    --- @cast end_row integer
+                    local bottom_pad_row = end_row - 2 - 1
+
+                    assert.equal(
+                        bottom_pad_row + 1,
+                        writer:get_button_row("get-row-two-options", 1)
+                    )
+                    assert.equal(
+                        bottom_pad_row + 2,
+                        writer:get_button_row("get-row-two-options", 2)
+                    )
+                    assert.is_nil(
+                        writer:get_button_row("get-row-two-options", 3)
+                    )
+                    assert.is_nil(
+                        writer:get_button_row("get-row-two-options", 0)
+                    )
+                end
+            )
         end)
     end)
 

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -662,6 +662,63 @@ describe("agentic.ui.MessageWriter", function()
                 assert.truthy(text:find("pending"))
             end
         )
+
+        describe("_build_permission_section (Task 1 stub)", function()
+            it(
+                "returns the no-permission shape for a completed block",
+                function()
+                    writer:write_tool_call_block(
+                        make_tool_call_block("section-completed", "completed")
+                    )
+
+                    local tracker = writer.tool_call_blocks["section-completed"]
+                    assert.is_not_nil(tracker)
+                    --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                    local section = writer:_build_permission_section(tracker)
+
+                    assert.is_table(section.button_lines)
+                    assert.equal(0, #section.button_lines)
+                    assert.is_table(section.button_segments_per_line)
+                    assert.equal(0, #section.button_segments_per_line)
+                    assert.equal("string", type(section.status_text))
+                    assert.truthy(section.status_text:find("completed"))
+                    assert.is_table(section.status_segments)
+                    assert.is_true(#section.status_segments >= 1)
+                end
+            )
+
+            it(
+                "returns the no-permission shape for a pending block without permission state",
+                function()
+                    writer:write_tool_call_block(
+                        make_tool_call_block("section-pending", "pending")
+                    )
+
+                    local tracker = writer.tool_call_blocks["section-pending"]
+                    assert.is_not_nil(tracker)
+                    --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                    local section = writer:_build_permission_section(tracker)
+
+                    assert.equal(0, #section.button_lines)
+                    assert.equal(0, #section.button_segments_per_line)
+                    assert.truthy(section.status_text:find("pending"))
+                end
+            )
+        end)
+
+        describe("get_button_row (Task 1 stub)", function()
+            it("returns nil when the block has no permission state", function()
+                writer:write_tool_call_block(
+                    make_tool_call_block("get-row-no-perm", "pending")
+                )
+
+                assert.is_nil(writer:get_button_row("get-row-no-perm", 1))
+            end)
+
+            it("returns nil for an unknown tool_call_id", function()
+                assert.is_nil(writer:get_button_row("does-not-exist", 1))
+            end)
+        end)
     end)
 
     describe("_prepare_block_lines", function()

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -483,129 +483,199 @@ describe("agentic.ui.MessageWriter", function()
             assert.truthy(text:find("Allow"))
         end)
 
-        describe("button label wrapping (NBSP)", function()
-            -- U+00A0 NBSP, 2 bytes in UTF-8 (\xC2\xA0).
-            local NBSP = "\194\160"
+        describe("_build_permission_section button rows", function()
+            --- @param id string
+            --- @param state { is_focused: boolean, focused_button_index?: integer, sorted_options?: table[] }
+            --- @return agentic.ui.MessageWriter.PermissionSection
+            local function build_section(id, state)
+                writer:write_tool_call_block(
+                    make_tool_call_block(id, "pending")
+                )
+                writer:set_permission_state(id, {
+                    sorted_options = state.sorted_options
+                        or ALLOW_REJECT_OPTIONS,
+                    is_focused = state.is_focused,
+                    focused_button_index = state.focused_button_index,
+                })
+                local tracker = writer.tool_call_blocks[id]
+                --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                return writer:_build_permission_section(tracker)
+            end
 
             it(
-                "uses provider option.name and joins internal spaces with NBSP",
+                "builds one button line per option without digit prefix when not focused",
                 function()
-                    setup_permission_block("row-n-nbsp-name", {
+                    local section = build_section("section-non-focused", {
+                        is_focused = false,
+                    })
+
+                    assert.equal(2, #section.button_lines)
+                    -- No digit prefix in non-focused state.
+                    assert.is_nil(section.button_lines[1]:find("^1 "))
+                    assert.is_nil(section.button_lines[2]:find("^2 "))
+                    assert.truthy(section.button_lines[1]:find("Allow once"))
+                    assert.truthy(section.button_lines[2]:find("Reject once"))
+                end
+            )
+
+            it(
+                "prefixes each line with the 1-indexed digit when focused",
+                function()
+                    local section = build_section("section-focused", {
+                        is_focused = true,
+                        focused_button_index = 1,
+                    })
+
+                    assert.equal(2, #section.button_lines)
+                    assert.truthy(section.button_lines[1]:find("^1 "))
+                    assert.truthy(section.button_lines[2]:find("^2 "))
+                    assert.truthy(section.button_lines[1]:find("Allow once"))
+                    assert.truthy(section.button_lines[2]:find("Reject once"))
+                end
+            )
+
+            for _, case in ipairs({
+                {
+                    index = 1,
+                    focused_hl = "AgenticPermissionButtonAllow",
+                    unfocused_hl = "AgenticPermissionButtonInactive",
+                    label = "allow",
+                },
+                {
+                    index = 2,
+                    focused_hl = "AgenticPermissionButtonReject",
+                    unfocused_hl = "AgenticPermissionButtonInactive",
+                    label = "reject",
+                },
+            }) do
+                it(
+                    "emits one full-row segment per button line for the focused "
+                        .. case.label
+                        .. " button",
+                    function()
+                        local section =
+                            build_section("section-hl-" .. case.label, {
+                                is_focused = true,
+                                focused_button_index = case.index,
+                            })
+
+                        assert.equal(2, #section.button_segments_per_line)
+                        for i, line in ipairs(section.button_lines) do
+                            local segs = section.button_segments_per_line[i]
+                            assert.equal(1, #segs)
+                            assert.equal(0, segs[1][1])
+                            assert.equal(#line, segs[1][2])
+                        end
+
+                        local focused_seg =
+                            section.button_segments_per_line[case.index][1]
+                        assert.equal(case.focused_hl, focused_seg[3])
+
+                        local other_index = case.index == 1 and 2 or 1
+                        local other_seg =
+                            section.button_segments_per_line[other_index][1]
+                        assert.equal(case.unfocused_hl, other_seg[3])
+                    end
+                )
+            end
+
+            it(
+                "uses the inactive hl group on every line when not focused",
+                function()
+                    local section = build_section("section-hl-inactive", {
+                        is_focused = false,
+                    })
+
+                    assert.equal(2, #section.button_segments_per_line)
+                    for _, segs in ipairs(section.button_segments_per_line) do
+                        assert.equal(1, #segs)
+                        assert.equal(
+                            "AgenticPermissionButtonInactive",
+                            segs[1][3]
+                        )
+                    end
+                end
+            )
+
+            it(
+                "writes the provider option.name verbatim on the button line",
+                function()
+                    local long_label =
+                        "Yes, and bypass permissions for this session"
+                    local section = build_section("section-long-label", {
                         sorted_options = {
                             {
                                 optionId = "allow-always",
-                                name = "Allow Always",
+                                name = long_label,
                                 kind = "allow_always",
                             },
                         },
                         is_focused = false,
                     })
 
-                    local text = status_row_text("row-n-nbsp-name")
-                    assert.truthy(text:find("Allow" .. NBSP .. "Always"))
-                    assert.is_nil(text:find("Allow Always", 1, true))
-                end
-            )
-
-            it(
-                "joins index, icon, and label tokens with NBSP when focused",
-                function()
-                    setup_permission_block("row-n-nbsp-focused", {
-                        sorted_options = {
-                            {
-                                optionId = "allow-always",
-                                name = "Allow Always",
-                                kind = "allow_always",
-                            },
-                        },
-                        is_focused = true,
-                        focused_button_index = 1,
-                    })
-
-                    local text = status_row_text("row-n-nbsp-focused")
-                    -- "1<NBSP>...<NBSP>Allow<NBSP>Always"
-                    assert.truthy(text:find("1" .. NBSP))
+                    assert.equal(1, #section.button_lines)
                     assert.truthy(
-                        text:find(NBSP .. "Allow" .. NBSP .. "Always")
+                        section.button_lines[1]:find(long_label, 1, true)
                     )
                 end
             )
 
-            it("pads each button with NBSP, not regular spaces", function()
-                setup_permission_block("row-n-nbsp-pad", {
-                    sorted_options = {
-                        {
-                            optionId = "allow-once",
-                            name = "Allow",
-                            kind = "allow_once",
+            it(
+                "falls back to the static label when option.name is nil",
+                function()
+                    local section = build_section("section-fallback-nil", {
+                        sorted_options = {
+                            {
+                                optionId = "allow-always",
+                                name = nil,
+                                kind = "allow_always",
+                            },
                         },
-                    },
+                        is_focused = false,
+                    })
+
+                    assert.equal(1, #section.button_lines)
+                    assert.truthy(
+                        section.button_lines[1]:find("Allow Always", 1, true)
+                    )
+                end
+            )
+
+            it(
+                "falls back to the static label when option.name is empty",
+                function()
+                    local section = build_section("section-fallback-empty", {
+                        sorted_options = {
+                            {
+                                optionId = "reject-always",
+                                name = "",
+                                kind = "reject_always",
+                            },
+                        },
+                        is_focused = false,
+                    })
+
+                    assert.equal(1, #section.button_lines)
+                    assert.truthy(
+                        section.button_lines[1]:find("Reject Always", 1, true)
+                    )
+                end
+            )
+
+            it("produces one button line for a single option", function()
+                local section = build_section("section-single", {
+                    sorted_options = { ALLOW_REJECT_OPTIONS[1] },
                     is_focused = false,
                 })
 
-                local text = status_row_text("row-n-nbsp-pad")
-                -- Button is " <icon> Allow " with all spaces -> NBSP.
-                assert.truthy(text:find(NBSP .. "Allow" .. NBSP))
-            end)
-
-            it("keeps the inter-button separator as regular spaces", function()
-                setup_permission_block("row-n-nbsp-sep", {
-                    sorted_options = {
-                        {
-                            optionId = "allow-once",
-                            name = "Allow",
-                            kind = "allow_once",
-                        },
-                        {
-                            optionId = "reject-once",
-                            name = "Reject",
-                            kind = "reject_once",
-                        },
-                    },
-                    is_focused = false,
-                })
-
-                local text = status_row_text("row-n-nbsp-sep")
-                -- Two regular spaces between the two buttons must survive.
-                assert.truthy(text:find("  "))
-            end)
-
-            it("falls back to the static label when name is nil", function()
-                setup_permission_block("row-n-nbsp-nil", {
-                    sorted_options = {
-                        {
-                            optionId = "allow-always",
-                            name = nil,
-                            kind = "allow_always",
-                        },
-                    },
-                    is_focused = false,
-                })
-
-                local text = status_row_text("row-n-nbsp-nil")
-                assert.truthy(text:find("Allow" .. NBSP .. "Always"))
-            end)
-
-            it("falls back to the static label when name is empty", function()
-                setup_permission_block("row-n-nbsp-empty", {
-                    sorted_options = {
-                        {
-                            optionId = "reject-always",
-                            name = "",
-                            kind = "reject_always",
-                        },
-                    },
-                    is_focused = false,
-                })
-
-                local text = status_row_text("row-n-nbsp-empty")
-                assert.truthy(text:find("Reject" .. NBSP .. "Always"))
+                assert.equal(1, #section.button_lines)
+                assert.equal(1, #section.button_segments_per_line)
             end)
 
             it(
-                "get_button_col returns the byte col of the NBSP padding before the button",
+                "produces one button line per option for four options",
                 function()
-                    setup_permission_block("row-n-nbsp-col", {
+                    local section = build_section("section-four", {
                         sorted_options = {
                             {
                                 optionId = "allow-once",
@@ -613,32 +683,68 @@ describe("agentic.ui.MessageWriter", function()
                                 kind = "allow_once",
                             },
                             {
+                                optionId = "allow-always",
+                                name = "Allow Always",
+                                kind = "allow_always",
+                            },
+                            {
                                 optionId = "reject-once",
                                 name = "Reject",
                                 kind = "reject_once",
                             },
+                            {
+                                optionId = "reject-always",
+                                name = "Reject Always",
+                                kind = "reject_always",
+                            },
                         },
                         is_focused = true,
-                        focused_button_index = 1,
+                        focused_button_index = 3,
                     })
 
-                    local text = status_row_text("row-n-nbsp-col")
-                    local col_1 = writer:get_button_col("row-n-nbsp-col", 1)
-                    local col_2 = writer:get_button_col("row-n-nbsp-col", 2)
-                    assert.is_not_nil(col_1)
-                    assert.is_not_nil(col_2)
+                    assert.equal(4, #section.button_lines)
+                    assert.equal(4, #section.button_segments_per_line)
+                    for i = 1, 4 do
+                        assert.truthy(
+                            section.button_lines[i]:find("^" .. i .. " ")
+                        )
+                    end
+                end
+            )
 
-                    -- Each focused button body starts with "<NBSP>1<NBSP>" / "<NBSP>2<NBSP>".
-                    -- get_button_col points at the leading NBSP of the button.
-                    --- @cast col_1 integer
-                    --- @cast col_2 integer
-                    assert.equal(
-                        NBSP .. "1" .. NBSP,
-                        text:sub(col_1 + 1, col_1 + #NBSP + 1 + #NBSP)
+            it(
+                "uses an empty icon when permission_icons config is empty",
+                function()
+                    local original = Config.permission_icons
+                    --- @diagnostic disable-next-line: missing-fields
+                    Config.permission_icons = {}
+
+                    local section = build_section("section-empty-icons", {
+                        sorted_options = { ALLOW_REJECT_OPTIONS[1] },
+                        is_focused = false,
+                    })
+
+                    Config.permission_icons = original
+
+                    assert.equal(1, #section.button_lines)
+                    -- No icon means the label is the line content.
+                    assert.equal("Allow once", section.button_lines[1])
+                end
+            )
+
+            it(
+                "carries the status word in status_text and excludes button text",
+                function()
+                    local section = build_section("section-status-text", {
+                        is_focused = false,
+                    })
+
+                    assert.truthy(section.status_text:find("pending"))
+                    assert.is_nil(
+                        section.status_text:find("Allow once", 1, true)
                     )
-                    assert.equal(
-                        NBSP .. "2" .. NBSP,
-                        text:sub(col_2 + 1, col_2 + #NBSP + 1 + #NBSP)
+                    assert.is_nil(
+                        section.status_text:find("Reject once", 1, true)
                     )
                 end
             )

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -438,13 +438,15 @@ describe("agentic.ui.MessageWriter", function()
                 assert.is_nil(status_text:find("Allow"))
                 assert.is_nil(status_text:find("Reject"))
 
+                -- 2 buttons + 1 spacer between them.
                 local rows = button_row_lines("row-n-inactive")
-                assert.equal(2, #rows)
+                assert.equal(3, #rows)
+                assert.equal("", rows[2])
                 assert.truthy(rows[1]:find("Allow"))
-                assert.truthy(rows[2]:find("Reject"))
+                assert.truthy(rows[3]:find("Reject"))
                 -- non-focused: no digit prefix
-                assert.is_nil(rows[1]:find("^1 "))
-                assert.is_nil(rows[2]:find("^2 "))
+                assert.is_nil(rows[1]:find(" 1 "))
+                assert.is_nil(rows[3]:find(" 2 "))
             end
         )
 
@@ -459,11 +461,12 @@ describe("agentic.ui.MessageWriter", function()
                 assert.is_nil(status_text:find("Reject"))
 
                 local rows = button_row_lines("row-n-focused")
-                assert.equal(2, #rows)
-                assert.truthy(rows[1]:find("^1 "))
-                assert.truthy(rows[2]:find("^2 "))
+                assert.equal(3, #rows)
+                assert.equal("", rows[2])
+                assert.truthy(rows[1]:find("^ 1 "))
+                assert.truthy(rows[3]:find("^ 2 "))
                 assert.truthy(rows[1]:find("Allow"))
-                assert.truthy(rows[2]:find("Reject"))
+                assert.truthy(rows[3]:find("Reject"))
             end
         )
 
@@ -480,11 +483,12 @@ describe("agentic.ui.MessageWriter", function()
             assert.truthy(status_text:find("in_progress"))
 
             local rows = button_row_lines("row-n-active-update")
-            assert.equal(2, #rows)
-            assert.truthy(rows[1]:find("^1 "))
-            assert.truthy(rows[2]:find("^2 "))
+            assert.equal(3, #rows)
+            assert.equal("", rows[2])
+            assert.truthy(rows[1]:find("^ 1 "))
+            assert.truthy(rows[3]:find("^ 2 "))
             assert.truthy(rows[1]:find("Allow"))
-            assert.truthy(rows[2]:find("Reject"))
+            assert.truthy(rows[3]:find("Reject"))
         end)
 
         for _, case in ipairs({
@@ -584,12 +588,14 @@ describe("agentic.ui.MessageWriter", function()
                         is_focused = false,
                     })
 
-                    assert.equal(2, #section.button_lines)
+                    -- 2 buttons + 1 spacer between them.
+                    assert.equal(3, #section.button_lines)
+                    assert.equal("", section.button_lines[2])
                     -- No digit prefix in non-focused state.
-                    assert.is_nil(section.button_lines[1]:find("^1 "))
-                    assert.is_nil(section.button_lines[2]:find("^2 "))
+                    assert.is_nil(section.button_lines[1]:find(" 1 "))
+                    assert.is_nil(section.button_lines[3]:find(" 2 "))
                     assert.truthy(section.button_lines[1]:find("Allow once"))
-                    assert.truthy(section.button_lines[2]:find("Reject once"))
+                    assert.truthy(section.button_lines[3]:find("Reject once"))
                 end
             )
 
@@ -601,11 +607,14 @@ describe("agentic.ui.MessageWriter", function()
                         focused_button_index = 1,
                     })
 
-                    assert.equal(2, #section.button_lines)
-                    assert.truthy(section.button_lines[1]:find("^1 "))
-                    assert.truthy(section.button_lines[2]:find("^2 "))
+                    -- 2 buttons + 1 spacer between them.
+                    assert.equal(3, #section.button_lines)
+                    assert.equal("", section.button_lines[2])
+                    -- Padded with leading + trailing space.
+                    assert.truthy(section.button_lines[1]:find("^ 1 "))
+                    assert.truthy(section.button_lines[3]:find("^ 2 "))
                     assert.truthy(section.button_lines[1]:find("Allow once"))
-                    assert.truthy(section.button_lines[2]:find("Reject once"))
+                    assert.truthy(section.button_lines[3]:find("Reject once"))
                 end
             )
 
@@ -634,35 +643,48 @@ describe("agentic.ui.MessageWriter", function()
                                 focused_button_index = case.index,
                             })
 
-                        assert.equal(2, #section.button_segments_per_line)
-                        for i, line in ipairs(section.button_lines) do
+                        -- 2 buttons + 1 spacer between them.
+                        assert.equal(3, #section.button_segments_per_line)
+                        -- Spacer at index 2 has no segments.
+                        assert.equal(0, #section.button_segments_per_line[2])
+
+                        for _, i in ipairs({ 1, 3 }) do
                             local segs = section.button_segments_per_line[i]
+                            local line = section.button_lines[i]
                             assert.equal(1, #segs)
                             assert.equal(0, segs[1][1])
                             assert.equal(#line, segs[1][2])
                         end
 
+                        -- Button index 1 -> line 1; button index 2 -> line 3.
+                        local focused_line_idx = case.index == 1 and 1 or 3
+                        local other_line_idx = case.index == 1 and 3 or 1
+
                         local focused_seg =
-                            section.button_segments_per_line[case.index][1]
+                            section.button_segments_per_line[focused_line_idx][1]
                         assert.equal(case.focused_hl, focused_seg[3])
 
-                        local other_index = case.index == 1 and 2 or 1
                         local other_seg =
-                            section.button_segments_per_line[other_index][1]
+                            section.button_segments_per_line[other_line_idx][1]
                         assert.equal(case.unfocused_hl, other_seg[3])
                     end
                 )
             end
 
             it(
-                "uses the inactive hl group on every line when not focused",
+                "uses the inactive hl group on every button line when not focused",
                 function()
                     local section = build_section("section-hl-inactive", {
                         is_focused = false,
                     })
 
-                    assert.equal(2, #section.button_segments_per_line)
-                    for _, segs in ipairs(section.button_segments_per_line) do
+                    -- 2 buttons + 1 spacer between them.
+                    assert.equal(3, #section.button_segments_per_line)
+                    -- Spacer has no segments.
+                    assert.equal(0, #section.button_segments_per_line[2])
+
+                    for _, i in ipairs({ 1, 3 }) do
+                        local segs = section.button_segments_per_line[i]
                         assert.equal(1, #segs)
                         assert.equal(
                             "AgenticPermissionButtonInactive",
@@ -777,12 +799,20 @@ describe("agentic.ui.MessageWriter", function()
                         focused_button_index = 3,
                     })
 
-                    assert.equal(4, #section.button_lines)
-                    assert.equal(4, #section.button_segments_per_line)
+                    -- 4 buttons + 3 spacers between them.
+                    assert.equal(7, #section.button_lines)
+                    assert.equal(7, #section.button_segments_per_line)
+                    -- Buttons at indices 1, 3, 5, 7; spacers at 2, 4, 6.
                     for i = 1, 4 do
+                        local line_idx = (i - 1) * 2 + 1
                         assert.truthy(
-                            section.button_lines[i]:find("^" .. i .. " ")
+                            section.button_lines[line_idx]:find(
+                                "^ " .. i .. " "
+                            )
                         )
+                    end
+                    for _, spacer_idx in ipairs({ 2, 4, 6 }) do
+                        assert.equal("", section.button_lines[spacer_idx])
                     end
                 end
             )
@@ -805,8 +835,8 @@ describe("agentic.ui.MessageWriter", function()
                     assert.is_true(ok)
                     local section = section_or_err
                     assert.equal(1, #section.button_lines)
-                    -- No icon means the label is the line content.
-                    assert.equal("Allow once", section.button_lines[1])
+                    -- No icon means label is wrapped in padding spaces.
+                    assert.equal(" Allow once ", section.button_lines[1])
                 end
             )
 
@@ -846,21 +876,23 @@ describe("agentic.ui.MessageWriter", function()
                     local tracker =
                         writer.tool_call_blocks["render-first-paint"]
                     --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
-                    assert.equal(2, tracker._rendered_button_count)
+                    -- 2 buttons + 1 spacer between them.
+                    assert.equal(3, tracker._rendered_button_count)
 
                     local end_row_after = block_end_row("render-first-paint")
-                    assert.equal(end_row_before + 2, end_row_after)
+                    assert.equal(end_row_before + 3, end_row_after)
 
                     local lines = vim.api.nvim_buf_get_lines(
                         bufnr,
-                        end_row_after - 2,
+                        end_row_after - 3,
                         end_row_after + 1,
                         false
                     )
-                    assert.equal(3, #lines)
+                    assert.equal(4, #lines)
                     assert.truthy(lines[1]:find("Allow"))
-                    assert.truthy(lines[2]:find("Reject"))
-                    assert.truthy(lines[3]:find("pending"))
+                    assert.equal("", lines[2])
+                    assert.truthy(lines[3]:find("Reject"))
+                    assert.truthy(lines[4]:find("pending"))
                 end
             )
 
@@ -875,7 +907,8 @@ describe("agentic.ui.MessageWriter", function()
                     local tracker = writer.tool_call_blocks["render-extmarks"]
                     --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
                     local k = tracker._rendered_button_count
-                    assert.equal(2, k)
+                    -- 2 buttons + 1 spacer between them.
+                    assert.equal(3, k)
 
                     local status_text = vim.api.nvim_buf_get_lines(
                         bufnr,
@@ -899,11 +932,9 @@ describe("agentic.ui.MessageWriter", function()
                     assert.equal(1, #marks_on_status)
 
                     local first_btn_row = end_row - k
-                    for i = 0, k - 1 do
-                        local btn_row = first_btn_row + i
-                        -- Use `{btn_row, -1}` as the end position so the
-                        -- inclusive `nvim_buf_get_extmarks` range does not
-                        -- bleed into the next row's marks.
+                    -- Button rows at offsets 0 and 2 (1 is the spacer).
+                    for _, offset in ipairs({ 0, 2 }) do
+                        local btn_row = first_btn_row + offset
                         local marks = vim.api.nvim_buf_get_extmarks(
                             bufnr,
                             ns,
@@ -913,6 +944,16 @@ describe("agentic.ui.MessageWriter", function()
                         )
                         assert.equal(1, #marks)
                     end
+
+                    -- Spacer row carries no segments.
+                    local spacer_marks = vim.api.nvim_buf_get_extmarks(
+                        bufnr,
+                        ns,
+                        { first_btn_row + 1, 0 },
+                        { first_btn_row + 1, -1 },
+                        { details = true }
+                    )
+                    assert.equal(0, #spacer_marks)
                 end
             )
 
@@ -931,7 +972,8 @@ describe("agentic.ui.MessageWriter", function()
                     writer:repaint_status_row("render-gravity")
 
                     local after = block_end_row("render-gravity")
-                    assert.equal(before + 2, after)
+                    -- 2 buttons + 1 spacer between them.
+                    assert.equal(before + 3, after)
 
                     -- end_row must be the new status row (the last line of the block).
                     local lines = vim.api.nvim_buf_get_lines(
@@ -952,14 +994,16 @@ describe("agentic.ui.MessageWriter", function()
                     })
 
                     local end_row = block_end_row("render-focus-switch")
+                    -- 2 buttons + 1 spacer: button rows at -3 and -1.
                     local rows_before = vim.api.nvim_buf_get_lines(
                         bufnr,
-                        end_row - 2,
+                        end_row - 3,
                         end_row,
                         false
                     )
-                    assert.is_nil(rows_before[1]:find("^1 "))
-                    assert.is_nil(rows_before[2]:find("^2 "))
+                    assert.is_nil(rows_before[1]:find(" 1 "))
+                    assert.equal("", rows_before[2])
+                    assert.is_nil(rows_before[3]:find(" 2 "))
 
                     writer:set_permission_state("render-focus-switch", {
                         sorted_options = ALLOW_REJECT_OPTIONS,
@@ -971,12 +1015,13 @@ describe("agentic.ui.MessageWriter", function()
                     end_row = block_end_row("render-focus-switch")
                     local rows_after = vim.api.nvim_buf_get_lines(
                         bufnr,
-                        end_row - 2,
+                        end_row - 3,
                         end_row,
                         false
                     )
-                    assert.truthy(rows_after[1]:find("^1 "))
-                    assert.truthy(rows_after[2]:find("^2 "))
+                    assert.truthy(rows_after[1]:find("^ 1 "))
+                    assert.equal("", rows_after[2])
+                    assert.truthy(rows_after[3]:find("^ 2 "))
 
                     -- Status row still only has the status word.
                     local status_text = vim.api.nvim_buf_get_lines(
@@ -1007,7 +1052,8 @@ describe("agentic.ui.MessageWriter", function()
                     assert.equal(0, tracker._rendered_button_count)
 
                     local end_row_after = block_end_row("render-clear")
-                    assert.equal(end_row_with_buttons - 2, end_row_after)
+                    -- 2 buttons + 1 spacer removed.
+                    assert.equal(end_row_with_buttons - 3, end_row_after)
 
                     local status_text = vim.api.nvim_buf_get_lines(
                         bufnr,
@@ -1031,7 +1077,7 @@ describe("agentic.ui.MessageWriter", function()
                     local end_row_1 = block_end_row("render-idempotent")
                     local lines_1 = vim.api.nvim_buf_get_lines(
                         bufnr,
-                        end_row_1 - 2,
+                        end_row_1 - 3,
                         end_row_1 + 1,
                         false
                     )
@@ -1043,7 +1089,7 @@ describe("agentic.ui.MessageWriter", function()
 
                     local lines_2 = vim.api.nvim_buf_get_lines(
                         bufnr,
-                        end_row_2 - 2,
+                        end_row_2 - 3,
                         end_row_2 + 1,
                         false
                     )
@@ -1051,7 +1097,8 @@ describe("agentic.ui.MessageWriter", function()
 
                     local tracker = writer.tool_call_blocks["render-idempotent"]
                     --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
-                    assert.equal(2, tracker._rendered_button_count)
+                    -- 2 buttons + 1 spacer between them.
+                    assert.equal(3, tracker._rendered_button_count)
                 end
             )
 
@@ -1078,8 +1125,9 @@ describe("agentic.ui.MessageWriter", function()
                     local a_end_after = block_end_row("render-multi-a")
                     local b_end_after = block_end_row("render-multi-b")
 
-                    assert.equal(a_end_before + 2, a_end_after)
-                    assert.equal(b_end_before + 2, b_end_after)
+                    -- 2 buttons + 1 spacer between them.
+                    assert.equal(a_end_before + 3, a_end_after)
+                    assert.equal(b_end_before + 3, b_end_after)
 
                     -- Block B unchanged: status row still carries the
                     -- status word and no button text.
@@ -1192,14 +1240,16 @@ describe("agentic.ui.MessageWriter", function()
 
                     local end_row = block_end_row("get-row-two-options")
                     --- @cast end_row integer
-                    local bottom_pad_row = end_row - 2 - 1
+                    -- 2 buttons + 1 spacer between them = 3 rendered rows.
+                    local bottom_pad_row = end_row - 3 - 1
 
+                    -- Button 1 at offset +1; button 2 at offset +3 (spacer at +2).
                     assert.equal(
                         bottom_pad_row + 1,
                         writer:get_button_row("get-row-two-options", 1)
                     )
                     assert.equal(
-                        bottom_pad_row + 2,
+                        bottom_pad_row + 3,
                         writer:get_button_row("get-row-two-options", 2)
                     )
                     assert.is_nil(

--- a/lua/agentic/ui/message_writer.test.lua
+++ b/lua/agentic/ui/message_writer.test.lua
@@ -285,8 +285,9 @@ describe("agentic.ui.MessageWriter", function()
 
                 assert.is_false(writer:_check_auto_scroll(bufnr))
 
-                -- Status row also carries an NS_STATUS extmark for the status
-                -- word, so parking there must also exempt from auto-scroll.
+                -- Status row sits at the upper bound of the rendered button
+                -- range scan in _cursor_on_permission_button_row, so parking
+                -- there must also exempt from auto-scroll.
                 vim.api.nvim_win_set_cursor(winid, { end_row + 1, 0 })
                 assert.is_false(writer:_check_auto_scroll(bufnr))
             end
@@ -304,9 +305,11 @@ describe("agentic.ui.MessageWriter", function()
                 local k = tracker._rendered_button_count or 0
                 local end_row = block_end_row("auto-scroll-above-perm")
                 local bottom_pad_row = end_row - k - 1
-                -- Park cursor on the bottom_pad row (one above the first
-                -- button row). This row has no NS_STATUS extmarks and is
-                -- still within the auto-scroll threshold of the buffer end.
+                -- Park cursor on the body row above the bottom_pad row
+                -- (0-indexed bottom_pad_row - 1 -> 1-indexed bottom_pad_row
+                -- for the cursor API). Outside the rendered button range
+                -- and still within the auto-scroll threshold of the
+                -- buffer end.
                 vim.api.nvim_win_set_cursor(winid, { bottom_pad_row, 0 })
 
                 assert.is_true(writer:_check_auto_scroll(bufnr))
@@ -333,33 +336,26 @@ describe("agentic.ui.MessageWriter", function()
         --- @param tool_call_id string
         --- @return string
         local function status_row_text(tool_call_id)
-            return PermissionSection.status_row_text(
+            local text = PermissionSection.status_row_text(
                 bufnr,
                 block_end_row(tool_call_id)
             )
+            assert.is_not_nil(text)
+            --- @cast text string
+            return text
         end
 
-        --- All NS_STATUS extmarks on the button rows of the block.
-        --- Uses `{last_btn_row, -1}` as the inclusive end so the query does
-        --- not bleed into the status row's marks below.
+        --- All NS_STATUS extmarks on the K rendered rows above the status
+        --- row of the block.
         --- @param tool_call_id string
         --- @return vim.api.keyset.get_extmark_item[]
         local function button_row_marks(tool_call_id)
             local tracker = writer.tool_call_blocks[tool_call_id]
             --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
-            local k = tracker._rendered_button_count or 0
-            if k == 0 then
-                return {}
-            end
-            local end_row = block_end_row(tool_call_id)
-            local bottom_pad_row = end_row - k - 1
-            local ns = vim.api.nvim_create_namespace("agentic_status_footer")
-            return vim.api.nvim_buf_get_extmarks(
+            return PermissionSection.button_row_extmarks(
                 bufnr,
-                ns,
-                { bottom_pad_row + 1, 0 },
-                { bottom_pad_row + k, -1 },
-                { details = true }
+                block_end_row(tool_call_id),
+                tracker._rendered_button_count or 0
             )
         end
 
@@ -455,6 +451,19 @@ describe("agentic.ui.MessageWriter", function()
                         status = "in_progress",
                         body = { "running" },
                     })
+                end,
+            },
+            {
+                name = "keeps button rows on a non-pending status with no post-update",
+                id = "row-n-focused-completed",
+                is_focused = true,
+                status_pattern = "completed",
+                expect_digit_prefix = true,
+                post_action = function(id)
+                    local tracker = writer.tool_call_blocks[id]
+                    --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                    tracker.status = "completed"
+                    writer:repaint_status_row(id)
                 end,
             },
         }) do
@@ -589,6 +598,9 @@ describe("agentic.ui.MessageWriter", function()
                         is_focused = false,
                     })
 
+                    -- 2 buttons + 2 spacers; pin shape first so a regression
+                    -- to N rows surfaces here, not as a nil-index error below.
+                    assert.equal(4, #section.button_lines)
                     -- No digit prefix in non-focused state.
                     assert.is_nil(section.button_lines[1]:find(" 1 "))
                     assert.is_nil(section.button_lines[3]:find(" 2 "))
@@ -605,6 +617,9 @@ describe("agentic.ui.MessageWriter", function()
                         focused_button_index = 1,
                     })
 
+                    -- 2 buttons + 2 spacers; pin shape first so a regression
+                    -- to N rows surfaces here, not as a nil-index error below.
+                    assert.equal(4, #section.button_lines)
                     -- Padded with leading + trailing space.
                     assert.truthy(section.button_lines[1]:find("^ 1 "))
                     assert.truthy(section.button_lines[3]:find("^ 2 "))
@@ -813,17 +828,24 @@ describe("agentic.ui.MessageWriter", function()
                     --- @diagnostic disable-next-line: missing-fields
                     Config.permission_icons = {}
 
-                    local section = build_section("section-empty-icons", {
-                        sorted_options = { ALLOW_REJECT_OPTIONS[1] },
-                        is_focused = false,
-                    })
+                    -- Restore on any error so a failing build_section does
+                    -- not leak the empty config into later tests.
+                    local ok, section =
+                        pcall(build_section, "section-empty-icons", {
+                            sorted_options = { ALLOW_REJECT_OPTIONS[1] },
+                            is_focused = false,
+                        })
 
                     Config.permission_icons = original
 
+                    assert.is_true(ok)
                     -- 1 button + 1 trailing spacer.
                     assert.equal(2, #section.button_lines)
-                    -- No icon means label is wrapped in padding spaces.
-                    assert.equal(" Allow once ", section.button_lines[1])
+                    -- No icon: label sits between leading + trailing space.
+                    assert.truthy(
+                        section.button_lines[1]:find("Allow once", 1, true)
+                    )
+                    assert.is_nil(section.button_lines[1]:match("[^%s%w]"))
                     assert.equal("", section.button_lines[2])
                 end
             )
@@ -1210,6 +1232,29 @@ describe("agentic.ui.MessageWriter", function()
                 assert.is_nil(writer:get_button_row("get-row-no-perm", 1))
             end)
 
+            it(
+                "returns nil when permission state exists but nothing rendered yet",
+                function()
+                    writer:write_tool_call_block(
+                        make_tool_call_block("get-row-not-rendered", "pending")
+                    )
+                    -- Permission state set but no repaint -> k == 0.
+                    writer:set_permission_state("get-row-not-rendered", {
+                        sorted_options = ALLOW_REJECT_OPTIONS,
+                        is_focused = true,
+                        focused_button_index = 1,
+                    })
+
+                    local tracker =
+                        writer.tool_call_blocks["get-row-not-rendered"]
+                    --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+                    assert.equal(0, tracker._rendered_button_count)
+                    assert.is_nil(
+                        writer:get_button_row("get-row-not-rendered", 1)
+                    )
+                end
+            )
+
             it("returns nil for an unknown tool_call_id", function()
                 assert.is_nil(writer:get_button_row("does-not-exist", 1))
             end)
@@ -1229,20 +1274,38 @@ describe("agentic.ui.MessageWriter", function()
 
                     -- Button 1 at offset +1; button 2 at offset +3 (spacers
                     -- at +2 and +4).
-                    assert.equal(
-                        bottom_pad_row + 1,
+                    local row_1 =
                         writer:get_button_row("get-row-two-options", 1)
-                    )
-                    assert.equal(
-                        bottom_pad_row + 3,
+                    local row_2 =
                         writer:get_button_row("get-row-two-options", 2)
-                    )
+                    assert.equal(bottom_pad_row + 1, row_1)
+                    assert.equal(bottom_pad_row + 3, row_2)
                     assert.is_nil(
                         writer:get_button_row("get-row-two-options", 3)
                     )
                     assert.is_nil(
                         writer:get_button_row("get-row-two-options", 0)
                     )
+
+                    -- Returned rows must contain actual button text, not a
+                    -- spacer; guards against get_button_row math drifting
+                    -- from the rendered layout.
+                    --- @cast row_1 integer
+                    --- @cast row_2 integer
+                    local line_1 = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        row_1,
+                        row_1 + 1,
+                        false
+                    )[1] or ""
+                    local line_2 = vim.api.nvim_buf_get_lines(
+                        bufnr,
+                        row_2,
+                        row_2 + 1,
+                        false
+                    )[1] or ""
+                    assert.truthy(line_1:find("Allow"))
+                    assert.truthy(line_2:find("Reject"))
                 end
             )
         end)

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -2,13 +2,7 @@ local BufHelpers = require("agentic.utils.buf_helpers")
 local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
 
--- Priority order for permission option kinds based on ACP tool-calls documentation
--- Lower number = higher priority (appears first)
--- Order from https://agentclientprotocol.com/protocol/tool-calls.md:
--- 1. allow_once - Allow this operation only this time
--- 2. allow_always - Allow this operation and remember the choice
--- 3. reject_once - Reject this operation only this time
--- 4. reject_always - Reject this operation and remember the choice
+-- See https://agentclientprotocol.com/protocol/tool-calls.md
 local PERMISSION_KIND_PRIORITY = {
     allow_once = 1,
     allow_always = 2,
@@ -157,8 +151,6 @@ function PermissionManager:add_request(request, callback)
     end
 end
 
---- Move button focus within the currently focused block. Wraps. No-op when
---- no block is focused or it has zero options.
 --- @param direction integer 1 = right (l), -1 = left (h)
 --- @protected
 function PermissionManager:_cycle_button(direction)
@@ -209,9 +201,7 @@ function PermissionManager:_jump_cursor_to_button(tool_call_id, button_index)
     end
 
     pcall(vim.api.nvim_win_set_cursor, winid, { button_row + 1, 0 })
-    -- `zb` matches the chat auto-scroll convention (`G0zb`); without it the
-    -- focused button row can disappear above the viewport when buttons cluster
-    -- near the bottom of the window.
+    -- `zb` matches the chat auto-scroll convention (`G0zb`).
     vim.api.nvim_win_call(winid, function()
         vim.cmd("noautocmd normal! zb")
     end)
@@ -263,13 +253,8 @@ function PermissionManager:resolve(tool_call_id, option_id)
 
     self.message_writer:set_permission_state(tool_call_id, nil)
 
-    -- Repaint BEFORE the callback so the user sees the buttons gone
-    -- immediately. The callback hits the ACP provider; any subsequent
-    -- agent update arrives on a later tick (notifications cross
-    -- `vim.schedule`), so no UI race. _set_focus below cannot do this
-    -- repaint for us because it skips the old-id branch once the id has
-    -- been removed from `pending`, and skips the new-id branch when there
-    -- is no next head.
+    -- Repaint BEFORE callback: avoids UI race; _set_focus below would skip
+    -- this id since it is no longer in `pending`.
     self.message_writer:repaint_status_row(tool_call_id)
 
     pcall(request.callback, option_id)
@@ -397,22 +382,11 @@ function PermissionManager:_cycle_focus(direction)
     self:_set_focus(target_id)
 end
 
---- Install the per-block focus keymaps: digits 1..N for direct dispatch,
---- h / l / <Left> / <Right> for button-focus cycling, and <CR> for submit.
---- Digits fire from anywhere in the chat buffer (direct dispatch is the whole
---- point of inline permissions). Motion / submit keys are `expr = true` and
---- only fire on the focused block's row N; off-row they return the original
---- key so the user can navigate / count normally.
+--- See ADR 0003. Row-gated `expr=true` keymaps with `vim.schedule` defer
+--- (expr-keymaps run inside textlock).
 --- @param pending agentic.ui.PermissionManager.PermissionRequest
 --- @protected
 function PermissionManager:_install_focus_keymaps(pending)
-    --- Build an expr-keymap callback that runs `action` only when the cursor
-    --- is on the focused row. Off-row, returns `fallback_keys` (typed via
-    --- noremap), giving the user normal cursor / count behavior.
-    --- On-row, defers the action via `vim.schedule` because expr-keymaps run
-    --- inside textlock and cannot call `nvim_buf_set_lines` directly. Without
-    --- the defer, the row-N text rewrite in `repaint_status_row` silently
-    --- fails and the button labels stay visible (only their highlights drop).
     --- @param fallback_keys string
     --- @param action fun()
     --- @return fun(): string
@@ -577,9 +551,6 @@ function PermissionManager:_jump_cursor_to(tool_call_id)
         or end_row
 
     pcall(vim.api.nvim_win_set_cursor, winid, { target_row + 1, 0 })
-    -- `zb` (not `zz`) matches the chat auto-scroll convention (`G0zb`),
-    -- anchoring the focused row near the bottom of the window where the user
-    -- expects new chat content to live.
     vim.api.nvim_win_call(winid, function()
         vim.cmd("noautocmd normal! zb")
     end)

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -200,11 +200,11 @@ function PermissionManager:_jump_cursor_to_button(tool_call_id, button_index)
         return
     end
 
+    -- Cycle keys only fire when the cursor sits on the focused permission
+    -- section, so the section is already on-screen; no `zb` needed.
+    -- Re-anchoring here would scroll the viewport on every cycle, hiding
+    -- buttons below the cursor row.
     pcall(vim.api.nvim_win_set_cursor, winid, { button_row + 1, 0 })
-    -- `zb` matches the chat auto-scroll convention (`G0zb`).
-    vim.api.nvim_win_call(winid, function()
-        vim.cmd("noautocmd normal! zb")
-    end)
 end
 
 --- Resolve the focused block with its currently focused button's option.
@@ -550,10 +550,15 @@ function PermissionManager:_jump_cursor_to(tool_call_id)
     local target_row = self.message_writer:get_button_row(tool_call_id, 1)
         or end_row
 
-    pcall(vim.api.nvim_win_set_cursor, winid, { target_row + 1, 0 })
+    -- Anchor the STATUS ROW at window bottom (matches chat auto-scroll
+    -- convention), THEN place cursor on the target button. Anchoring at the
+    -- cursor row would hide button rows + status below the cursor when
+    -- target_row is button 1.
+    pcall(vim.api.nvim_win_set_cursor, winid, { end_row + 1, 0 })
     vim.api.nvim_win_call(winid, function()
         vim.cmd("noautocmd normal! zb")
     end)
+    pcall(vim.api.nvim_win_set_cursor, winid, { target_row + 1, 0 })
 end
 
 return PermissionManager

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -151,7 +151,7 @@ function PermissionManager:add_request(request, callback)
     end
 end
 
---- @param direction integer 1 = right (l), -1 = left (h)
+--- @param direction integer 1 = forward, -1 = backward (wraps both ways)
 --- @protected
 function PermissionManager:_cycle_button(direction)
     if not self.focused_id then
@@ -197,6 +197,11 @@ function PermissionManager:_jump_cursor_to_button(tool_call_id, button_index)
     local button_row =
         self.message_writer:get_button_row(tool_call_id, button_index)
     if not button_row then
+        return
+    end
+
+    local line_count = vim.api.nvim_buf_line_count(self.message_writer.bufnr)
+    if button_row + 1 > line_count then
         return
     end
 
@@ -301,8 +306,9 @@ end
 
 --- Set focus to new_id (may be nil to clear focus). Repaints the previously
 --- focused block (if still pending) and the new focused block, rotates the
---- focus keymaps (digits + h/l/<CR>), and jumps the cursor to the new
---- focused row. Resets focused_button_index to 1 on every block-focus change.
+--- focus keymaps (digits + cycle keys + <CR>), and jumps the cursor to the
+--- new focused row. Resets focused_button_index to 1 on every block-focus
+--- change.
 --- @param new_id string|nil
 --- @protected
 function PermissionManager:_set_focus(new_id)
@@ -468,7 +474,8 @@ end
 
 --- True when the cursor sits on the focused block's status row or on any
 --- of its rendered button rows. Cycle keys and `<CR>` only fire on those
---- rows; elsewhere the gate falls through to default motion.
+--- rows; elsewhere (including spacer rows between buttons or before status)
+--- the gate falls through to default motion.
 --- @return boolean
 function PermissionManager:_cursor_on_focused_row()
     if not self.focused_id then
@@ -485,12 +492,24 @@ function PermissionManager:_cursor_on_focused_row()
     end
     local cursor_row = vim.api.nvim_win_get_cursor(winid)[1]
 
-    local first_button_row = self.message_writer:get_button_row(
-        self.focused_id,
-        1
-    ) or end_row
+    -- Status row (0-indexed end_row -> 1-indexed end_row + 1).
+    if cursor_row == end_row + 1 then
+        return true
+    end
 
-    return cursor_row >= first_button_row + 1 and cursor_row <= end_row + 1
+    local pending = self.pending[self.focused_id]
+    if not pending then
+        return false
+    end
+
+    for i = 1, #pending.sorted_options do
+        local btn_row = self.message_writer:get_button_row(self.focused_id, i)
+        if btn_row and cursor_row == btn_row + 1 then
+            return true
+        end
+    end
+
+    return false
 end
 
 function PermissionManager:_remove_focus_keymaps()
@@ -558,7 +577,9 @@ function PermissionManager:_jump_cursor_to(tool_call_id)
     vim.api.nvim_win_call(winid, function()
         vim.cmd("noautocmd normal! zb")
     end)
-    pcall(vim.api.nvim_win_set_cursor, winid, { target_row + 1, 0 })
+    if target_row ~= end_row then
+        pcall(vim.api.nvim_win_set_cursor, winid, { target_row + 1, 0 })
+    end
 end
 
 return PermissionManager

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -197,22 +197,24 @@ end
 --- @param button_index integer 1-indexed
 --- @protected
 function PermissionManager:_jump_cursor_to_button(tool_call_id, button_index)
-    local row = self.message_writer:get_block_end_row(tool_call_id)
-    if not row then
-        return
-    end
-
     local winid = self:_find_visible_chat_winid()
     if not winid then
         return
     end
 
-    local col = self.message_writer:get_button_col(tool_call_id, button_index)
-    if not col then
+    local button_row =
+        self.message_writer:get_button_row(tool_call_id, button_index)
+    if not button_row then
         return
     end
 
-    pcall(vim.api.nvim_win_set_cursor, winid, { row + 1, col })
+    pcall(vim.api.nvim_win_set_cursor, winid, { button_row + 1, 0 })
+    -- `zb` matches the chat auto-scroll convention (`G0zb`); without it the
+    -- focused button row can disappear above the viewport when buttons cluster
+    -- near the bottom of the window.
+    vim.api.nvim_win_call(winid, function()
+        vim.cmd("noautocmd normal! zb")
+    end)
 end
 
 --- Resolve the focused block with its currently focused button's option.
@@ -447,14 +449,14 @@ function PermissionManager:_install_focus_keymaps(pending)
         self:_cycle_button(1)
     end
 
-    for _, lhs in ipairs({ "h", "<Left>" }) do
+    for _, lhs in ipairs({ "h", "<Left>", "k", "<Up>" }) do
         BufHelpers.keymap_set(bufnr, "n", lhs, gated(lhs, prev_button), {
             desc = "Permission: focus previous button",
             expr = true,
         })
     end
 
-    for _, lhs in ipairs({ "l", "<Right>" }) do
+    for _, lhs in ipairs({ "l", "<Right>", "j", "<Down>" }) do
         BufHelpers.keymap_set(bufnr, "n", lhs, gated(lhs, next_button), {
             desc = "Permission: focus next button",
             expr = true,
@@ -490,13 +492,16 @@ function PermissionManager:_find_visible_chat_winid()
     return nil
 end
 
+--- True when the cursor sits on the focused block's status row or on any
+--- of its rendered button rows. Cycle keys and `<CR>` only fire on those
+--- rows; elsewhere the gate falls through to default motion.
 --- @return boolean
 function PermissionManager:_cursor_on_focused_row()
     if not self.focused_id then
         return false
     end
-    local row = self.message_writer:get_block_end_row(self.focused_id)
-    if not row then
+    local end_row = self.message_writer:get_block_end_row(self.focused_id)
+    if not end_row then
         return false
     end
 
@@ -505,7 +510,13 @@ function PermissionManager:_cursor_on_focused_row()
         return false
     end
     local cursor_row = vim.api.nvim_win_get_cursor(winid)[1]
-    return cursor_row == row + 1
+
+    local first_button_row = self.message_writer:get_button_row(
+        self.focused_id,
+        1
+    ) or end_row
+
+    return cursor_row >= first_button_row + 1 and cursor_row <= end_row + 1
 end
 
 function PermissionManager:_remove_focus_keymaps()
@@ -517,7 +528,17 @@ function PermissionManager:_remove_focus_keymaps()
     for i = 1, MAX_DIGIT_KEYS do
         BufHelpers.keymap_del(bufnr, "n", tostring(i))
     end
-    for _, lhs in ipairs({ "h", "l", "<Left>", "<Right>", "<CR>" }) do
+    for _, lhs in ipairs({
+        "h",
+        "l",
+        "j",
+        "k",
+        "<Left>",
+        "<Right>",
+        "<Up>",
+        "<Down>",
+        "<CR>",
+    }) do
         BufHelpers.keymap_del(bufnr, "n", lhs)
     end
 end
@@ -535,8 +556,8 @@ end
 
 --- @param tool_call_id string
 function PermissionManager:_jump_cursor_to(tool_call_id)
-    local row = self.message_writer:get_block_end_row(tool_call_id)
-    if not row then
+    local end_row = self.message_writer:get_block_end_row(tool_call_id)
+    if not end_row then
         return
     end
 
@@ -546,16 +567,19 @@ function PermissionManager:_jump_cursor_to(tool_call_id)
     end
 
     local line_count = vim.api.nvim_buf_line_count(self.message_writer.bufnr)
-    if row + 1 > line_count then
+    if end_row + 1 > line_count then
         return
     end
 
-    --- @diagnostic disable-next-line: invisible
-    local col = self.message_writer:get_button_col(tool_call_id, 1) or 0
-    pcall(vim.api.nvim_win_set_cursor, winid, { row + 1, col })
+    -- Land on button row 1 when the block has a pending permission; otherwise
+    -- fall back to the block end_row (status row).
+    local target_row = self.message_writer:get_button_row(tool_call_id, 1)
+        or end_row
+
+    pcall(vim.api.nvim_win_set_cursor, winid, { target_row + 1, 0 })
     -- `zb` (not `zz`) matches the chat auto-scroll convention (`G0zb`),
-    -- anchoring row N near the bottom of the window where the user expects
-    -- new chat content to live.
+    -- anchoring the focused row near the bottom of the window where the user
+    -- expects new chat content to live.
     vim.api.nvim_win_call(winid, function()
         vim.cmd("noautocmd normal! zb")
     end)

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -46,7 +46,7 @@ describe("agentic.ui.PermissionManager", function()
         }
     end
 
-    --- Write a tool call block so the writer can resolve its row N.
+    --- Write a tool call block so the writer can resolve its permission rows.
     --- @param tool_call_id string
     local function seed_block(tool_call_id)
         writer:write_tool_call_block({

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -527,27 +527,18 @@ describe("agentic.ui.PermissionManager", function()
                     assert.is_not_nil(row_2)
                     local cursor = vim.api.nvim_win_get_cursor(winid)
                     assert.equal((row_2 or 0) + 1, cursor[1])
+
+                    -- Second press to disambiguate prev vs next: with 2
+                    -- options, a single prev-step from 1 wraps to 2 and
+                    -- coincides with next-step. A second step exercises
+                    -- the direction-dependent modular wrap.
+                    if cb then
+                        cb()
+                    end
+                    assert.equal(1, writer:get_focused_button_index("tc-1"))
                 end
             )
         end
-
-        it("digit 2 submits option 2", function()
-            seed_block("tc-1")
-            local cb = spy.new(function() end)
-            pm:add_request(make_request("tc-1"), cb --[[@as function]])
-
-            local digit_cb = get_digit_callback("2")
-            assert.is_not_nil(digit_cb)
-            if digit_cb then
-                digit_cb()
-            end
-
-            -- After submit the permission state is cleared and button rows
-            -- are removed; the digit dispatch's job is the resolve call, not
-            -- a cursor position. Cursor lands wherever Neovim clamps it.
-            assert.spy(cb).was.called(1)
-            assert.equal("reject-once", cb.calls[1][1])
-        end)
 
         it(
             "<CR> resolves the focused block with focused button's option",
@@ -582,14 +573,10 @@ describe("agentic.ui.PermissionManager", function()
                 )
 
                 local button_row_1 = writer:get_button_row("tc-1", 1)
-                local end_row = writer:get_block_end_row("tc-1")
                 assert.is_not_nil(button_row_1)
-                assert.is_not_nil(end_row)
 
                 local cursor = vim.api.nvim_win_get_cursor(winid)
                 assert.equal((button_row_1 or 0) + 1, cursor[1])
-                -- Cursor does NOT sit on the status row.
-                assert.are_not.equal((end_row or 0) + 1, cursor[1])
             end
         )
 
@@ -602,11 +589,9 @@ describe("agentic.ui.PermissionManager", function()
                     spy.new(function() end) --[[@as function]]
                 )
 
-                -- Resolve clears the permission state; subsequent block focus
-                -- jump must fall back to end_row since there are no buttons.
-                -- end_row is recomputed AFTER resolve since removing button
-                -- rows shifts the status row up.
                 pm:resolve("tc-1", "allow-once")
+                -- Recompute end_row AFTER resolve: removing button rows
+                -- shifts the status row up.
 
                 local end_row = writer:get_block_end_row("tc-1")
                 assert.is_not_nil(end_row)
@@ -714,8 +699,12 @@ describe("agentic.ui.PermissionManager", function()
                 }
                 for _, lhs in ipairs(cycle_keys) do
                     assert.is_true(has_buf_keymap("n", lhs))
+                    -- Also confirm the manager installed a callback, not
+                    -- just that something else happens to bind this key.
+                    assert.is_not_nil(get_digit_callback(lhs))
                 end
                 assert.is_true(has_buf_keymap("n", "<CR>"))
+                assert.is_not_nil(get_digit_callback("<CR>"))
 
                 pm:resolve("tc-1", "allow-once")
 
@@ -728,6 +717,21 @@ describe("agentic.ui.PermissionManager", function()
     end)
 
     describe("digit keymap lifecycle", function()
+        it("digit 2 submits option 2", function()
+            seed_block("tc-1")
+            local cb = spy.new(function() end)
+            pm:add_request(make_request("tc-1"), cb --[[@as function]])
+
+            local digit_cb = get_digit_callback("2")
+            assert.is_not_nil(digit_cb)
+            if digit_cb then
+                digit_cb()
+            end
+
+            assert.spy(cb).was.called(1)
+            assert.equal("reject-once", cb.calls[1][1])
+        end)
+
         it(
             "rebinds digit keymaps with new mapping after focus transition",
             function()
@@ -817,10 +821,13 @@ describe("agentic.ui.PermissionManager", function()
         --- @param tool_call_id string
         --- @return string
         local function status_row_text(tool_call_id)
-            return PermissionSection.status_row_text(
+            local text = PermissionSection.status_row_text(
                 bufnr,
                 writer:get_block_end_row(tool_call_id) or 0
             )
+            assert.is_not_nil(text)
+            --- @cast text string
+            return text
         end
 
         --- @param tool_call_id string

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -397,7 +397,6 @@ describe("agentic.ui.PermissionManager", function()
                 )
 
                 local end_row = writer:get_block_end_row("tc-only")
-                local first_btn_col = writer:get_button_col("tc-only", 1)
                 assert.is_not_nil(end_row)
 
                 -- Move cursor away from the focused row.
@@ -406,9 +405,10 @@ describe("agentic.ui.PermissionManager", function()
                 pm:_cycle_focus(1)
 
                 assert.equal("tc-only", pm.focused_id)
+                -- Task 4 will move the landing target to the first button row;
+                -- Task 3 keeps the legacy row-N jump.
                 local cursor = vim.api.nvim_win_get_cursor(winid)
                 assert.equal((end_row or 0) + 1, cursor[1])
-                assert.equal(first_btn_col, cursor[2])
             end
         )
 
@@ -497,31 +497,28 @@ describe("agentic.ui.PermissionManager", function()
             end
         end)
 
-        it(
-            "l moves cursor to the start col of the newly focused button",
-            function()
-                seed_block("tc-1")
-                pm:add_request(
-                    make_request("tc-1"),
-                    spy.new(function() end) --[[@as function]]
-                )
+        it("l moves cursor to the focused block's row N", function()
+            seed_block("tc-1")
+            pm:add_request(
+                make_request("tc-1"),
+                spy.new(function() end) --[[@as function]]
+            )
 
-                local end_row = writer:get_block_end_row("tc-1")
-                assert.is_not_nil(end_row)
+            local end_row = writer:get_block_end_row("tc-1")
+            assert.is_not_nil(end_row)
 
-                local l_cb = get_digit_callback("l")
-                assert.is_not_nil(l_cb)
-                if l_cb then
-                    l_cb()
-                end
-
-                local expected_col = writer:get_button_col("tc-1", 2)
-                assert.is_not_nil(expected_col)
-                local cursor = vim.api.nvim_win_get_cursor(winid)
-                assert.equal((end_row or 0) + 1, cursor[1])
-                assert.equal(expected_col, cursor[2])
+            local l_cb = get_digit_callback("l")
+            assert.is_not_nil(l_cb)
+            if l_cb then
+                l_cb()
             end
-        )
+
+            -- Task 4 will move the cursor to the focused button row.
+            -- Task 3 keeps the legacy row-N jump; column is clamped to
+            -- the status row length.
+            local cursor = vim.api.nvim_win_get_cursor(winid)
+            assert.equal((end_row or 0) + 1, cursor[1])
+        end)
 
         it("h cycles button focus backward and wraps", function()
             seed_block("tc-1")
@@ -563,23 +560,24 @@ describe("agentic.ui.PermissionManager", function()
             end
         )
 
-        it("places cursor on first button column on block focus", function()
-            seed_block("tc-1")
-            pm:add_request(
-                make_request("tc-1"),
-                spy.new(function() end) --[[@as function]]
-            )
+        it(
+            "places cursor on row N of the focused block on block focus",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
 
-            local end_row = writer:get_block_end_row("tc-1")
-            local first_btn_col = writer:get_button_col("tc-1", 1)
-            assert.is_not_nil(end_row)
-            assert.is_not_nil(first_btn_col)
-            assert.is_true((first_btn_col or 0) > 0)
+                local end_row = writer:get_block_end_row("tc-1")
+                assert.is_not_nil(end_row)
 
-            local cursor = vim.api.nvim_win_get_cursor(winid)
-            assert.equal((end_row or 0) + 1, cursor[1])
-            assert.equal(first_btn_col, cursor[2])
-        end)
+                -- Task 4 will move the landing target to the first button row;
+                -- Task 3 keeps the legacy row-N jump.
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((end_row or 0) + 1, cursor[1])
+            end
+        )
 
         it(
             "<Left> / <Right> are installed and cycle button focus when on row",
@@ -783,28 +781,60 @@ describe("agentic.ui.PermissionManager", function()
                 or ""
         end
 
-        it("strips buttons from row N as soon as the user resolves", function()
-            seed_block("tc-only")
-            local cb = spy.new(function() end)
-            pm:add_request(make_request("tc-only"), cb --[[@as function]])
-
-            assert.truthy(status_row_text("tc-only"):find("Allow"))
-
-            local digit_cb = get_digit_callback("1")
-            assert.is_not_nil(digit_cb)
-            if digit_cb then
-                digit_cb()
+        --- @param tool_call_id string
+        --- @return string[]
+        local function button_row_lines(tool_call_id)
+            local tracker = writer.tool_call_blocks[tool_call_id]
+            --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
+            local k = tracker._rendered_button_count or 0
+            if k == 0 then
+                return {}
             end
-
-            assert.spy(cb).was.called(1)
-            local text = status_row_text("tc-only")
-            assert.is_nil(text:find("Allow"))
-            assert.is_nil(text:find("Reject"))
-            assert.truthy(text:find("pending"))
-        end)
+            local end_row = writer:get_block_end_row(tool_call_id) or 0
+            local bottom_pad_row = end_row - k - 1
+            return vim.api.nvim_buf_get_lines(
+                bufnr,
+                bottom_pad_row + 1,
+                bottom_pad_row + 1 + k,
+                false
+            )
+        end
 
         it(
-            "strips buttons from a non-focused block when it is resolved",
+            "strips button rows from the block as soon as the user resolves",
+            function()
+                seed_block("tc-only")
+                local cb = spy.new(function() end)
+                pm:add_request(make_request("tc-only"), cb --[[@as function]])
+
+                local rows_before = button_row_lines("tc-only")
+                assert.is_true(#rows_before > 0)
+                local found_allow = false
+                for _, line in ipairs(rows_before) do
+                    if line:find("Allow") then
+                        found_allow = true
+                        break
+                    end
+                end
+                assert.is_true(found_allow)
+
+                local digit_cb = get_digit_callback("1")
+                assert.is_not_nil(digit_cb)
+                if digit_cb then
+                    digit_cb()
+                end
+
+                assert.spy(cb).was.called(1)
+                assert.equal(0, #button_row_lines("tc-only"))
+                local text = status_row_text("tc-only")
+                assert.is_nil(text:find("Allow"))
+                assert.is_nil(text:find("Reject"))
+                assert.truthy(text:find("pending"))
+            end
+        )
+
+        it(
+            "strips button rows from a non-focused block when it is resolved",
             function()
                 seed_block("tc-1")
                 seed_block("tc-2")
@@ -819,6 +849,7 @@ describe("agentic.ui.PermissionManager", function()
 
                 pm:resolve("tc-2", nil)
 
+                assert.equal(0, #button_row_lines("tc-2"))
                 local text = status_row_text("tc-2")
                 assert.is_nil(text:find("Allow"))
                 assert.is_nil(text:find("Reject"))

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -288,7 +288,7 @@ describe("agentic.ui.PermissionManager", function()
         )
 
         it(
-            "jumps the cursor to row N of the new focused block on focus change",
+            "jumps the cursor to the first button row of the new focused block on focus change",
             function()
                 seed_block("tc-1")
                 seed_block("tc-2")
@@ -302,14 +302,13 @@ describe("agentic.ui.PermissionManager", function()
                     spy.new(function() end) --[[@as function]]
                 )
 
-                local end_row_2 = writer:get_block_end_row("tc-2")
-                assert.is_not_nil(end_row_2)
-
                 pm:_cycle_focus(1)
                 assert.equal("tc-2", pm.focused_id)
 
+                local button_row_1 = writer:get_button_row("tc-2", 1)
+                assert.is_not_nil(button_row_1)
                 local cursor = vim.api.nvim_win_get_cursor(winid)
-                assert.equal(end_row_2 + 1, cursor[1])
+                assert.equal((button_row_1 or 0) + 1, cursor[1])
             end
         )
     end)
@@ -388,7 +387,7 @@ describe("agentic.ui.PermissionManager", function()
         end)
 
         it(
-            "cycle_next / cycle_prev jumps cursor to the focused row even with only one pending block",
+            "cycle_next / cycle_prev jumps cursor to the first button row even with only one pending block",
             function()
                 seed_block("tc-only")
                 pm:add_request(
@@ -396,19 +395,16 @@ describe("agentic.ui.PermissionManager", function()
                     spy.new(function() end) --[[@as function]]
                 )
 
-                local end_row = writer:get_block_end_row("tc-only")
-                assert.is_not_nil(end_row)
-
                 -- Move cursor away from the focused row.
                 vim.api.nvim_win_set_cursor(winid, { 1, 0 })
 
                 pm:_cycle_focus(1)
 
                 assert.equal("tc-only", pm.focused_id)
-                -- Task 4 will move the landing target to the first button row;
-                -- Task 3 keeps the legacy row-N jump.
+                local button_row_1 = writer:get_button_row("tc-only", 1)
+                assert.is_not_nil(button_row_1)
                 local cursor = vim.api.nvim_win_get_cursor(winid)
-                assert.equal((end_row or 0) + 1, cursor[1])
+                assert.equal((button_row_1 or 0) + 1, cursor[1])
             end
         )
 
@@ -497,45 +493,185 @@ describe("agentic.ui.PermissionManager", function()
             end
         end)
 
-        it("l moves cursor to the focused block's row N", function()
-            seed_block("tc-1")
-            pm:add_request(
-                make_request("tc-1"),
-                spy.new(function() end) --[[@as function]]
-            )
+        it(
+            "l moves cursor to button-row-2 from focus index 1 with two options",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
 
-            local end_row = writer:get_block_end_row("tc-1")
-            assert.is_not_nil(end_row)
+                local l_cb = get_digit_callback("l")
+                assert.is_not_nil(l_cb)
+                if l_cb then
+                    l_cb()
+                end
 
-            local l_cb = get_digit_callback("l")
-            assert.is_not_nil(l_cb)
-            if l_cb then
-                l_cb()
+                local row_2 = writer:get_button_row("tc-1", 2)
+                assert.is_not_nil(row_2)
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((row_2 or 0) + 1, cursor[1])
+                assert.equal(0, cursor[2])
             end
+        )
 
-            -- Task 4 will move the cursor to the focused button row.
-            -- Task 3 keeps the legacy row-N jump; column is clamped to
-            -- the status row length.
-            local cursor = vim.api.nvim_win_get_cursor(winid)
-            assert.equal((end_row or 0) + 1, cursor[1])
-        end)
+        it(
+            "j moves cursor to button-row-2 from focus index 1 (next)",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
 
-        it("h cycles button focus backward and wraps", function()
-            seed_block("tc-1")
-            pm:add_request(
-                make_request("tc-1"),
-                spy.new(function() end) --[[@as function]]
-            )
+                local j_cb = get_digit_callback("j")
+                assert.is_not_nil(j_cb)
+                if j_cb then
+                    j_cb()
+                end
 
-            local h_cb = get_digit_callback("h")
-            assert.is_not_nil(h_cb)
-            if h_cb then
-                h_cb() -- wraps from 1 to last (2)
                 assert.equal(2, writer:get_focused_button_index("tc-1"))
-                h_cb()
-                assert.equal(1, writer:get_focused_button_index("tc-1"))
+                local row_2 = writer:get_button_row("tc-1", 2)
+                assert.is_not_nil(row_2)
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((row_2 or 0) + 1, cursor[1])
+                assert.equal(0, cursor[2])
             end
+        )
+
+        it(
+            "<Down> moves cursor to button-row-2 from focus index 1 (next)",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                local down_cb = get_digit_callback("<Down>")
+                assert.is_not_nil(down_cb)
+                if down_cb then
+                    down_cb()
+                end
+
+                assert.equal(2, writer:get_focused_button_index("tc-1"))
+                local row_2 = writer:get_button_row("tc-1", 2)
+                assert.is_not_nil(row_2)
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((row_2 or 0) + 1, cursor[1])
+            end
+        )
+
+        it(
+            "k wraps to button-row-2 from focus index 1 (prev with two options)",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                local k_cb = get_digit_callback("k")
+                assert.is_not_nil(k_cb)
+                if k_cb then
+                    k_cb()
+                end
+
+                assert.equal(2, writer:get_focused_button_index("tc-1"))
+                local row_2 = writer:get_button_row("tc-1", 2)
+                assert.is_not_nil(row_2)
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((row_2 or 0) + 1, cursor[1])
+            end
+        )
+
+        it(
+            "<Up> wraps to button-row-2 from focus index 1 (prev with two options)",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                local up_cb = get_digit_callback("<Up>")
+                assert.is_not_nil(up_cb)
+                if up_cb then
+                    up_cb()
+                end
+
+                assert.equal(2, writer:get_focused_button_index("tc-1"))
+                local row_2 = writer:get_button_row("tc-1", 2)
+                assert.is_not_nil(row_2)
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((row_2 or 0) + 1, cursor[1])
+            end
+        )
+
+        it("digit 2 submits option 2", function()
+            seed_block("tc-1")
+            local cb = spy.new(function() end)
+            pm:add_request(make_request("tc-1"), cb --[[@as function]])
+
+            local digit_cb = get_digit_callback("2")
+            assert.is_not_nil(digit_cb)
+            if digit_cb then
+                digit_cb()
+            end
+
+            -- After submit the permission state is cleared and button rows
+            -- are removed; the digit dispatch's job is the resolve call, not
+            -- a cursor position. Cursor lands wherever Neovim clamps it.
+            assert.spy(cb).was.called(1)
+            assert.equal("reject-once", cb.calls[1][1])
         end)
+
+        it(
+            "h wraps focus from button 1 to button 2 and moves cursor",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                local h_cb = get_digit_callback("h")
+                assert.is_not_nil(h_cb)
+                if h_cb then
+                    h_cb()
+                end
+
+                assert.equal(2, writer:get_focused_button_index("tc-1"))
+                local row_2 = writer:get_button_row("tc-1", 2)
+                assert.is_not_nil(row_2)
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((row_2 or 0) + 1, cursor[1])
+            end
+        )
+
+        it(
+            "<Left> wraps focus from button 1 to button 2 and moves cursor",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                local left_cb = get_digit_callback("<Left>")
+                assert.is_not_nil(left_cb)
+                if left_cb then
+                    left_cb()
+                end
+
+                assert.equal(2, writer:get_focused_button_index("tc-1"))
+                local row_2 = writer:get_button_row("tc-1", 2)
+                assert.is_not_nil(row_2)
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((row_2 or 0) + 1, cursor[1])
+            end
+        )
 
         it(
             "<CR> resolves the focused block with focused button's option",
@@ -561,7 +697,7 @@ describe("agentic.ui.PermissionManager", function()
         )
 
         it(
-            "places cursor on row N of the focused block on block focus",
+            "places cursor on the first button row of the focused block on block focus",
             function()
                 seed_block("tc-1")
                 pm:add_request(
@@ -569,11 +705,40 @@ describe("agentic.ui.PermissionManager", function()
                     spy.new(function() end) --[[@as function]]
                 )
 
+                local button_row_1 = writer:get_button_row("tc-1", 1)
+                local end_row = writer:get_block_end_row("tc-1")
+                assert.is_not_nil(button_row_1)
+                assert.is_not_nil(end_row)
+
+                local cursor = vim.api.nvim_win_get_cursor(winid)
+                assert.equal((button_row_1 or 0) + 1, cursor[1])
+                -- Cursor does NOT sit on the status row.
+                assert.are_not.equal((end_row or 0) + 1, cursor[1])
+            end
+        )
+
+        it(
+            "block focus on a block without pending permission falls back to end_row",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+
+                -- Resolve clears the permission state; subsequent block focus
+                -- jump must fall back to end_row since there are no buttons.
+                -- end_row is recomputed AFTER resolve since removing button
+                -- rows shifts the status row up.
+                pm:resolve("tc-1", "allow-once")
+
                 local end_row = writer:get_block_end_row("tc-1")
                 assert.is_not_nil(end_row)
 
-                -- Task 4 will move the landing target to the first button row;
-                -- Task 3 keeps the legacy row-N jump.
+                -- Move cursor away, then call _jump_cursor_to directly.
+                vim.api.nvim_win_set_cursor(winid, { 1, 0 })
+                pm:_jump_cursor_to("tc-1")
+
                 local cursor = vim.api.nvim_win_get_cursor(winid)
                 assert.equal((end_row or 0) + 1, cursor[1])
             end
@@ -653,22 +818,37 @@ describe("agentic.ui.PermissionManager", function()
             end
         )
 
-        it("h / l / <CR> removed when no block is focused", function()
-            seed_block("tc-1")
-            pm:add_request(
-                make_request("tc-1"),
-                spy.new(function() end) --[[@as function]]
-            )
-            assert.is_true(has_buf_keymap("n", "h"))
-            assert.is_true(has_buf_keymap("n", "l"))
-            assert.is_true(has_buf_keymap("n", "<CR>"))
+        it(
+            "all eight cycle keys + <CR> removed when no block is focused",
+            function()
+                seed_block("tc-1")
+                pm:add_request(
+                    make_request("tc-1"),
+                    spy.new(function() end) --[[@as function]]
+                )
+                local cycle_keys = {
+                    "h",
+                    "l",
+                    "j",
+                    "k",
+                    "<Left>",
+                    "<Right>",
+                    "<Up>",
+                    "<Down>",
+                }
+                for _, lhs in ipairs(cycle_keys) do
+                    assert.is_true(has_buf_keymap("n", lhs))
+                end
+                assert.is_true(has_buf_keymap("n", "<CR>"))
 
-            pm:resolve("tc-1", "allow-once")
+                pm:resolve("tc-1", "allow-once")
 
-            assert.is_false(has_buf_keymap("n", "h"))
-            assert.is_false(has_buf_keymap("n", "l"))
-            assert.is_false(has_buf_keymap("n", "<CR>"))
-        end)
+                for _, lhs in ipairs(cycle_keys) do
+                    assert.is_false(has_buf_keymap("n", lhs))
+                end
+                assert.is_false(has_buf_keymap("n", "<CR>"))
+            end
+        )
     end)
 
     describe("digit keymap lifecycle", function()

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -1,6 +1,7 @@
 --- @diagnostic disable: invisible
 local assert = require("tests.helpers.assert")
 local spy = require("tests.helpers.spy")
+local PermissionSection = require("tests.helpers.permission_section")
 
 describe("agentic.ui.PermissionManager", function()
     --- @type agentic.ui.MessageWriter
@@ -493,121 +494,42 @@ describe("agentic.ui.PermissionManager", function()
             end
         end)
 
-        it(
-            "l moves cursor to button-row-2 from focus index 1 with two options",
-            function()
-                seed_block("tc-1")
-                pm:add_request(
-                    make_request("tc-1"),
-                    spy.new(function() end) --[[@as function]]
-                )
+        for _, case in ipairs({
+            { key = "l", direction = "next" },
+            { key = "<Right>", direction = "next" },
+            { key = "j", direction = "next" },
+            { key = "<Down>", direction = "next" },
+            { key = "h", direction = "prev" },
+            { key = "<Left>", direction = "prev" },
+            { key = "k", direction = "prev" },
+            { key = "<Up>", direction = "prev" },
+        }) do
+            it(
+                case.key
+                    .. " moves focus to button 2 from index 1 ("
+                    .. case.direction
+                    .. ") and jumps cursor",
+                function()
+                    seed_block("tc-1")
+                    pm:add_request(
+                        make_request("tc-1"),
+                        spy.new(function() end) --[[@as function]]
+                    )
 
-                local l_cb = get_digit_callback("l")
-                assert.is_not_nil(l_cb)
-                if l_cb then
-                    l_cb()
+                    local cb = get_digit_callback(case.key)
+                    assert.is_not_nil(cb)
+                    if cb then
+                        cb()
+                    end
+
+                    assert.equal(2, writer:get_focused_button_index("tc-1"))
+                    local row_2 = writer:get_button_row("tc-1", 2)
+                    assert.is_not_nil(row_2)
+                    local cursor = vim.api.nvim_win_get_cursor(winid)
+                    assert.equal((row_2 or 0) + 1, cursor[1])
                 end
-
-                local row_2 = writer:get_button_row("tc-1", 2)
-                assert.is_not_nil(row_2)
-                local cursor = vim.api.nvim_win_get_cursor(winid)
-                assert.equal((row_2 or 0) + 1, cursor[1])
-                assert.equal(0, cursor[2])
-            end
-        )
-
-        it(
-            "j moves cursor to button-row-2 from focus index 1 (next)",
-            function()
-                seed_block("tc-1")
-                pm:add_request(
-                    make_request("tc-1"),
-                    spy.new(function() end) --[[@as function]]
-                )
-
-                local j_cb = get_digit_callback("j")
-                assert.is_not_nil(j_cb)
-                if j_cb then
-                    j_cb()
-                end
-
-                assert.equal(2, writer:get_focused_button_index("tc-1"))
-                local row_2 = writer:get_button_row("tc-1", 2)
-                assert.is_not_nil(row_2)
-                local cursor = vim.api.nvim_win_get_cursor(winid)
-                assert.equal((row_2 or 0) + 1, cursor[1])
-                assert.equal(0, cursor[2])
-            end
-        )
-
-        it(
-            "<Down> moves cursor to button-row-2 from focus index 1 (next)",
-            function()
-                seed_block("tc-1")
-                pm:add_request(
-                    make_request("tc-1"),
-                    spy.new(function() end) --[[@as function]]
-                )
-
-                local down_cb = get_digit_callback("<Down>")
-                assert.is_not_nil(down_cb)
-                if down_cb then
-                    down_cb()
-                end
-
-                assert.equal(2, writer:get_focused_button_index("tc-1"))
-                local row_2 = writer:get_button_row("tc-1", 2)
-                assert.is_not_nil(row_2)
-                local cursor = vim.api.nvim_win_get_cursor(winid)
-                assert.equal((row_2 or 0) + 1, cursor[1])
-            end
-        )
-
-        it(
-            "k wraps to button-row-2 from focus index 1 (prev with two options)",
-            function()
-                seed_block("tc-1")
-                pm:add_request(
-                    make_request("tc-1"),
-                    spy.new(function() end) --[[@as function]]
-                )
-
-                local k_cb = get_digit_callback("k")
-                assert.is_not_nil(k_cb)
-                if k_cb then
-                    k_cb()
-                end
-
-                assert.equal(2, writer:get_focused_button_index("tc-1"))
-                local row_2 = writer:get_button_row("tc-1", 2)
-                assert.is_not_nil(row_2)
-                local cursor = vim.api.nvim_win_get_cursor(winid)
-                assert.equal((row_2 or 0) + 1, cursor[1])
-            end
-        )
-
-        it(
-            "<Up> wraps to button-row-2 from focus index 1 (prev with two options)",
-            function()
-                seed_block("tc-1")
-                pm:add_request(
-                    make_request("tc-1"),
-                    spy.new(function() end) --[[@as function]]
-                )
-
-                local up_cb = get_digit_callback("<Up>")
-                assert.is_not_nil(up_cb)
-                if up_cb then
-                    up_cb()
-                end
-
-                assert.equal(2, writer:get_focused_button_index("tc-1"))
-                local row_2 = writer:get_button_row("tc-1", 2)
-                assert.is_not_nil(row_2)
-                local cursor = vim.api.nvim_win_get_cursor(winid)
-                assert.equal((row_2 or 0) + 1, cursor[1])
-            end
-        )
+            )
+        end
 
         it("digit 2 submits option 2", function()
             seed_block("tc-1")
@@ -626,52 +548,6 @@ describe("agentic.ui.PermissionManager", function()
             assert.spy(cb).was.called(1)
             assert.equal("reject-once", cb.calls[1][1])
         end)
-
-        it(
-            "h wraps focus from button 1 to button 2 and moves cursor",
-            function()
-                seed_block("tc-1")
-                pm:add_request(
-                    make_request("tc-1"),
-                    spy.new(function() end) --[[@as function]]
-                )
-
-                local h_cb = get_digit_callback("h")
-                assert.is_not_nil(h_cb)
-                if h_cb then
-                    h_cb()
-                end
-
-                assert.equal(2, writer:get_focused_button_index("tc-1"))
-                local row_2 = writer:get_button_row("tc-1", 2)
-                assert.is_not_nil(row_2)
-                local cursor = vim.api.nvim_win_get_cursor(winid)
-                assert.equal((row_2 or 0) + 1, cursor[1])
-            end
-        )
-
-        it(
-            "<Left> wraps focus from button 1 to button 2 and moves cursor",
-            function()
-                seed_block("tc-1")
-                pm:add_request(
-                    make_request("tc-1"),
-                    spy.new(function() end) --[[@as function]]
-                )
-
-                local left_cb = get_digit_callback("<Left>")
-                assert.is_not_nil(left_cb)
-                if left_cb then
-                    left_cb()
-                end
-
-                assert.equal(2, writer:get_focused_button_index("tc-1"))
-                local row_2 = writer:get_button_row("tc-1", 2)
-                assert.is_not_nil(row_2)
-                local cursor = vim.api.nvim_win_get_cursor(winid)
-                assert.equal((row_2 or 0) + 1, cursor[1])
-            end
-        )
 
         it(
             "<CR> resolves the focused block with focused button's option",
@@ -852,21 +728,6 @@ describe("agentic.ui.PermissionManager", function()
     end)
 
     describe("digit keymap lifecycle", function()
-        it("digit 1 resolves the focused block's option 1", function()
-            seed_block("tc-1")
-            local cb = spy.new(function() end)
-            pm:add_request(make_request("tc-1"), cb --[[@as function]])
-
-            local digit_cb = get_digit_callback("1")
-            assert.is_not_nil(digit_cb)
-            if digit_cb then
-                digit_cb()
-            end
-
-            assert.spy(cb).was.called(1)
-            assert.equal("allow-once", cb.calls[1][1])
-        end)
-
         it(
             "rebinds digit keymaps with new mapping after focus transition",
             function()
@@ -956,9 +817,10 @@ describe("agentic.ui.PermissionManager", function()
         --- @param tool_call_id string
         --- @return string
         local function status_row_text(tool_call_id)
-            local row = writer:get_block_end_row(tool_call_id) or 0
-            return vim.api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
-                or ""
+            return PermissionSection.status_row_text(
+                bufnr,
+                writer:get_block_end_row(tool_call_id) or 0
+            )
         end
 
         --- @param tool_call_id string
@@ -966,75 +828,73 @@ describe("agentic.ui.PermissionManager", function()
         local function button_row_lines(tool_call_id)
             local tracker = writer.tool_call_blocks[tool_call_id]
             --- @cast tracker agentic.ui.MessageWriter.ToolCallBlock
-            local k = tracker._rendered_button_count or 0
-            if k == 0 then
-                return {}
-            end
-            local end_row = writer:get_block_end_row(tool_call_id) or 0
-            local bottom_pad_row = end_row - k - 1
-            return vim.api.nvim_buf_get_lines(
+            return PermissionSection.button_row_lines(
                 bufnr,
-                bottom_pad_row + 1,
-                bottom_pad_row + 1 + k,
-                false
+                writer:get_block_end_row(tool_call_id) or 0,
+                tracker._rendered_button_count or 0
             )
         end
 
-        it(
-            "strips button rows from the block as soon as the user resolves",
-            function()
-                seed_block("tc-only")
-                local cb = spy.new(function() end)
-                pm:add_request(make_request("tc-only"), cb --[[@as function]])
-
-                local rows_before = button_row_lines("tc-only")
-                assert.is_true(#rows_before > 0)
-                local found_allow = false
-                for _, line in ipairs(rows_before) do
-                    if line:find("Allow") then
-                        found_allow = true
-                        break
+        for _, case in ipairs({
+            {
+                name = "strips button rows from the focused block as soon as the user resolves via digit",
+                target_id = "tc-only",
+                seed = function()
+                    seed_block("tc-only")
+                    local cb = spy.new(function() end)
+                    pm:add_request(
+                        make_request("tc-only"),
+                        cb --[[@as function]]
+                    )
+                    return cb
+                end,
+                resolve = function()
+                    local digit_cb = get_digit_callback("1")
+                    assert.is_not_nil(digit_cb)
+                    if digit_cb then
+                        digit_cb()
                     end
-                end
-                assert.is_true(found_allow)
+                end,
+                assert_callback_fired = true,
+            },
+            {
+                name = "strips button rows from a non-focused block when it is resolved",
+                target_id = "tc-2",
+                seed = function()
+                    seed_block("tc-1")
+                    seed_block("tc-2")
+                    pm:add_request(
+                        make_request("tc-1"),
+                        spy.new(function() end) --[[@as function]]
+                    )
+                    pm:add_request(
+                        make_request("tc-2"),
+                        spy.new(function() end) --[[@as function]]
+                    )
+                end,
+                resolve = function()
+                    pm:resolve("tc-2", nil)
+                end,
+                assert_callback_fired = false,
+            },
+        }) do
+            it(case.name, function()
+                local cb = case.seed()
 
-                local digit_cb = get_digit_callback("1")
-                assert.is_not_nil(digit_cb)
-                if digit_cb then
-                    digit_cb()
-                end
+                local rows_before = button_row_lines(case.target_id)
+                assert.is_true(#rows_before > 0)
 
-                assert.spy(cb).was.called(1)
-                assert.equal(0, #button_row_lines("tc-only"))
-                local text = status_row_text("tc-only")
+                case.resolve()
+
+                if case.assert_callback_fired then
+                    assert.spy(cb).was.called(1)
+                end
+                assert.equal(0, #button_row_lines(case.target_id))
+                local text = status_row_text(case.target_id)
                 assert.is_nil(text:find("Allow"))
                 assert.is_nil(text:find("Reject"))
-                assert.truthy(text:find("pending"))
-            end
-        )
-
-        it(
-            "strips button rows from a non-focused block when it is resolved",
-            function()
-                seed_block("tc-1")
-                seed_block("tc-2")
-                pm:add_request(
-                    make_request("tc-1"),
-                    spy.new(function() end) --[[@as function]]
-                )
-                pm:add_request(
-                    make_request("tc-2"),
-                    spy.new(function() end) --[[@as function]]
-                )
-
-                pm:resolve("tc-2", nil)
-
-                assert.equal(0, #button_row_lines("tc-2"))
-                local text = status_row_text("tc-2")
-                assert.is_nil(text:find("Allow"))
-                assert.is_nil(text:find("Reject"))
-            end
-        )
+            end)
+        end
     end)
 
     describe("remove_request_by_tool_call_id", function()

--- a/tests/helpers/permission_section.lua
+++ b/tests/helpers/permission_section.lua
@@ -3,6 +3,8 @@
 local M = {}
 
 --- Return the K button rows above the status row (empty when k = 0).
+--- Errors on a degenerate `(end_row, k)` pair so callers cannot silently
+--- read pre-section rows.
 --- @param bufnr integer
 --- @param end_row integer Status row (0-indexed)
 --- @param k integer Rendered button-row count
@@ -10,6 +12,14 @@ local M = {}
 function M.button_row_lines(bufnr, end_row, k)
     if k == 0 then
         return {}
+    end
+    if end_row < k + 1 then
+        error(
+            "PermissionSection.button_row_lines: bogus end_row "
+                .. tostring(end_row)
+                .. " for k="
+                .. tostring(k)
+        )
     end
     local bottom_pad_row = end_row - k - 1
     return vim.api.nvim_buf_get_lines(
@@ -20,12 +30,33 @@ function M.button_row_lines(bufnr, end_row, k)
     )
 end
 
+--- Return the status-row text, or nil when the row does not exist.
 --- @param bufnr integer
 --- @param end_row integer Status row (0-indexed)
---- @return string
+--- @return string|nil
 function M.status_row_text(bufnr, end_row)
     return vim.api.nvim_buf_get_lines(bufnr, end_row, end_row + 1, false)[1]
-        or ""
+end
+
+--- All NS_STATUS extmarks on the K rendered rows (button + spacer rows)
+--- above the status row. Empty when k = 0.
+--- @param bufnr integer
+--- @param end_row integer Status row (0-indexed)
+--- @param k integer Rendered button-row count
+--- @return vim.api.keyset.get_extmark_item[]
+function M.button_row_extmarks(bufnr, end_row, k)
+    if k == 0 then
+        return {}
+    end
+    local bottom_pad_row = end_row - k - 1
+    local ns = vim.api.nvim_create_namespace("agentic_status_footer")
+    return vim.api.nvim_buf_get_extmarks(
+        bufnr,
+        ns,
+        { bottom_pad_row + 1, 0 },
+        { bottom_pad_row + k, -1 },
+        { details = true }
+    )
 end
 
 return M

--- a/tests/helpers/permission_section.lua
+++ b/tests/helpers/permission_section.lua
@@ -1,0 +1,31 @@
+--- Shared test helpers for the permission section (button rows + status row).
+--- @class agentic.tests.helpers.PermissionSection
+local M = {}
+
+--- Return the K button rows above the status row (empty when k = 0).
+--- @param bufnr integer
+--- @param end_row integer Status row (0-indexed)
+--- @param k integer Rendered button-row count
+--- @return string[]
+function M.button_row_lines(bufnr, end_row, k)
+    if k == 0 then
+        return {}
+    end
+    local bottom_pad_row = end_row - k - 1
+    return vim.api.nvim_buf_get_lines(
+        bufnr,
+        bottom_pad_row + 1,
+        bottom_pad_row + 1 + k,
+        false
+    )
+end
+
+--- @param bufnr integer
+--- @param end_row integer Status row (0-indexed)
+--- @return string
+function M.status_row_text(bufnr, end_row)
+    return vim.api.nvim_buf_get_lines(bufnr, end_row, end_row + 1, false)[1]
+        or ""
+end
+
+return M


### PR DESCRIPTION
- fix #252 
- inline buttons were using hard-coded labels
- the labels did not reflect the Agent's intentions 
- the labels are too long to fit in a single line 
- other IDEs, like Zed, use stacked as well. 

## preview

<img width="843" height="402" alt="image" src="https://github.com/user-attachments/assets/bc1dd3dc-6b83-4ad8-b609-13b12f0de61b" />

## Zed for comparison

<img width="585" height="251" alt="image" src="https://github.com/user-attachments/assets/3f002762-7de2-49ca-8a66-e04194e680a4" />


