### PR TITLE
feat(acp): recover from an unresponsive agent without restarting Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ Negative values are clamped to 0. Diff tool calls keep full header-only titles.
 | `:lua require("agentic").stop_generation()`                  | Stop current generation or tool execution (session stays active)  |
 | `:lua require("agentic").restore_session()`                  | Show provider's session picker to restore a previous session      |
 | `:lua require("agentic").restore_session_by_id(session_id)`  | Restore a session by its ID                                       |
+| `:lua require("agentic").reconnect()`                        | Respawn a hung agent and reload the session in place              |
 | `:lua require("agentic").switch_provider()`                  | Switch ACP provider mid-session (shows picker, preserves history) |
 | `:lua require("agentic").rotate_layout()`                    | Rotate window position through layouts (right → bottom → left)    |
 

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -610,6 +610,20 @@ agentic.restore_session_by_id({session_id})
   Parameters: ~
     {session_id}  (string)  Session ID to restore.
 
+                                             *agentic.reconnect()*
+agentic.reconnect()
+  Respawn the agent process and reload the current session in
+  place, without quitting Neovim. Use it when the agent stops
+  responding, typically after the machine resumes from suspend.
+
+  The watchdog surfaces a stalled control request on its own, but
+  a prompt can run silently for minutes while a tool works, so a
+  hang during generation is not detected automatically. This is
+  the manual way out of that state.
+
+  The agent process is shared per provider, so every session on
+  that provider re-establishes; they do so on their next use.
+
                                               *agentic.rotate_layout()*
 agentic.rotate_layout({layouts})
   Rotate through window positions (right -> bottom -> left).

