### PR TITLE
fix: improve session restore reliability

### DIFF
--- a/lua/agentic/init.lua
+++ b/lua/agentic/init.lua
@@ -299,12 +299,12 @@ end
 --- Safe to call multiple times or when no generation is active
 function Agentic.stop_generation()
     SessionRegistry.get_session_for_tab_page(nil, function(session)
-        if session.is_generating then
+        if session.is_generating and session.session_id then
             session.agent:stop_generation(session.session_id)
-            session.permission_manager:clear()
-            session.is_generating = false
-            session.status_animation:stop()
         end
+        session.permission_manager:clear()
+        session.is_generating = false
+        session.status_animation:stop()
     end)
 end
 

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -719,6 +719,15 @@ function SessionManager:new_session(opts)
             return
         end
 
+        -- A session restore was initiated after this create_session was sent.
+        -- Race A: load still in-flight → _is_restoring_session is true.
+        -- Race B: load already completed → session_id is already set.
+        -- In both cases discard this stale session.
+        if self._is_restoring_session or self.session_id ~= nil then
+            self.agent:cancel_session(response.sessionId)
+            return
+        end
+
         self.session_id = response.sessionId
         self.chat_history.session_id = response.sessionId
         self.chat_history.timestamp = os.time()

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -210,6 +210,7 @@ end
 function SessionManager:_handle_connection_error()
     self._connection_error = true
     self._session_ready_callbacks = {}
