### PR TITLE
feat(acp): render rawInput as json - opencode asks permission without context

### DIFF
--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -470,10 +470,9 @@ function ACPClient:__build_tool_call_message(update)
         end
     end
 
-    -- Last resort: render rawInput as expanded JSON so tool calls with no
-    -- content and no diff still show their input (e.g. OpenCode's bash
-    -- command lives only in rawInput). Skip `read` -- its renderer treats
-    -- #body as a line count and would print a bogus number.
+    -- Surface rawInput for tool calls with no content and no diff (e.g.
+    -- OpenCode's bash command lives only in rawInput). Skip `read` -- its
+    -- renderer treats #body as a line count and would print a bogus number.
     if
         not message.body
         and not message.diff
@@ -481,7 +480,16 @@ function ACPClient:__build_tool_call_message(update)
         and raw_input
         and not vim.tbl_isempty(raw_input)
     then
-        message.body = vim.split(JsonFormat.format_value(raw_input), "\n")
+        if type(raw_input.command) == "string" then
+            -- OpenCode execute tools: the command is the meaningful title and
+            -- the optional description reads better than raw JSON.
+            message.argument = raw_input.command
+            if type(raw_input.description) == "string" then
+                message.body = self:safe_split(raw_input.description)
+            end
+        else
+            message.body = vim.split(JsonFormat.format_value(raw_input), "\n")
+        end
     end
 
     return message

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -480,11 +480,14 @@ function ACPClient:__build_tool_call_message(update)
         and raw_input
         and not vim.tbl_isempty(raw_input)
     then
-        if type(raw_input.command) == "string" then
+        if type(raw_input.command) == "string" and raw_input.command ~= "" then
             -- OpenCode execute tools: the command is the meaningful title and
             -- the optional description reads better than raw JSON.
             message.argument = raw_input.command
-            if type(raw_input.description) == "string" then
+            if
+                type(raw_input.description) == "string"
+                and raw_input.description ~= ""
+            then
                 message.body = self:safe_split(raw_input.description)
             end
         else

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -1,4 +1,5 @@
 local Logger = require("agentic.utils.logger")
+local JsonFormat = require("agentic.utils.json_format")
 local transport_module = require("agentic.acp.acp_transport")
 
 --- Known ACP protocol tool call kinds.
@@ -467,6 +468,20 @@ function ACPClient:__build_tool_call_message(update)
         if first_location and first_location.path then
             message.file_path = first_location.path
         end
+    end
+
+    -- Last resort: render rawInput as expanded JSON so tool calls with no
+    -- content and no diff still show their input (e.g. OpenCode's bash
+    -- command lives only in rawInput). Skip `read` -- its renderer treats
+    -- #body as a line count and would print a bogus number.
+    if
+        not message.body
+        and not message.diff
+        and update.kind ~= "read"
+        and raw_input
+        and not vim.tbl_isempty(raw_input)
+    then
+        message.body = vim.split(JsonFormat.format_value(raw_input), "\n")
     end
 
     return message

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -422,5 +422,90 @@ describe("ACPClient", function()
                 ---@diagnostic enable: invisible, assign-type-mismatch
             end)
         end)