--- a/doc/tags
+++ b/doc/tags
@@ -72,6 +72,7 @@ agentic.next_session()	agentic.txt	/*agentic.next_session()*
 agentic.nvim	agentic.txt	/*agentic.nvim*
 agentic.open()	agentic.txt	/*agentic.open()*
 agentic.prev_session()	agentic.txt	/*agentic.prev_session()*
+agentic.reconnect()	agentic.txt	/*agentic.reconnect()*
 agentic.restore_session()	agentic.txt	/*agentic.restore_session()*
 agentic.restore_session_by_id()	agentic.txt	/*agentic.restore_session_by_id()*
 agentic.rotate_layout()	agentic.txt	/*agentic.rotate_layout()*

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -787,6 +787,17 @@ function ACPClient:stop()
     self.transport:stop()
 end
 
+--- Force a fresh agent process in place: kill the current (possibly hung)
+--- child, then respawn and re-initialize. `stop()` drains every pending
+--- callback and moves the state to "disconnected", which `_connect()` requires.
+--- Sessions are not restored here; the caller re-establishes them once the
+--- client reaches "ready" again (via `when_ready`).
+function ACPClient:reconnect()
+    self.transport:stop()
+    self.reconnect_count = 0
+    self:_connect()
+end
+
 function ACPClient:_connect()
     if self.state ~= "disconnected" then
         return

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -16,8 +16,10 @@ local WATCHDOG_CHECK_INTERVAL_MS = 5000
 
 --- Methods the silence watchdog must NOT govern. `session/prompt` can run for
 --- minutes while a tool executes, producing no traffic, so silence is not a
---- death signal there; it is guarded separately by the liveness probe. All
---- other (control) RPCs are expected to answer within seconds.
+--- death signal there and no timeout distinguishes a working agent from a dead
+--- one. A prompt that hangs is therefore NOT detected automatically; the way
+--- out is `Agentic.reconnect()`, which respawns the child on demand. All other
+--- (control) RPCs are expected to answer within seconds.
 local UNWATCHED_METHODS = {
     ["session/prompt"] = true,
 }
@@ -314,8 +316,9 @@ end
 
 --- Surface a stalled connection: reject the in-flight control requests with a
 --- timeout error so their UI resets instead of hanging. Any in-flight
---- session/prompt is deliberately left untouched; a long silent tool run is
---- not a death signal and is guarded by the liveness probe.
+--- session/prompt is deliberately left untouched, since a long silent tool run
+--- is indistinguishable from a dead one and cancelling real work is worse than
+--- waiting. Recovering from a hung prompt is manual, see `UNWATCHED_METHODS`.
 --- @protected
 --- @param timeout number
 function ACPClient:_on_request_stall(timeout)
@@ -402,7 +405,8 @@ function ACPClient:_send_request(method, params, callback)
     Logger.debug_to_file("request: ", message)
 
     -- Arm the silence watchdog for control requests only. session/prompt is
-    -- excluded: it can run silently for minutes and is guarded separately.
+    -- excluded because it can run silently for minutes; silence does not
+    -- distinguish real work from a dead prompt, so recovery is manual.
     if not UNWATCHED_METHODS[method] then
         self._watched_pending[id] = true
         self._last_activity = uv.now()

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -1,6 +1,26 @@
 local Logger = require("agentic.utils.logger")
 local JsonFormat = require("agentic.utils.json_format")
 local transport_module = require("agentic.acp.acp_transport")
+local uv = vim.uv or vim.loop
+
+--- Default time with no inbound activity before an in-flight request is
+--- treated as stalled. A suspended/hung agent child keeps its stdio pipes
+--- open and never exits, so the process-exit path never fires; this watchdog
+--- is the only thing that surfaces such a dead connection.
+local DEFAULT_REQUEST_TIMEOUT_MS = 60000
+
+--- How often the watchdog checks for inactivity while a request is pending.
+--- Coarse on purpose: the cost is one subtraction per tick, and the timer is
+--- only armed while at least one request is in flight.
+local WATCHDOG_CHECK_INTERVAL_MS = 5000
+
+--- Methods the silence watchdog must NOT govern. `session/prompt` can run for
+--- minutes while a tool executes, producing no traffic, so silence is not a
+--- death signal there; it is guarded separately by the liveness probe. All
+--- other (control) RPCs are expected to answer within seconds.
+local UNWATCHED_METHODS = {
+    ["session/prompt"] = true,
+}
 
 local KNOWN_ACP_KINDS = {
     read = true,
@@ -32,6 +52,9 @@ local KNOWN_ACP_KINDS = {
 --- @field transport? agentic.acp.ACPTransportInstance
 --- @field ready_listeners fun(client: agentic.acp.ACPClient)[]
 --- @field subscribers table<string, agentic.acp.ClientHandlers>
+--- @field _last_activity number `uv.now()` of the last inbound message; the watchdog measures silence against it.
+--- @field _watchdog_timer? uv.uv_timer_t Repeating inactivity timer, armed only while a watched request is pending.
+--- @field _watched_pending table<number, true> Ids of in-flight control requests the silence watchdog governs (excludes session/prompt).
 
 --- @class agentic.acp.ACPClient : agentic.acp.ACPClientData
 --- @field _on_ready fun(client: agentic.acp.ACPClient)
@@ -81,6 +104,9 @@ function ACPClient:new(config, on_ready)
         transport = nil,
         state = "disconnected",
         reconnect_count = 0,
+        _last_activity = 0,
+        _watchdog_timer = nil,
+        _watched_pending = {},
     }
 
     local client = setmetatable(instance, self) --[[@as agentic.acp.ACPClient]]
@@ -209,16 +235,127 @@ end
 
 --- @protected
 --- @param reason string
-function ACPClient:_drain_pending_callbacks(reason)
+--- @param code? number Error code to reject with; defaults to TRANSPORT_ERROR.
+function ACPClient:_drain_pending_callbacks(reason, code)
     local pending = self.callbacks
     self.callbacks = {}
+    self._watched_pending = {}
+    self:_disarm_watchdog()
 
-    local err = self:__create_error(self.ERROR_CODES.TRANSPORT_ERROR, reason)
+    local err =
+        self:__create_error(code or self.ERROR_CODES.TRANSPORT_ERROR, reason)
 
     for _, callback in pairs(pending) do
         vim.schedule(function()
             pcall(callback, nil, err)
         end)
+    end
+end
+
+--- Start the inactivity watchdog if it is not already running. Idempotent;
+--- safe to call on every request. The timer disarms itself once no requests
+--- are pending, so there is no idle cost.
+--- @protected
+function ACPClient:_arm_watchdog()
+    if self._watchdog_timer then
+        return
+    end
+
+    local timer = uv.new_timer()
+    if not timer then
+        return
+    end
+
+    self._watchdog_timer = timer
+    timer:start(
+        WATCHDOG_CHECK_INTERVAL_MS,
+        WATCHDOG_CHECK_INTERVAL_MS,
+        function()
+            self:_check_watchdog()
+        end
+    )
+end
+
+--- Stop and release the watchdog timer.
+--- @protected
+function ACPClient:_disarm_watchdog()
+    local timer = self._watchdog_timer
+    if not timer then
+        return
+    end
+
+    self._watchdog_timer = nil
+    timer:stop()
+    if not timer:is_closing() then
+        timer:close()
+    end
+end
+
+--- Watchdog tick: runs in libuv fast context, so it only reads `uv.now()`
+--- and touches plain Lua state, deferring the actual handling to the main loop.
+--- @protected
+function ACPClient:_check_watchdog()
+    if not next(self._watched_pending) then
+        self:_disarm_watchdog()
+        return
+    end
+
+    local timeout = self.provider_config.timeout
+        or DEFAULT_REQUEST_TIMEOUT_MS
+
+    if uv.now() - self._last_activity >= timeout then
+        -- Disarm here (still cheap, fast-context-safe) so a slow main loop
+        -- can't queue several stall handlers before the first one runs.
+        self:_disarm_watchdog()
+        vim.schedule(function()
+            self:_on_request_stall(timeout)
+        end)
+    end
+end
+
+--- Surface a stalled connection: reject the in-flight control requests with a
+--- timeout error so their UI resets instead of hanging. Any in-flight
+--- session/prompt is deliberately left untouched; a long silent tool run is
+--- not a death signal and is guarded by the liveness probe.
+--- @protected
+--- @param timeout number
+function ACPClient:_on_request_stall(timeout)
+    if not next(self._watched_pending) then
+        return
+    end
+
+    Logger.notify(
+        string.format(
+            "Agent control request timed out after %ds.",
+            math.floor(timeout / 1000)
+        ),
+        vim.log.levels.WARN
+    )
+
+    self:_reject_watched("Request timed out", self.ERROR_CODES.TIMEOUT_ERROR)
+end
+
+--- Reject only the watched (control) requests, leaving session/prompt and any
+--- other unwatched callback in place.
+--- @protected
+--- @param reason string
+--- @param code? number
+function ACPClient:_reject_watched(reason, code)
+    local watched = self._watched_pending
+    self._watched_pending = {}
+    self:_disarm_watchdog()
+
+    local err =
+        self:__create_error(code or self.ERROR_CODES.TRANSPORT_ERROR, reason)
+
+    for id in pairs(watched) do
+        local callback = self.callbacks[id]
+        self.callbacks[id] = nil
+        if callback then
+            vim.schedule(function()
+                pcall(callback, nil, err)
+            end)
+        end
     end
 end
 
@@ -259,7 +396,33 @@ function ACPClient:_send_request(method, params, callback)
 
     Logger.debug_to_file("request: ", message)
 
-    self.transport:send(data)
+    -- Arm the silence watchdog for control requests only. session/prompt is
+    -- excluded: it can run silently for minutes and is guarded separately.
+    if not UNWATCHED_METHODS[method] then
+        self._watched_pending[id] = true
+        self._last_activity = uv.now()
+        self:_arm_watchdog()
+    end
+
+    if self.transport:send(data) == false then
+        -- The pipe is already closing; reject now rather than wait, since no
+        -- response can ever arrive. Only an explicit false counts as failure;
+        -- an ambiguous return falls back to the watchdog. Applies to every
+        -- method, including session/prompt, since the send genuinely failed.
+        self.callbacks[id] = nil
+        self._watched_pending[id] = nil
+        if not next(self._watched_pending) then
+            self:_disarm_watchdog()
+        end
+
+        local err = self:__create_error(
+            self.ERROR_CODES.TRANSPORT_ERROR,
+            "Failed to send request: transport not writable"
+        )
+        vim.schedule(function()
+            pcall(callback, nil, err)
+        end)
+    end
 end
 
 --- @param method string
@@ -292,6 +455,10 @@ end
 
 --- @param message agentic.acp.ResponseRaw
 function ACPClient:_handle_message(message)
+    -- Any inbound message (response or streamed update) counts as activity and
+    -- keeps the watchdog from tripping during a legitimately long generation.
+    self._last_activity = uv.now()
+
     -- Chunks are not logged: they would flood the log file.
     if
         not (
@@ -313,6 +480,10 @@ function ACPClient:_handle_message(message)
         local callback = self.callbacks[message.id]
         if callback then
             self.callbacks[message.id] = nil
+            self._watched_pending[message.id] = nil
+            if not next(self._watched_pending) then
+                self:_disarm_watchdog()
+            end
             callback(message.result, message.error)
         else
             Logger.notify(

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -300,8 +300,7 @@ function ACPClient:_check_watchdog()
         return
     end
 
-    local timeout = self.provider_config.timeout
-        or DEFAULT_REQUEST_TIMEOUT_MS
+    local timeout = self.provider_config.timeout or DEFAULT_REQUEST_TIMEOUT_MS
 
     if uv.now() - self._last_activity >= timeout then
         -- Disarm here (still cheap, fast-context-safe) so a slow main loop
@@ -321,6 +320,12 @@ end
 --- @param timeout number
 function ACPClient:_on_request_stall(timeout)
     if not next(self._watched_pending) then
+        return
+    end
+
+    -- Re-check: a response may have arrived in the gap between the watchdog
+    -- disarming and this handler running via vim.schedule.
+    if uv.now() - self._last_activity < timeout then
         return
     end
 

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -1715,7 +1715,7 @@ describe("ACPClient", function()
                 assert.is_nil(received_err)
 
                 -- Pretend no message has arrived for far longer than the timeout.
-                watched_client._last_activity = 0
+                watched_client._last_activity = uv.now() - 70000
                 watched_client:_check_watchdog()
 
                 assert.is_not_nil(received_err)
@@ -1776,7 +1776,7 @@ describe("ACPClient", function()
             -- A prompt must not arm the silence watchdog at all.
             assert.is_nil(watched_client._watchdog_timer)
 
-            watched_client._last_activity = 0
+            watched_client._last_activity = uv.now() - 70000
             watched_client:_check_watchdog()
 
             assert.is_nil(received_err)
@@ -1799,7 +1799,7 @@ describe("ACPClient", function()
                     control_err = err
                 end)
 
-                watched_client._last_activity = 0
+                watched_client._last_activity = uv.now() - 70000
                 watched_client:_check_watchdog()
 
                 -- Only the control request is rejected; the prompt is left alone.

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -1827,4 +1827,88 @@ describe("ACPClient", function()
             assert.is_nil(watched_client._watchdog_timer)
         end)
     end)
+
+    describe("reconnect", function()
+        local original_schedule
+
+        before_each(function()
+            -- The drain on disconnect defers rejection via vim.schedule; run it
+            -- inline so it resolves within the test.
+            original_schedule = vim.schedule
+            vim.schedule = function(fn)
+                fn()
+            end
+        end)
+
+        after_each(function()
+            vim.schedule = original_schedule
+        end)
+
+        it("stops the transport and re-initializes back to ready", function()
+            local client = create_ready_client(LOAD_CAPS)
+            assert.equal("ready", client.state)
+
+            -- stop() drives the connection down; _connect() needs "disconnected".
+            transport_stop_stub:invokes(function()
+                if captured_on_state_change then
+                    captured_on_state_change("disconnected")
+                end
+            end)
+
+            -- A fresh start() reconnects and answers the new initialize.
+            transport_start_stub:reset()
+            transport_start_stub:invokes(function()
+                if captured_on_state_change then
+                    captured_on_state_change("connected")
+                end
+            end)
+            transport_send_stub:reset()
+            transport_send_stub:invokes(function(_self, data)
+                local decoded = vim.json.decode(data)
+                if decoded.method == "initialize" and captured_on_message then
+                    captured_on_message({
+                        jsonrpc = "2.0",
+                        id = decoded.id,
+                        result = {
+                            protocolVersion = 1,
+                            agentCapabilities = LOAD_CAPS,
+                            agentInfo = { name = "test" },
+                        },
+                    })
+                end
+            end)
+
+            client:reconnect()
+
+            assert.spy(transport_stop_stub).was.called(1)
+            assert.spy(transport_start_stub).was.called(1)
+            assert.equal("ready", client.state)
+        end)
+
+        it(
+            "rejects in-flight requests when it tears the connection down",
+            function()
+                local client = create_ready_client(LOAD_CAPS)
+
+                --- @type agentic.acp.ACPError|nil
+                local prompt_err
+                client:send_prompt("sess-1", {}, function(_result, err)
+                    prompt_err = err
+                end)
+
+                -- stop() reports the drop, which must drain pending callbacks.
+                transport_stop_stub:invokes(function()
+                    if captured_on_state_change then
+                        captured_on_state_change("disconnected")
+                    end
+                end)
+                transport_start_stub:reset()
+                transport_start_stub:invokes(function() end)
+
+                client:reconnect()
+
+                assert.is_not_nil(prompt_err)
+            end
+        )
+    end)
 end)

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -1743,6 +1743,27 @@ describe("ACPClient", function()
             assert.is_nil(received_err)
         end)
 
+        it(
+            "spares a pending request if activity resumes before stall handler fires",
+            function()
+                watched_client = create_ready_client(LIST_CAPS)
+
+                --- @type agentic.acp.ACPError|nil
+                local received_err
+                watched_client:list_sessions("/tmp", function(_result, err)
+                    received_err = err
+                end)
+
+                -- Simulate a response arriving in the vim.schedule gap between
+                -- _check_watchdog disarming and _on_request_stall running.
+                -- The stall handler must re-check _last_activity and bail out.
+                watched_client._last_activity = uv.now()
+                watched_client:_on_request_stall(60000)
+
+                assert.is_nil(received_err)
+            end
+        )
+
         it("never times out session/prompt, even after long silence", function()
             watched_client = create_ready_client(LOAD_CAPS)
 

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -1,3 +1,4 @@
+--- @diagnostic disable: invisible, duplicate-set-field
 local assert = require("tests.helpers.assert")
 local Child = require("tests.helpers.child")
 local spy = require("tests.helpers.spy")
@@ -1673,6 +1674,157 @@ describe("ACPClient", function()
 
             assert.is_true(message.diff ~= nil)
             assert.equal(nil, message.body)
+        end)
+    end)
+
+    describe("request watchdog", function()
+        local uv = vim.uv or vim.loop
+        local original_schedule
+        --- @type agentic.acp.ACPClient|nil
+        local watched_client
+
+        before_each(function()
+            -- Run scheduled work inline so the stall/send-fail paths, which
+            -- defer rejection via vim.schedule, resolve within the test.
+            original_schedule = vim.schedule
+            vim.schedule = function(fn)
+                fn()
+            end
+        end)
+
+        after_each(function()
+            vim.schedule = original_schedule
+            -- Release any real timer a test left armed.
+            if watched_client then
+                watched_client:_disarm_watchdog()
+                watched_client = nil
+            end
+        end)
+
+        it(
+            "rejects a pending control request with a timeout after silence",
+            function()
+                watched_client = create_ready_client(LIST_CAPS)
+
+                --- @type agentic.acp.ACPError|nil
+                local received_err
+                watched_client:list_sessions("/tmp", function(_result, err)
+                    received_err = err
+                end)
+                -- No response stubbed: the callback is still parked.
+                assert.is_nil(received_err)
+
+                -- Pretend no message has arrived for far longer than the timeout.
+                watched_client._last_activity = 0
+                watched_client:_check_watchdog()
+
+                assert.is_not_nil(received_err)
+                --- @cast received_err agentic.acp.ACPError
+                assert.equal(
+                    watched_client.ERROR_CODES.TIMEOUT_ERROR,
+                    received_err.code
+                )
+            end
+        )
+
+        it("does not trip while inbound activity keeps arriving", function()
+            watched_client = create_ready_client(LIST_CAPS)
+
+            --- @type agentic.acp.ACPError|nil
+            local received_err
+            watched_client:list_sessions("/tmp", function(_result, err)
+                received_err = err
+            end)
+
+            -- Activity just happened: the silence window has not elapsed.
+            watched_client._last_activity = uv.now()
+            watched_client:_check_watchdog()
+
+            assert.is_nil(received_err)
+        end)
+
+        it("never times out session/prompt, even after long silence", function()
+            watched_client = create_ready_client(LOAD_CAPS)
+
+            --- @type agentic.acp.ACPError|nil
+            local received_err
+            watched_client:send_prompt("sess-1", {}, function(_result, err)
+                received_err = err
+            end)
+
+            -- A prompt must not arm the silence watchdog at all.
+            assert.is_nil(watched_client._watchdog_timer)
+
+            watched_client._last_activity = 0
+            watched_client:_check_watchdog()
+
+            assert.is_nil(received_err)
+        end)
+
+        it(
+            "times out a stalled control request without touching an in-flight prompt",
+            function()
+                watched_client = create_ready_client(LIST_CAPS)
+
+                --- @type agentic.acp.ACPError|nil
+                local prompt_err
+                watched_client:send_prompt("sess-1", {}, function(_result, err)
+                    prompt_err = err
+                end)
+
+                --- @type agentic.acp.ACPError|nil
+                local control_err
+                watched_client:list_sessions("/tmp", function(_result, err)
+                    control_err = err
+                end)
+
+                watched_client._last_activity = 0
+                watched_client:_check_watchdog()
+
+                -- Only the control request is rejected; the prompt is left alone.
+                assert.is_not_nil(control_err)
+                --- @cast control_err agentic.acp.ACPError
+                assert.equal(
+                    watched_client.ERROR_CODES.TIMEOUT_ERROR,
+                    control_err.code
+                )
+                assert.is_nil(prompt_err)
+            end
+        )
+
+        it("rejects immediately when the transport send fails", function()
+            watched_client = create_ready_client(LIST_CAPS)
+            transport_send_stub:reset()
+            transport_send_stub:invokes(function()
+                return false
+            end)
+
+            --- @type agentic.acp.ACPError|nil
+            local received_err
+            watched_client:list_sessions("/tmp", function(_result, err)
+                received_err = err
+            end)
+
+            assert.is_not_nil(received_err)
+            --- @cast received_err agentic.acp.ACPError
+            assert.equal(
+                watched_client.ERROR_CODES.TRANSPORT_ERROR,
+                received_err.code
+            )
+        end)
+
+        it("disarms the timer once no control request is pending", function()
+            watched_client = create_ready_client(LIST_CAPS)
+            -- The initialize round-trip during setup resolved, so nothing armed.
+            assert.is_nil(watched_client._watchdog_timer)
+
+            stub_send_response(watched_client, "session/list", {
+                sessions = {},
+            }, nil)
+            watched_client:list_sessions("/tmp", function() end)
+
+            -- Response resolved synchronously, so the watchdog disarmed again.
+            assert.is_nil(watched_client._watchdog_timer)
         end)
     end)
 end)

--- a/lua/agentic/acp/acp_client_types.lua
+++ b/lua/agentic/acp/acp_client_types.lua
@@ -360,7 +360,7 @@
 --- @field command? string Command to spawn agent (for stdio)
 --- @field args? string[] Arguments for agent command
 --- @field env? table<string, string|nil> Environment variables
---- @field timeout? number Request timeout in milliseconds
+--- @field timeout? number Inactivity silence timeout for the watchdog (ms); rejects stalled control requests after this duration
 --- @field reconnect? boolean Enable auto-reconnect
 --- @field max_reconnect_attempts? number Maximum reconnection attempts
 --- @field auth_method? string Authentication method

--- a/lua/agentic/acp/acp_transport.test.lua
+++ b/lua/agentic/acp/acp_transport.test.lua
@@ -101,6 +101,74 @@ describe("ACPTransport process lifecycle", function()
     )
 end)
 
+describe("ACPTransport reconnect-in-place", function()
+    local child
+
+    before_each(function()
+        child = MiniTest.new_child_neovim()
+        child.restart({ "-i", "NONE", "-u", "NONE" })
+        child.lua("vim.opt.rtp:prepend(...)", { vim.fn.getcwd() })
+    end)
+
+    after_each(function()
+        child.stop()
+    end)
+
+    it(
+        "can stop and start the same transport, yielding a fresh live child",
+        function()
+            -- The reconnect feature reuses one transport object: stop() kills the
+            -- child and start() spawns a new one. stop() closes the process
+            -- handle, which cancels the dead child's exit callback, so the killed
+            -- child can never disturb the connection that replaced it.
+            local result = child.lua([[
+                local Transport = require("agentic.acp.acp_transport")
+                _G.states = {}
+                _G.reconnects = 0
+                _G.transport = Transport.create_stdio_transport({
+                    command = "/bin/cat",
+                }, {
+                    on_state_change = function(s)
+                        table.insert(_G.states, s)
+                    end,
+                    on_message = function() end,
+                    on_reconnect = function()
+                        _G.reconnects = _G.reconnects + 1
+                    end,
+                })
+
+                _G.transport:start()           -- child A
+                local pid_a = _G.transport.pid
+                _G.transport:stop()            -- kill A
+                _G.transport:start()           -- child B, same transport object
+                local pid_b = _G.transport.pid
+
+                -- Let any stale callback from A fire before we assert.
+                vim.wait(800)
+
+                local function alive(pid)
+                    vim.fn.system({ "kill", "-0", tostring(pid) })
+                    return vim.v.shell_error == 0
+                end
+
+                return {
+                    final_state = _G.states[#_G.states],
+                    reconnects = _G.reconnects,
+                    different_pid = pid_a ~= pid_b,
+                    b_alive = alive(pid_b),
+                }
+            ]])
+
+            assert.is_true(result.different_pid)
+            assert.equal("connected", result.final_state)
+            assert.equal(0, result.reconnects)
+            assert.is_true(result.b_alive)
+
+            child.lua([[ _G.transport:stop() ]])
+        end
+    )
+end)
+
 describe("ACPTransport.decode_line", function()
     local Transport = require("agentic.acp.acp_transport")
 

--- a/lua/agentic/agentic.test.lua
+++ b/lua/agentic/agentic.test.lua
@@ -940,6 +940,29 @@ describe("agentic: switch_provider", function()
         assert.spy(switch_stub).was.called_with(opts)
     end)
 
+    it("reconnects the resolved session without creating one", function()
+        local Agentic = require("agentic")
+        local session = create_session()
+        local reconnect_stub = track_stub(session, "reconnect")
+        local create_stub = track_stub(SessionRegistry, "create")
+
+        Agentic.reconnect()
+
+        assert.spy(reconnect_stub).was.called(1)
+        assert.spy(create_stub).was.called(0)
+    end)
+
+    it("creates no session when reconnecting with none open", function()
+        local Agentic = require("agentic")
+        local create_stub = track_stub(SessionRegistry, "create")
+
+        assert.has_no_errors(function()
+            Agentic.reconnect()
+        end)
+
+        assert.spy(create_stub).was.called(0)
+    end)
+
     it("does not clear prompt buffer when session cannot submit", function()
         -- No flush: `session_id` stays nil, so submit must be blocked
         local session = SessionRegistry.create() --[[@as agentic.SessionManager]]

--- a/lua/agentic/init.lua
+++ b/lua/agentic/init.lua
@@ -247,6 +247,15 @@ function Agentic.restore_session()
     end)
 end
 
+--- Recover from an unresponsive agent: respawn the agent process and reload the
+--- current session in place, without quitting Neovim. Use when the agent stops
+--- responding (e.g. after the machine resumes from suspend).
+function Agentic.reconnect()
+    SessionRegistry.get_session_for_tab_page(nil, function(session)
+        session:reconnect()
+    end)
+end
+
 --- Restore a session by its ID.
 --- @param session_id string
 function Agentic.restore_session_by_id(session_id)

--- a/lua/agentic/init.lua
+++ b/lua/agentic/init.lua
@@ -251,9 +251,14 @@ end
 --- current session in place, without quitting Neovim. Use when the agent stops
 --- responding (e.g. after the machine resumes from suspend).
 function Agentic.reconnect()
-    SessionRegistry.get_session_for_tab_page(nil, function(session)
+    -- `current`, never `resolve_or_create`: recovery acts on a session that
+    -- already exists, and spawning a provider subprocess is the opposite of
+    -- what a user reaching for this wants.
+    local session = SessionRegistry.current()
+
+    if session then
         session:reconnect()
-    end)
+    end
 end
 
 --- Restore a session by its ID.

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -1074,8 +1074,6 @@ end
 --- Note: the agent process is shared per provider, so this also resets other
 --- tabs' sessions on the same provider; they re-establish on their next use.
 function SessionManager:reconnect()
-    local session_id = self.session_id
-
     -- Reset the local UI immediately. The respawn also drains the dead request
     -- callbacks, but don't make the user wait for that to see the spinner stop.
     self.is_generating = false
@@ -1086,6 +1084,11 @@ function SessionManager:reconnect()
     self.agent:reconnect()
 
     self.agent:when_ready(function()
+        -- Re-read the session at ready-time rather than capturing it earlier:
+        -- re-initialization is async, so the current session may have changed
+        -- meanwhile and a captured id could be stale. Reloading whatever is
+        -- current avoids clobbering a newer session.
+        local session_id = self.session_id
         local caps = self.agent.agent_capabilities
         if session_id and caps and caps.loadSession then
             self:load_acp_session(session_id)

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -1106,6 +1106,13 @@ function SessionManager:reconnect()
             return
         end
 
+        -- The agent answered, so the failure these flags record is over.
+        -- Leaving them set would keep `can_submit_prompt` refusing prompts and
+        -- `on_session_ready` taking its failure branch on a healthy session,
+        -- telling the user to start a new one right after recovery worked.
+        self._connection_error = false
+        self._session_creation_failed = false
+
         -- Re-read the session at ready-time rather than capturing it earlier:
         -- re-initialization is async, so the current session may have changed
         -- meanwhile and a captured id could be stale. Reloading whatever is

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -1084,6 +1084,13 @@ function SessionManager:reconnect()
     self.agent:reconnect()
 
     self.agent:when_ready(function()
+        -- The agent outlives this session and `destroy` cannot unregister a
+        -- ready listener, so liveness is re-checked here at run time rather
+        -- than captured when the callback was queued.
+        if self._destroyed then
+            return
+        end
+
         -- Re-read the session at ready-time rather than capturing it earlier:
         -- re-initialization is async, so the current session may have changed
         -- meanwhile and a captured id could be stale. Reloading whatever is

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -35,6 +35,7 @@ local Hooks = require("agentic.utils.hooks")
 --- @field history_to_send agentic.ui.ChatHistory.Message[]|nil
 --- @field _is_restoring_session boolean
 --- @field _connection_error boolean
+--- @field _reconnecting boolean Set while a respawn is in flight, so retries do not stack ready listeners
 --- @field _destroyed boolean Async callbacks must re-check this at RUN time, not capture it
 --- @field _session_creation_failed boolean
 --- @field _session_ready_callbacks fun(succeeded: boolean)[]
@@ -78,6 +79,7 @@ function SessionManager:new()
         is_generating = false,
         _is_restoring_session = false,
         _connection_error = false,
+        _reconnecting = false,
         _destroyed = false,
         _session_creation_failed = false,
         history_to_send = nil,
@@ -1074,6 +1076,17 @@ end
 --- Note: the agent process is shared per provider, so this also resets other
 --- tabs' sessions on the same provider; they re-establish on their next use.
 function SessionManager:reconnect()
+    -- Every call queues another ready listener that reloads the session, so a
+    -- user hammering the key while nothing visibly happens would stack reloads
+    -- on the respawned agent. The flag clears when the agent reports ready; if
+    -- the respawn itself never gets there, the child is unrecoverable in-place
+    -- and further retries would not help either.
+    if self._reconnecting then
+        return
+    end
+
+    self._reconnecting = true
+
     -- Reset the local UI immediately. The respawn also drains the dead request
     -- callbacks, but don't make the user wait for that to see the spinner stop.
     self.is_generating = false
@@ -1084,6 +1097,8 @@ function SessionManager:reconnect()
     self.agent:reconnect()
 
     self.agent:when_ready(function()
+        self._reconnecting = false
+
         -- The agent outlives this session and `destroy` cannot unregister a
         -- ready listener, so liveness is re-checked here at run time rather
         -- than captured when the callback was queued.

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -1065,6 +1065,37 @@ function SessionManager:destroy()
     end
 end
 
+--- Recover from an unresponsive agent without quitting Neovim: kill and
+--- respawn the agent process, then reload the current session so the
+--- conversation continues. This is the in-place equivalent of quitting Neovim
+--- and restoring the session, the only recovery available when the child is
+--- hung (e.g. after the machine resumes from suspend with a dead connection).
+---
+--- Note: the agent process is shared per provider, so this also resets other
+--- tabs' sessions on the same provider; they re-establish on their next use.
+function SessionManager:reconnect()
+    local session_id = self.session_id
+
+    -- Reset the local UI immediately. The respawn also drains the dead request
+    -- callbacks, but don't make the user wait for that to see the spinner stop.
+    self.is_generating = false
+    self.status_animation:stop()
+
+    Logger.notify("Reconnecting to agent…", vim.log.levels.INFO)
+
+    self.agent:reconnect()
+
+    self.agent:when_ready(function()
+        local caps = self.agent.agent_capabilities
+        if session_id and caps and caps.loadSession then
+            self:load_acp_session(session_id)
+        else
+            self:new_session()
+        end
+    end)
+end
+
+--- Load an existing ACP session by ID, subscribing to its updates
 --- @param session_id string
 --- @param title string|nil
 --- @param timestamp string|integer|nil Banner timestamp; defaults to now

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -3247,6 +3247,34 @@ describe("agentic.SessionManager", function()
             assert.is_true(calls.new)
         end)
 
+        it("clears the connection error once the agent is back", function()
+            local session, calls = make_session({
+                session_id = "sess-1",
+                caps = { loadSession = true },
+            })
+            session._connection_error = true
+            session._session_creation_failed = true
+
+            session:reconnect()
+
+            assert.is_false(session._connection_error)
+            assert.is_false(session._session_creation_failed)
+            assert.equal("sess-1", calls.loaded_with)
+        end)
+
+        it("keeps the connection error when the respawn never lands", function()
+            local session = make_session({
+                session_id = "sess-1",
+                caps = { loadSession = true },
+                defer = true,
+            })
+            session._connection_error = true
+
+            session:reconnect()
+
+            assert.is_true(session._connection_error)
+        end)
+
         it("ignores a second reconnect while one is in flight", function()
             local session, calls = make_session({
                 session_id = "sess-1",

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -3231,5 +3231,39 @@ describe("agentic.SessionManager", function()
             assert.is_nil(calls.loaded_with)
             assert.is_true(calls.new)
         end)
+
+        it(
+            "reloads the current session, not a stale one, when ready fires late",
+            function()
+                local calls = { loaded_with = nil }
+                local ready_cb
+                local session = {
+                    session_id = "sess-old",
+                    is_generating = true,
+                    status_animation = { stop = function() end },
+                    agent = {
+                        reconnect = function() end,
+                        -- Defer the ready callback so the session can change
+                        -- before re-initialization completes.
+                        when_ready = function(_self, cb)
+                            ready_cb = cb
+                        end,
+                        agent_capabilities = { loadSession = true },
+                    },
+                    reconnect = SessionManager.reconnect,
+                    load_acp_session = function(_self, id)
+                        calls.loaded_with = id
+                    end,
+                    new_session = function() end,
+                } --[[@as agentic.SessionManager]]
+
+                session:reconnect()
+                -- The session is swapped while the agent is still re-initializing.
+                session.session_id = "sess-new"
+                ready_cb()
+
+                assert.equal("sess-new", calls.loaded_with)
+            end
+        )
     end)
 end)

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -1,4 +1,4 @@
---- @diagnostic disable: invisible, missing-fields, assign-type-mismatch, cast-local-type, param-type-mismatch
+--- @diagnostic disable: invisible, missing-fields, assign-type-mismatch, cast-local-type, param-type-mismatch, return-type-mismatch
 local assert = require("tests.helpers.assert")
 local spy = require("tests.helpers.spy")
 
@@ -3161,5 +3161,75 @@ describe("agentic.SessionManager", function()
                 assert.equal("  new   question  ", prompt[2].text)
             end
         )
+    end)
+
+    describe("reconnect", function()
+        --- @type TestStub
+        local notify_stub
+
+        before_each(function()
+            notify_stub = spy.stub(Logger, "notify")
+        end)
+
+        after_each(function()
+            notify_stub:revert()
+        end)
+
+        --- @param overrides table
+        --- @return agentic.SessionManager session, table calls
+        local function make_session(overrides)
+            local calls =
+                { reconnected = false, loaded_with = nil, new = false }
+            local session = {
+                session_id = overrides.session_id,
+                is_generating = true,
+                status_animation = { stop = function() end },
+                agent = {
+                    reconnect = function()
+                        calls.reconnected = true
+                    end,
+                    -- Fire the ready callback synchronously.
+                    when_ready = function(_self, cb)
+                        cb()
+                    end,
+                    agent_capabilities = overrides.caps,
+                },
+                reconnect = SessionManager.reconnect,
+                load_acp_session = function(_self, id)
+                    calls.loaded_with = id
+                end,
+                new_session = function()
+                    calls.new = true
+                end,
+            } --[[@as agentic.SessionManager]]
+            return session, calls
+        end
+
+        it("respawns the agent and reloads the current session", function()
+            local session, calls = make_session({
+                session_id = "sess-1",
+                caps = { loadSession = true },
+            })
+
+            session:reconnect()
+
+            assert.is_true(calls.reconnected)
+            assert.is_false(session.is_generating)
+            assert.equal("sess-1", calls.loaded_with)
+            assert.is_false(calls.new)
+        end)
+
+        it("starts a fresh session when there is none to reload", function()
+            local session, calls = make_session({
+                session_id = nil,
+                caps = { loadSession = true },
+            })
+
+            session:reconnect()
+
+            assert.is_true(calls.reconnected)
+            assert.is_nil(calls.loaded_with)
+            assert.is_true(calls.new)
+        end)
     end)
 end)

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -3178,19 +3178,29 @@ describe("agentic.SessionManager", function()
         --- @param overrides table
         --- @return agentic.SessionManager session, table calls
         local function make_session(overrides)
-            local calls =
-                { reconnected = false, loaded_with = nil, new = false }
+            local calls = {
+                reconnected = false,
+                loaded_with = nil,
+                new = false,
+                ready_cb = nil,
+            }
             local session = {
                 session_id = overrides.session_id,
                 is_generating = true,
+                _destroyed = false,
                 status_animation = { stop = function() end },
                 agent = {
                     reconnect = function()
                         calls.reconnected = true
                     end,
-                    -- Fire the ready callback synchronously.
+                    -- Synchronous unless the case needs to act in the window
+                    -- between the respawn and the agent reaching ready.
                     when_ready = function(_self, cb)
-                        cb()
+                        if overrides.defer then
+                            calls.ready_cb = cb
+                        else
+                            cb()
+                        end
                     end,
                     agent_capabilities = overrides.caps,
                 },
@@ -3230,6 +3240,22 @@ describe("agentic.SessionManager", function()
             assert.is_true(calls.reconnected)
             assert.is_nil(calls.loaded_with)
             assert.is_true(calls.new)
+        end)
+
+        it("does not reload a session destroyed while reconnecting", function()
+            local session, calls = make_session({
+                session_id = "sess-1",
+                caps = { loadSession = true },
+                defer = true,
+            })
+
+            session:reconnect()
+            -- `destroy` runs while the respawned agent is still initializing.
+            session._destroyed = true
+            calls.ready_cb()
+
+            assert.is_nil(calls.loaded_with)
+            assert.is_false(calls.new)
         end)
 
         it(

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -3180,6 +3180,8 @@ describe("agentic.SessionManager", function()
         local function make_session(overrides)
             local calls = {
                 reconnected = false,
+                reconnect_count = 0,
+                ready_registrations = 0,
                 loaded_with = nil,
                 new = false,
                 ready_cb = nil,
@@ -3192,10 +3194,13 @@ describe("agentic.SessionManager", function()
                 agent = {
                     reconnect = function()
                         calls.reconnected = true
+                        calls.reconnect_count = calls.reconnect_count + 1
                     end,
                     -- Synchronous unless the case needs to act in the window
                     -- between the respawn and the agent reaching ready.
                     when_ready = function(_self, cb)
+                        calls.ready_registrations = calls.ready_registrations
+                            + 1
                         if overrides.defer then
                             calls.ready_cb = cb
                         else
@@ -3240,6 +3245,34 @@ describe("agentic.SessionManager", function()
             assert.is_true(calls.reconnected)
             assert.is_nil(calls.loaded_with)
             assert.is_true(calls.new)
+        end)
+
+        it("ignores a second reconnect while one is in flight", function()
+            local session, calls = make_session({
+                session_id = "sess-1",
+                caps = { loadSession = true },
+                defer = true,
+            })
+
+            session:reconnect()
+            session:reconnect()
+
+            assert.equal(1, calls.reconnect_count)
+            assert.equal(1, calls.ready_registrations)
+        end)
+
+        it("reconnects again once the agent has come back ready", function()
+            local session, calls = make_session({
+                session_id = "sess-1",
+                caps = { loadSession = true },
+                defer = true,
+            })
+
+            session:reconnect()
+            calls.ready_cb()
+            session:reconnect()
+
+            assert.equal(2, calls.reconnect_count)
         end)
 
         it("does not reload a session destroyed while reconnecting", function()


### PR DESCRIPTION
After the machine resumes from suspend (or the agent child otherwise hangs), a prompt gets no reply and the connection can't recover; the only fix was to quit Neovim and restore, since quitting is what actually kills the child. This adds in-place recovery, split out of #266 per your request.

- **Control-RPC inactivity watchdog**: a stalled control request (`initialize`/`session/load`/`session/list`/`set_mode`/`set_model`) is rejected with a timeout instead of hanging forever. `session/prompt` is deliberately excluded, since it can legitimately run silently for minutes during a tool call.
- **`Agentic.reconnect()`**: kills the hung child (which drains the stuck request and clears the spinner), respawns and re-initializes, then reloads the current session so the conversation continues, with no Neovim restart needed.

Follow-up to #266.