+    self.is_generating = false
     self.status_animation:stop()
     self.message_writer:write_message(
         ACPPayloads.generate_agent_message(

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -714,18 +714,20 @@ function SessionManager:new_session(opts)
 
         Hooks.invoke("on_create_session_response", hook_data)
 
-        if err or not response then
-            -- no log here, already logged in create_session
-            self.session_id = nil
-            return
-        end
-
         -- A session restore was initiated after this create_session was sent.
         -- Race A: load still in-flight → _is_restoring_session is true.
         -- Race B: load already completed → session_id is already set.
-        -- In both cases discard this stale session.
+        -- Check staleness first so a failed stale callback can't wipe restored state.
         if self._is_restoring_session or self.session_id ~= nil then
-            self.agent:cancel_session(response.sessionId)
+            if response and response.sessionId then
+                self.agent:cancel_session(response.sessionId)
+            end
+            return
+        end
+
+        if err or not response then
+            -- no log here, already logged in create_session
+            self.session_id = nil
             return
         end
 

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -1749,32 +1749,37 @@ describe("agentic.SessionManager", function()
             end)
         end)
 
-        it("fires before the early return on error", function()
-            -- Verifies the contract: hook receives err, then session_id is
-            -- cleared. If the hook fired AFTER the early return, it would
-            -- never run on the error path.
-            local hook_call_order = {}
-            Config.hooks = Config.hooks or {}
-            Config.hooks.on_create_session_response = function(data)
-                table.insert(hook_call_order, {
-                    err = data.err,
-                    session_id_at_fire = data.session_id,
-                })
+        it(
+            "fires on error but preserves an already-owned session_id",
+            function()
+                -- Contract: the hook still fires on the error path, but if a
+                -- session_id is already set when this create callback fires, a
+                -- restore/takeover owns the session. The staleness guard runs
+                -- before the error branch, so even a FAILED stale create must not
+                -- null out the owned session_id.
+                local hook_call_order = {}
+                Config.hooks = Config.hooks or {}
+                Config.hooks.on_create_session_response = function(data)
+                    table.insert(hook_call_order, {
+                        err = data.err,
+                        session_id_at_fire = data.session_id,
+                    })
+                end
+
+                local session = make_session()
+                session.session_id = "owned-id"
+                fake_create_session(session, nil, {
+                    code = -32000,
+                    message = "boom",
+                } --[[@as agentic.acp.ACPError]])
+
+                SessionManager.new_session(session)
+
+                assert.equal(1, #hook_call_order)
+                assert.is_not_nil(hook_call_order[1].err)
+                assert.equal("owned-id", session.session_id)
             end
-
-            local session = make_session()
-            session.session_id = "stale-id"
-            fake_create_session(session, nil, {
-                code = -32000,
-                message = "boom",
-            } --[[@as agentic.acp.ACPError]])
-
-            SessionManager.new_session(session)
-
-            assert.equal(1, #hook_call_order)
-            assert.is_not_nil(hook_call_order[1].err)
-            assert.is_nil(session.session_id)
-        end)
+        )
     end)
 
     describe("initial thought_level wiring", function()

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -36,13 +36,9 @@ describe("race: stale create_session after load_acp_session", function()
         end
 
         slash_stub = spy.stub(SlashCommands, "setCommands")
-        payload_stub = spy.stub(
-            ACPPayloads,
-            "generate_user_message",
-            function()
-                return {}
-            end
-        )
+        payload_stub = spy.stub(ACPPayloads, "generate_user_message", function()
+            return {}
+        end)
     end)
 
     after_each(function()
@@ -151,91 +147,100 @@ describe("race: stale create_session after load_acp_session", function()
 
     -- Race A: create_session callback fires BEFORE load_session completes.
     -- _is_restoring_session is still true → our guard should catch it.
-    it("Race A: create fires before load completes — fix should prevent overwrite", function()
-        local create_cb_ref = {}
-        local load_cb_ref = {}
-        local session = make_session(create_cb_ref, load_cb_ref)
+    it(
+        "Race A: create fires before load completes — fix should prevent overwrite",
+        function()
+            local create_cb_ref = {}
+            local load_cb_ref = {}
+            local session = make_session(create_cb_ref, load_cb_ref)
 
-        -- Step 1: new_session in-flight (create deferred)
-        session:new_session()
-        assert.is_nil(session.session_id)
+            -- Step 1: new_session in-flight (create deferred)
+            session:new_session()
+            assert.is_nil(session.session_id)
 
-        -- Step 2: load_acp_session starts but load_session callback is also deferred
-        session:load_acp_session("restored-id", "title", nil)
-        assert.is_true(session._is_restoring_session) -- load hasn't completed yet
+            -- Step 2: load_acp_session starts but load_session callback is also deferred
+            session:load_acp_session("restored-id", "title", nil)
+            assert.is_true(session._is_restoring_session) -- load hasn't completed yet
 
-        -- Step 3: create fires first (while _is_restoring_session is still true)
-        create_cb_ref.cb({ sessionId = "new-id" }, nil)
+            -- Step 3: create fires first (while _is_restoring_session is still true)
+            create_cb_ref.cb({ sessionId = "new-id" }, nil)
 
-        -- Step 4: load completes
-        load_cb_ref.cb(nil)
+            -- Step 4: load completes
+            load_cb_ref.cb(nil)
 
-        assert.equal("restored-id", session.session_id)
-        assert.is_true(
-            vim.tbl_contains(session._cancelled, "new-id"),
-            "stale new session should be cancelled"
-        )
-    end)
+            assert.equal("restored-id", session.session_id)
+            assert.is_true(
+                vim.tbl_contains(session._cancelled, "new-id"),
+                "stale new session should be cancelled"
+            )
+        end
+    )
 
     -- Race B: load_session completes BEFORE create_session callback fires.
     -- session_id is already set by the time create fires; the staleness guard catches it.
-    it("Race B: load completes before create fires — session_id guard prevents overwrite", function()
-        local create_cb_ref = {}
-        local session = make_session(create_cb_ref, nil) -- load fires immediately
+    it(
+        "Race B: load completes before create fires — session_id guard prevents overwrite",
+        function()
+            local create_cb_ref = {}
+            local session = make_session(create_cb_ref, nil) -- load fires immediately
 
-        -- Step 1: new_session in-flight (create deferred)
-        session:new_session()
-        assert.is_nil(session.session_id)
+            -- Step 1: new_session in-flight (create deferred)
+            session:new_session()
+            assert.is_nil(session.session_id)
 
-        -- Step 2: load_acp_session — load fires and completes synchronously
-        session:load_acp_session("restored-id", "title", nil)
-        assert.equal("restored-id", session.session_id)
-        assert.is_false(session._is_restoring_session) -- cleared by load callback
+            -- Step 2: load_acp_session — load fires and completes synchronously
+            session:load_acp_session("restored-id", "title", nil)
+            assert.equal("restored-id", session.session_id)
+            assert.is_false(session._is_restoring_session) -- cleared by load callback
 
-        -- Step 3: stale create fires after load already finished
-        create_cb_ref.cb({ sessionId = "new-id" }, nil)
+            -- Step 3: stale create fires after load already finished
+            create_cb_ref.cb({ sessionId = "new-id" }, nil)
 
-        assert.equal(
-            "restored-id",
-            session.session_id,
-            "stale create_session must not overwrite the restored session"
-        )
-        assert.is_true(
-            vim.tbl_contains(session._cancelled, "new-id"),
-            "stale new session should be cancelled"
-        )
-    end)
+            assert.equal(
+                "restored-id",
+                session.session_id,
+                "stale create_session must not overwrite the restored session"
+            )
+            assert.is_true(
+                vim.tbl_contains(session._cancelled, "new-id"),
+                "stale new session should be cancelled"
+            )
+        end
+    )
 
     -- Race B with a FAILED stale create: response is nil and err is set.
     -- The staleness guard runs before the `if err or not response` branch, so
     -- the restored session_id survives. If the guard were moved below that
     -- branch, the error path would null out session_id and silently drop the
     -- restore. No cancellation is expected: a failed create has no sessionId.
-    it("Race B: stale create ERRORS after load — restored session survives", function()
-        local create_cb_ref = {}
-        local session = make_session(create_cb_ref, nil) -- load fires immediately
+    it(
+        "Race B: stale create ERRORS after load — restored session survives",
+        function()
+            local create_cb_ref = {}
+            local session = make_session(create_cb_ref, nil) -- load fires immediately
 
-        -- Step 1: new_session in-flight (create deferred)
-        session:new_session()
-        assert.is_nil(session.session_id)
+            -- Step 1: new_session in-flight (create deferred)
+            session:new_session()
+            assert.is_nil(session.session_id)
 
-        -- Step 2: load_acp_session — load fires and completes synchronously
-        session:load_acp_session("restored-id", "title", nil)
-        assert.equal("restored-id", session.session_id)
-        assert.is_false(session._is_restoring_session) -- cleared by load callback
+            -- Step 2: load_acp_session — load fires and completes synchronously
+            session:load_acp_session("restored-id", "title", nil)
+            assert.equal("restored-id", session.session_id)
+            assert.is_false(session._is_restoring_session) -- cleared by load callback
 
-        -- Step 3: stale create fails after restore already finished
-        create_cb_ref.cb(nil, { message = "boom" })
+            -- Step 3: stale create fails after restore already finished
+            create_cb_ref.cb(nil, { message = "boom" })
 
-        assert.equal(
-            "restored-id",
-            session.session_id,
-            "failed stale create must not null out the restored session"
-        )
-        assert.equal(
-            0,
-            #session._cancelled,
-            "a failed stale create has no sessionId to cancel"
-        )
-    end)
+            assert.equal(
+                "restored-id",
+                session.session_id,
+                "failed stale create must not null out the restored session"
+            )
+            assert.equal(
+                0,
+                #session._cancelled,
+                "a failed stale create has no sessionId to cancel"
+            )
+        end
+    )
 end)

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -178,8 +178,8 @@ describe("race: stale create_session after load_acp_session", function()
     end)
 
     -- Race B: load_session completes BEFORE create_session callback fires.
-    -- _is_restoring_session is cleared; our current fix does NOT cover this.
-    it("Race B: load completes before create fires — exposes gap in current fix", function()
+    -- session_id is already set by the time create fires; the staleness guard catches it.
+    it("Race B: load completes before create fires — session_id guard prevents overwrite", function()
         local create_cb_ref = {}
         local session = make_session(create_cb_ref, nil) -- load fires immediately
 
@@ -195,12 +195,14 @@ describe("race: stale create_session after load_acp_session", function()
         -- Step 3: stale create fires after load already finished
         create_cb_ref.cb({ sessionId = "new-id" }, nil)
 
-        -- This assertion will FAIL with the current fix (only Race A is protected).
-        -- It will PASS once the generation-counter fix is applied.
         assert.equal(
             "restored-id",
             session.session_id,
             "stale create_session must not overwrite the restored session"
+        )
+        assert.is_true(
+            vim.tbl_contains(session._cancelled, "new-id"),
+            "stale new session should be cancelled"
         )
     end)
 end)

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -106,6 +106,13 @@ describe("race: stale create_session after load_acp_session", function()
                 mode = nil,
                 model = nil,
                 thought_level = nil,
+                snapshot = function()
+                    return {}
+                end,
+                restore_snapshot = function() end,
+                get_mode_id = function()
+                    return nil
+                end,
                 legacy_agent_modes = {
                     save = function()
                         return {}
@@ -130,6 +137,9 @@ describe("race: stale create_session after load_acp_session", function()
                 write_structural_message = function() end,
                 write_message = function() end,
                 reset_sender_tracking = function() end,
+                generate_welcome_header = function()
+                    return ""
+                end,
                 tool_call_blocks = {},
             },
             chat_history = ChatHistory:new(),

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -170,10 +170,7 @@ describe("race: stale create_session after load_acp_session", function()
             load_cb_ref.cb(nil)
 
             assert.equal("restored-id", session.session_id)
-            assert.is_true(
-                vim.tbl_contains(session._cancelled, "new-id"),
-                "stale new session should be cancelled"
-            )
+            assert.is_true(vim.tbl_contains(session._cancelled, "new-id"))
         end
     )
 
@@ -197,15 +194,8 @@ describe("race: stale create_session after load_acp_session", function()
             -- Step 3: stale create fires after load already finished
             create_cb_ref.cb({ sessionId = "new-id" }, nil)
 
-            assert.equal(
-                "restored-id",
-                session.session_id,
-                "stale create_session must not overwrite the restored session"
-            )
-            assert.is_true(
-                vim.tbl_contains(session._cancelled, "new-id"),
-                "stale new session should be cancelled"
-            )
+            assert.equal("restored-id", session.session_id)
+            assert.is_true(vim.tbl_contains(session._cancelled, "new-id"))
         end
     )
 
@@ -232,16 +222,8 @@ describe("race: stale create_session after load_acp_session", function()
             -- Step 3: stale create fails after restore already finished
             create_cb_ref.cb(nil, { message = "boom" })
 
-            assert.equal(
-                "restored-id",
-                session.session_id,
-                "failed stale create must not null out the restored session"
-            )
-            assert.equal(
-                0,
-                #session._cancelled,
-                "a failed stale create has no sessionId to cancel"
-            )
+            assert.equal("restored-id", session.session_id)
+            assert.equal(0, #session._cancelled)
         end
     )
 end)

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -1,0 +1,206 @@
+--- MRE for the race condition between create_session and load_acp_session.
+---
+--- When new_session() is called, an async create_session ACP request goes in-flight.
+--- If load_acp_session() is called before the create_session callback returns, the
+--- late-firing callback can overwrite session_id with a fresh empty session, silently
+--- discarding the restored context.
+---
+--- Two orderings are possible:
+---   Race A: create_session callback fires while _is_restoring_session is still true
+---            (load_session hasn't completed yet).
+---   Race B: load_session completes first (clearing _is_restoring_session), then
+---            create_session callback fires and overwrites session_id.
+---
+--- Race B is the more common one in practice: the user has to interact with the
+--- restore picker, giving load_session time to complete before create fires.
+
+--- @diagnostic disable: invisible, missing-fields, assign-type-mismatch, param-type-mismatch
+local assert = require("tests.helpers.assert")
+local spy = require("tests.helpers.spy")
+
+local SessionManager = require("agentic.session_manager")
+local ACPPayloads = require("agentic.acp.acp_payloads")
+local ChatHistory = require("agentic.ui.chat_history")
+local SlashCommands = require("agentic.acp.slash_commands")
+
+describe("race: stale create_session after load_acp_session", function()
+    local original_schedule
+    local slash_stub
+    local payload_stub
+
+    before_each(function()
+        original_schedule = vim.schedule
+        -- Run vim.schedule callbacks synchronously so callbacks fire inline
+        vim.schedule = function(fn)
+            fn()
+        end
+
+        slash_stub = spy.stub(SlashCommands, "setCommands")
+        payload_stub = spy.stub(
+            ACPPayloads,
+            "generate_user_message",
+            function()
+                return {}
+            end
+        )
+    end)
+
+    after_each(function()
+        vim.schedule = original_schedule
+        slash_stub:revert()
+        payload_stub:revert()
+    end)
+
+    --- Build a minimal session object that can run new_session() and
+    --- load_acp_session() without a real UI or ACP process.
+    --- @param create_cb_ref table Mutable holder; .cb is set when create_session is called.
+    --- @param load_cb_ref table  Mutable holder; .cb is set when load_session is called (for deferring in Race A).
+    local function make_session(create_cb_ref, load_cb_ref)
+        local cancelled = {}
+
+        local session = {
+            session_id = nil,
+            _is_restoring_session = false,
+            is_generating = false,
+            _session_ready_callbacks = {},
+            _is_first_message = true,
+            _connection_error = false,
+            _header_refresh_scheduled = false,
+            history_to_send = nil,
+            tab_page_id = 1,
+
+            agent = {
+                agent_capabilities = { loadSession = true },
+                provider_config = { name = "test-provider" },
+                agent_info = nil,
+
+                create_session = function(_, handlers, cb)
+                    create_cb_ref.cb = cb -- capture; do NOT call yet
+                end,
+
+                load_session = function(_, sid, cwd, mcp, handlers, cb)
+                    if load_cb_ref then
+                        load_cb_ref.cb = cb -- capture; caller fires manually (Race A)
+                    else
+                        cb(nil) -- fire immediately (Race B)
+                    end
+                end,
+
+                cancel_session = function(_, sid)
+                    table.insert(cancelled, sid)
+                end,
+            },
+            _cancelled = cancelled,
+
+            status_animation = {
+                start = function() end,
+                stop = function() end,
+            },
+            widget = {
+                clear = function() end,
+                buf_nrs = { input = 0, chat = 0 },
+            },
+            todo_list = { clear = function() end },
+            file_list = { clear = function() end },
+            code_selection = { clear = function() end },
+            diagnostics_list = { clear = function() end },
+            config_options = {
+                clear = function() end,
+                mode = nil,
+                model = nil,
+                thought_level = nil,
+                legacy_agent_modes = {
+                    save = function()
+                        return {}
+                    end,
+                    restore = function() end,
+                    current_mode_id = nil,
+                },
+                legacy_agent_models = {
+                    save = function()
+                        return {}
+                    end,
+                    restore = function() end,
+                },
+                set_initial_model = function()
+                    return false
+                end,
+                set_initial_mode = function() end,
+                set_initial_thought_level = function() end,
+            },
+            permission_manager = { clear = function() end },
+            message_writer = {
+                write_structural_message = function() end,
+                write_message = function() end,
+                reset_sender_tracking = function() end,
+                tool_call_blocks = {},
+            },
+            chat_history = ChatHistory:new(),
+
+            _build_handlers = function()
+                return {}
+            end,
+            _set_mode_to_chat_header = function() end,
+            _cancel_session = SessionManager._cancel_session,
+            new_session = SessionManager.new_session,
+            load_acp_session = SessionManager.load_acp_session,
+        }
+
+        return session
+    end
+
+    -- Race A: create_session callback fires BEFORE load_session completes.
+    -- _is_restoring_session is still true → our guard should catch it.
+    it("Race A: create fires before load completes — fix should prevent overwrite", function()
+        local create_cb_ref = {}
+        local load_cb_ref = {}
+        local session = make_session(create_cb_ref, load_cb_ref)
+
+        -- Step 1: new_session in-flight (create deferred)
+        session:new_session()
+        assert.is_nil(session.session_id)
+
+        -- Step 2: load_acp_session starts but load_session callback is also deferred
+        session:load_acp_session("restored-id", "title", nil)
+        assert.is_true(session._is_restoring_session) -- load hasn't completed yet
+
+        -- Step 3: create fires first (while _is_restoring_session is still true)
+        create_cb_ref.cb({ sessionId = "new-id" }, nil)
+
+        -- Step 4: load completes
+        load_cb_ref.cb(nil)
+
+        assert.equal("restored-id", session.session_id)
+        assert.is_true(
+            vim.tbl_contains(session._cancelled, "new-id"),
+            "stale new session should be cancelled"
+        )
+    end)
+
+    -- Race B: load_session completes BEFORE create_session callback fires.
+    -- _is_restoring_session is cleared; our current fix does NOT cover this.
+    it("Race B: load completes before create fires — exposes gap in current fix", function()
+        local create_cb_ref = {}
+        local session = make_session(create_cb_ref, nil) -- load fires immediately
+
+        -- Step 1: new_session in-flight (create deferred)
+        session:new_session()
+        assert.is_nil(session.session_id)
+
+        -- Step 2: load_acp_session — load fires and completes synchronously
+        session:load_acp_session("restored-id", "title", nil)
+        assert.equal("restored-id", session.session_id)
+        assert.is_false(session._is_restoring_session) -- cleared by load callback
+
+        -- Step 3: stale create fires after load already finished
+        create_cb_ref.cb({ sessionId = "new-id" }, nil)
+
+        -- This assertion will FAIL with the current fix (only Race A is protected).
+        -- It will PASS once the generation-counter fix is applied.
+        assert.equal(
+            "restored-id",
+            session.session_id,
+            "stale create_session must not overwrite the restored session"
+        )
+    end)
+end)

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -205,4 +205,32 @@ describe("race: stale create_session after load_acp_session", function()
             "stale new session should be cancelled"
         )
     end)
+
+    -- Race B with a FAILED stale create: response is nil and err is set.
+    -- The staleness guard runs before the `if err or not response` branch, so
+    -- the restored session_id survives. If the guard were moved below that
+    -- branch, the error path would null out session_id and silently drop the
+    -- restore. No cancellation is expected: a failed create has no sessionId.
+    it("Race B: stale create ERRORS after load — restored session survives", function()
+        local create_cb_ref = {}
+        local session = make_session(create_cb_ref, nil) -- load fires immediately
+
+        -- Step 1: new_session in-flight (create deferred)
+        session:new_session()
+        assert.is_nil(session.session_id)
+
+        -- Step 2: load_acp_session — load fires and completes synchronously
+        session:load_acp_session("restored-id", "title", nil)
+        assert.equal("restored-id", session.session_id)
+        assert.is_false(session._is_restoring_session) -- cleared by load callback
+
+        -- Step 3: stale create fails after restore already finished
+        create_cb_ref.cb(nil, { message = "boom" })
+
+        assert.equal(
+            "restored-id",
+            session.session_id,
+            "failed stale create must not null out the restored session"
+        )
+    end)
 end)

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -232,5 +232,10 @@ describe("race: stale create_session after load_acp_session", function()
             session.session_id,
             "failed stale create must not null out the restored session"
         )
+        assert.equal(
+            0,
+            #session._cancelled,
+            "a failed stale create has no sessionId to cancel"
+        )
     end)
 end)

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -14,7 +14,7 @@
 --- Race B is the more common one in practice: the user has to interact with the
 --- restore picker, giving load_session time to complete before create fires.
 
---- @diagnostic disable: invisible, missing-fields, assign-type-mismatch, param-type-mismatch
+--- @diagnostic disable: invisible, missing-fields, assign-type-mismatch, param-type-mismatch, duplicate-set-field
 local assert = require("tests.helpers.assert")
 local spy = require("tests.helpers.spy")
 
@@ -36,7 +36,8 @@ describe("race: stale create_session after load_acp_session", function()
         end
 
         slash_stub = spy.stub(SlashCommands, "setCommands")
-        payload_stub = spy.stub(ACPPayloads, "generate_user_message", function()
+        payload_stub = spy.stub(ACPPayloads, "generate_user_message")
+        payload_stub:invokes(function()
             return {}
         end)
     end)
@@ -70,11 +71,11 @@ describe("race: stale create_session after load_acp_session", function()
                 provider_config = { name = "test-provider" },
                 agent_info = nil,
 
-                create_session = function(_, handlers, cb)
+                create_session = function(_, _handlers, cb)
                     create_cb_ref.cb = cb -- capture; do NOT call yet
                 end,
 
-                load_session = function(_, sid, cwd, mcp, handlers, cb)
+                load_session = function(_, _sid, _cwd, _mcp, _handlers, cb)
                     if load_cb_ref then
                         load_cb_ref.cb = cb -- capture; caller fires manually (Race A)
                     else

--- a/tests/helpers/assert.lua
+++ b/tests/helpers/assert.lua
@@ -16,8 +16,7 @@ local M = {}
 --- Basic equality assertion
 --- @param actual any Actual value
 --- @param expected any Expected value
---- @param _message? string Optional failure message (not forwarded; kept for call-site readability)
-function M.equal(actual, expected, _message)
+function M.equal(actual, expected)
     expect.equality(actual, expected)
 end
 
@@ -37,8 +36,7 @@ end
 
 --- Assert value is true
 --- @param value any Value to check
---- @param _message? string Optional failure message (not forwarded; kept for call-site readability)
-function M.is_true(value, _message)
+function M.is_true(value)
     expect.equality(value, true)
 end
 

--- a/tests/helpers/assert.lua
+++ b/tests/helpers/assert.lua
@@ -16,7 +16,8 @@ local M = {}
 --- Basic equality assertion
 --- @param actual any Actual value
 --- @param expected any Expected value
-function M.equal(actual, expected)
+--- @param _message? string Optional failure message (not forwarded; kept for call-site readability)
+function M.equal(actual, expected, _message)
     expect.equality(actual, expected)
 end
 
@@ -36,7 +37,8 @@ end
 
 --- Assert value is true
 --- @param value any Value to check
-function M.is_true(value)
+--- @param _message? string Optional failure message (not forwarded; kept for call-site readability)
+function M.is_true(value, _message)
     expect.equality(value, true)
 end
 


### PR DESCRIPTION
Two issues with session restore and generation state are fixed.

**Race condition in session restore**

When `load_acp_session` was called while a `create_session` request was still in flight, the late-firing `create_session` callback would overwrite `session_id` with a fresh empty session, silently discarding the restored context. The fix checks whether a session is already set (Race B: load completed first) or a restore is in progress (Race A: load still in flight), and cancels the stale new session in both cases. A minimal test covers both orderings.

**Stuck generation state after connection issues**

When the Claude API hangs mid-generation (network drop, suspend/resume), no disconnect event fires and `is_generating` stays `true` indefinitely, blocking new prompts. `stop_generation` was guarded by `is_generating`, so it could not unstick desynced state. It now always resets `is_generating` and stops the animation, only sending the cancel request to the agent when a session is actually active. `_handle_connection_error` also clears `is_generating`, which it previously left set.