+
+        it("injects rawInput JSON as body for execute with command", function()
+            local client = create_ready_client()
+
+            ---@diagnostic disable: invisible, assign-type-mismatch
+            local message = client:__build_tool_call_message({
+                toolCallId = "tc-x",
+                kind = "execute",
+                title = "bash",
+                rawInput = { command = "ls -la", description = "List files" },
+            })
+            ---@diagnostic enable: invisible, assign-type-mismatch
+
+            assert.is_true(type(message.body) == "table")
+            assert.is_true(#message.body > 1)
+            local joined = table.concat(message.body, "\n")
+            assert.is_true(joined:find('"command": "ls %-la"') ~= nil)
+        end)
+
+        it("does not inject body for empty rawInput", function()
+            local client = create_ready_client()
+
+            ---@diagnostic disable: invisible, assign-type-mismatch
+            local message = client:__build_tool_call_message({
+                toolCallId = "tc-x",
+                kind = "execute",
+                title = "bash",
+                rawInput = vim.empty_dict(),
+            })
+            ---@diagnostic enable: invisible, assign-type-mismatch
+
+            assert.equal(nil, message.body)
+        end)
+
+        it("keeps content-derived body over rawInput JSON", function()
+            local client = create_ready_client()
+
+            ---@diagnostic disable: invisible, assign-type-mismatch
+            local message = client:__build_tool_call_message({
+                toolCallId = "tc-x",
+                kind = "execute",
+                title = "ls",
+                rawInput = { command = "ls" },
+                content = {
+                    {
+                        type = "content",
+                        content = { type = "text", text = "List files" },
+                    },
+                },
+            })
+            ---@diagnostic enable: invisible, assign-type-mismatch
+
+            assert.same({ "List files" }, message.body)
+            local joined = table.concat(message.body, "\n")
+            assert.is_true(joined:find('"command"') == nil)
+        end)
+
+        it("does not inject body for read kind", function()
+            local client = create_ready_client()
+
+            ---@diagnostic disable: invisible, assign-type-mismatch
+            local message = client:__build_tool_call_message({
+                toolCallId = "tc-x",
+                kind = "read",
+                rawInput = { file_path = "/tmp/x" },
+            })
+            ---@diagnostic enable: invisible, assign-type-mismatch
+
+            assert.equal(nil, message.body)
+        end)
+
+        it("keeps edit diff and skips rawInput body injection", function()
+            local client = create_ready_client()
+
+            ---@diagnostic disable: invisible, assign-type-mismatch
+            local message = client:__build_tool_call_message({
+                toolCallId = "tc-x",
+                kind = "edit",
+                rawInput = { newString = "a", oldString = "b" },
+            })
+            ---@diagnostic enable: invisible, assign-type-mismatch
+
+            assert.is_true(message.diff ~= nil)
+            assert.equal(nil, message.body)
+        end)
     end)
 end)

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -458,6 +458,39 @@ describe("ACPClient", function()
             assert.equal(nil, message.body)
         end)
 
