### PR TITLE
fix(acp): guard vim.NIL in tool-call message builder

### DIFF
--- a/.agents/skills/agentic-acp-protocol-flow/references/transport-framing.md
+++ b/.agents/skills/agentic-acp-protocol-flow/references/transport-framing.md
@@ -27,9 +27,23 @@ Invariants:
 - A read can dispatch zero or more complete messages.
 - Empty or whitespace-only lines are skipped.
 - JSON decode failures call `Logger.notify` and continue.
+- Decode goes through `ACPTransport.decode_line`, which passes
+  `{ luanil = { object = true, array = true } }`. JSON `null` becomes Lua `nil`,
+  not `vim.NIL`.
 
 Why preserved: large payloads routinely exceed a single pipe read. Dropping the
 partial tail turns multi-chunk messages into JSON parse errors and message loss.
+
+Why `luanil`: `vim.NIL` is truthy userdata. A consumer that truthiness-guards a
+decoded field (`if x then ipairs(x)` or `x.field`) crashes when the provider
+sends explicit `null` instead of omitting the field. This crashed session
+restore in `ACPClient:__build_tool_call_message` (`ipairs` on userdata).
+Removing the opt re-crashes every such consumer (tool-call content/locations,
+plan entries, availableCommands, configOptions, modes).
+
+Regression:
+
+- `lua/agentic/acp/acp_transport.test.lua::"decodes JSON null as nil, not vim.NIL"`
 
 ## Subprocess lifecycle
 

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -401,7 +401,7 @@ function ACPClient:__build_tool_call_message(update)
         message.argument = update.title
     end
 
-    if update.content then
+    if type(update.content) == "table" then
         local body_parts = {}
         for _, content in ipairs(update.content) do
             if content then
@@ -442,7 +442,8 @@ function ACPClient:__build_tool_call_message(update)
     end
 
     -- Fallback: build diff from rawInput when content is missing (e.g. OpenCode)
-    local raw_input = update.rawInput
+    local raw_input = type(update.rawInput) == "table" and update.rawInput
+        or nil
 
     if not message.diff and update.kind == "edit" and raw_input then
         local new_string = raw_input.new_string or raw_input.newString
@@ -461,7 +462,7 @@ function ACPClient:__build_tool_call_message(update)
         message.file_path = raw_input.file_path or raw_input.filePath
     end
 
-    if not message.file_path and update.locations then
+    if not message.file_path and type(update.locations) == "table" then
         local first_location = update.locations[1]
         if first_location and first_location.path then
             message.file_path = first_location.path

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -405,4 +405,22 @@ describe("ACPClient", function()
             assert.equal(0, vim.tbl_count(client.callbacks))
         end)
     end)
+
+    describe("__build_tool_call_message", function()
+        it("handles vim.NIL content and locations (JSON null)", function()
+            local client = create_ready_client()
+
+            assert.has_no_errors(function()
+                ---@diagnostic disable: invisible, assign-type-mismatch
+                client:__build_tool_call_message({
+                    toolCallId = "tc-1",
+                    kind = "edit",
+                    content = vim.NIL,
+                    locations = vim.NIL,
+                    rawInput = vim.NIL,
+                })
+                ---@diagnostic enable: invisible, assign-type-mismatch
+            end)
+        end)
+    end)
 end)

--- a/lua/agentic/acp/acp_transport.lua
+++ b/lua/agentic/acp/acp_transport.lua
@@ -32,6 +32,18 @@ local IGNORE_STDERR_PATTERNS = {
     "[PreToolUseHook]",
 }
 
+--- `luanil` decodes JSON `null` as `nil`, not truthy `vim.NIL` userdata.
+--- @param line string
+--- @return boolean ok
+--- @return agentic.acp.ResponseRaw|string decoded
+function M.decode_line(line)
+    return pcall(
+        vim.json.decode,
+        line,
+        { luanil = { object = true, array = true } }
+    )
+end
+
 --- Create stdio transport for ACP communication
 --- @param config agentic.acp.StdioTransportConfig
 --- @param callbacks agentic.acp.TransportCallbacks
@@ -203,8 +215,9 @@ function M.create_stdio_transport(config, callbacks)
                 for i = 1, #lines - 1 do
                     local line = vim.trim(lines[i])
                     if line ~= "" then
-                        local ok, message = pcall(vim.json.decode, line)
+                        local ok, message = M.decode_line(line)
                         if ok then
+                            --- @cast message agentic.acp.ResponseRaw
                             callbacks.on_message(message)
                         else
                             Logger.notify(

--- a/lua/agentic/acp/acp_transport.test.lua
+++ b/lua/agentic/acp/acp_transport.test.lua
@@ -100,3 +100,23 @@ describe("ACPTransport process lifecycle", function()
         end
     )
 end)
+
+describe("ACPTransport.decode_line", function()
+    local Transport = require("agentic.acp.acp_transport")
+
+    it("decodes JSON null as nil, not vim.NIL", function()
+        local ok, message = Transport.decode_line('{"a":null,"b":[],"c":{}}')
+        --- @cast message any
+
+        assert.is_true(ok)
+        assert.is_nil(message.a)
+        assert.is_table(message.b)
+        assert.equal(type(message.c), "table")
+    end)
+
+    it("returns false on malformed JSON", function()
+        local ok = Transport.decode_line("{not json")
+
+        assert.is_false(ok)
+    end)
+end)


### PR DESCRIPTION
- providers send JSON null for tool-call fields
- vim.NIL is truthy userdata, broke ipairs/index
- crashed on session restore via __build_tool_call_message
- guards content, locations, rawInput