+        it("falls back to rawInput JSON for empty command", function()
+            local client = create_ready_client()
+
+            ---@diagnostic disable: invisible, assign-type-mismatch
+            local message = client:__build_tool_call_message({
+                toolCallId = "tc-x",
+                kind = "execute",
+                title = "bash",
+                rawInput = { command = "", other = "value here" },
+            })
+            ---@diagnostic enable: invisible, assign-type-mismatch
+
+            assert.equal("bash", message.argument)
+            assert.is_true(type(message.body) == "table")
+            assert.is_true(#message.body > 1)
+        end)
+
+        it("ignores empty description, sets only command title", function()
+            local client = create_ready_client()
+
+            ---@diagnostic disable: invisible, assign-type-mismatch
+            local message = client:__build_tool_call_message({
+                toolCallId = "tc-x",
+                kind = "execute",
+                title = "bash",
+                rawInput = { command = "ls -la", description = "" },
+            })
+            ---@diagnostic enable: invisible, assign-type-mismatch
+
+            assert.equal("ls -la", message.argument)
+            assert.equal(nil, message.body)
+        end)
+
         it("falls back to rawInput JSON when no command field", function()
             local client = create_ready_client()
 

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -423,7 +423,7 @@ describe("ACPClient", function()
             end)
         end)
 
-        it("injects rawInput JSON as body for execute with command", function()
+        it("uses rawInput command as title and description as body", function()
             local client = create_ready_client()
 
             ---@diagnostic disable: invisible, assign-type-mismatch
@@ -431,14 +431,49 @@ describe("ACPClient", function()
                 toolCallId = "tc-x",
                 kind = "execute",
                 title = "bash",
-                rawInput = { command = "ls -la", description = "List files" },
+                rawInput = {
+                    command = "rm demo.md",
+                    description = "Remove demo.md file",
+                },
+            })
+            ---@diagnostic enable: invisible, assign-type-mismatch
+
+            assert.equal("rm demo.md", message.argument)
+            assert.same({ "Remove demo.md file" }, message.body)
+        end)
+
+        it("uses rawInput command as title with no description body", function()
+            local client = create_ready_client()
+
+            ---@diagnostic disable: invisible, assign-type-mismatch
+            local message = client:__build_tool_call_message({
+                toolCallId = "tc-x",
+                kind = "execute",
+                title = "bash",
+                rawInput = { command = "ls -la" },
+            })
+            ---@diagnostic enable: invisible, assign-type-mismatch
+
+            assert.equal("ls -la", message.argument)
+            assert.equal(nil, message.body)
+        end)
+
+        it("falls back to rawInput JSON when no command field", function()
+            local client = create_ready_client()
+
+            ---@diagnostic disable: invisible, assign-type-mismatch
+            local message = client:__build_tool_call_message({
+                toolCallId = "tc-x",
+                kind = "execute",
+                title = "bash",
+                rawInput = { foo = "bar baz" },
             })
             ---@diagnostic enable: invisible, assign-type-mismatch
 
             assert.is_true(type(message.body) == "table")
             assert.is_true(#message.body > 1)
             local joined = table.concat(message.body, "\n")
-            assert.is_true(joined:find('"command": "ls %-la"') ~= nil)
+            assert.is_true(joined:find('"foo": "bar baz"') ~= nil)
         end)
 
         it("does not inject body for empty rawInput", function()

--- a/lua/agentic/utils/json_format.lua
+++ b/lua/agentic/utils/json_format.lua
@@ -41,6 +41,10 @@ end
 --- @param value table
 --- @return boolean
 local function is_array(value)
+    if getmetatable(value) == vim._empty_dict_mt then
+        return false
+    end
+
     local count = 0
     for _ in pairs(value) do
         count = count + 1
@@ -148,6 +152,14 @@ local function pretty(value)
     local parts = {}
     encode(value, 0, parts)
     return table.concat(parts)
+end
+
+--- Pretty-print any Lua value to multi-line JSON, with no length gate.
+--- Unlike `format_line`, short values still expand to multiple lines.
+--- @param value any
+--- @return string
+function M.format_value(value)
+    return pretty(value)
 end
 
 --- Try to format a single string as pretty-printed JSON. Returns the

--- a/lua/agentic/utils/json_format.test.lua
+++ b/lua/agentic/utils/json_format.test.lua
@@ -127,4 +127,59 @@ describe("JsonFormat", function()
             assert.same(once, twice)
         end)
     end)
+
+    describe("format_value", function()
+        it("expands a short object below the length threshold", function()
+            local result = JsonFormat.format_value({ command = "ls -la" })
+
+            assert.is_true(result:find("\n") ~= nil)
+            assert.equal("{", result:sub(1, 1))
+            assert.is_true(result:find('"command": "ls %-la"') ~= nil)
+        end)
+
+        it("emits sorted keys on their own indented lines", function()
+            local result = JsonFormat.format_value({
+                command = "ls",
+                description = "List files",
+            })
+
+            local lines = vim.split(result, "\n")
+            assert.equal('  "command": "ls",', lines[2])
+            assert.equal('  "description": "List files"', lines[3])
+        end)
+
+        it("returns {} for an empty dict without crashing", function()
+            assert.equal("{}", JsonFormat.format_value(vim.empty_dict()))
+        end)
+
+        it("expands nested objects", function()
+            local result = JsonFormat.format_value({
+                outer = { inner = "value" },
+            })
+
+            assert.is_true(result:find('"outer": {') ~= nil)
+            assert.is_true(result:find('"inner": "value"') ~= nil)
+        end)
+
+        it("renders array-shaped tables", function()
+            local result = JsonFormat.format_value({ "a", "b" })
+
+            assert.equal("[", result:sub(1, 1))
+            assert.is_true(result:find('"a"') ~= nil)
+            assert.is_true(result:find('"b"') ~= nil)
+        end)
+
+        it("encodes vim.NIL as null", function()
+            local result = JsonFormat.format_value({ value = vim.NIL })
+
+            assert.is_true(result:find('"value": null') ~= nil)
+        end)
+
+        it("encodes boolean and number values", function()
+            local result = JsonFormat.format_value({ flag = true, count = 3 })
+
+            assert.is_true(result:find('"count": 3') ~= nil)
+            assert.is_true(result:find('"flag": true') ~= nil)
+        end)
+    end)
 end)


### PR DESCRIPTION
- show command for content-less tool calls
- fixes OpenCode bash approval showing only "bash"
- inject rawInput JSON when no body and no diff
- providers supplying content (Claude, Codex, etc...) untouched
