### PR TITLE
feat(acp): expose SessionState public API for custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,9 +492,12 @@ Every getter is nil-able by contract — always nil-check before use.
 | `get_mode_name()`          | `string\|nil` | Current mode display name           |
 | `get_thought_level_id()`   | `string\|nil` | Current thought level id            |
 | `get_thought_level_name()` | `string\|nil` | Current thought level display name  |
-| `get_context_used()`       | `number\|nil` | Tokens currently in context         |
-| `get_context_size()`       | `number\|nil` | Total context window size in tokens |
-| `get_cost_amount()`        | `number\|nil` | Cumulative session cost amount      |
+| `get_context_used()`       | `string\|nil` | Formatted context used              |
+| `get_context_used_raw()`   | `number\|nil` | Tokens currently in context         |
+| `get_context_size()`       | `string\|nil` | Formatted context window size       |
+| `get_context_size_raw()`   | `number\|nil` | Total context window size in tokens |
+| `get_cost_amount()`        | `string\|nil` | Formatted cumulative session cost   |
+| `get_cost_amount_raw()`    | `number\|nil` | Cumulative session cost amount      |
 | `get_cost_currency()`      | `string\|nil` | Cost currency code (e.g. `"USD"`)   |
 | `get_provider_name()`      | `string\|nil` | Provider display name               |
 
@@ -517,7 +520,8 @@ again after a session restore until the next one.
           end
           local cost = session_state:get_cost_amount()
           if cost then
-            header = header .. " | $" .. string.format("%.2f", cost)
+            local currency = session_state:get_cost_currency()
+            header = header .. " | " .. (currency and currency .. " " or "") .. cost
           end
         end
         return header

--- a/README.md
+++ b/README.md
@@ -470,6 +470,63 @@ header parts:
 }
 ```
 
+#### Live Session State
+
+Header and `buffer_name` functions receive an optional second argument,
+`session_state`, exposing live session data (current model, mode, thought level,
+context-window usage, cost, and provider name).
+
+The `session_state` argument is only provided for the **chat** and **input**
+panels. For every other panel it is `nil`. It is also `nil` on the very first
+frame and after a session restore until the next usage update arrives.
+
+Every getter is nil-able by contract — always nil-check before use.
+
+`SessionState` getters:
+
+| Getter                     | Returns       | Notes                               |
+| -------------------------- | ------------- | ----------------------------------- |
+| `get_model_id()`           | `string\|nil` | Current model id                    |
+| `get_model_name()`         | `string\|nil` | Current model display name          |
+| `get_mode_id()`            | `string\|nil` | Current mode id                     |
+| `get_mode_name()`          | `string\|nil` | Current mode display name           |
+| `get_thought_level_id()`   | `string\|nil` | Current thought level id            |
+| `get_thought_level_name()` | `string\|nil` | Current thought level display name  |
+| `get_context_used()`       | `number\|nil` | Tokens currently in context         |
+| `get_context_size()`       | `number\|nil` | Total context window size in tokens |
+| `get_cost_amount()`        | `number\|nil` | Cumulative session cost amount      |
+| `get_cost_currency()`      | `string\|nil` | Cost currency code (e.g. `"USD"`)   |
+| `get_provider_name()`      | `string\|nil` | Provider display name               |
+
+Usage getters (`get_context_used`, `get_context_size`, `get_cost_amount`,
+`get_cost_currency`) stay `nil` until the agent emits the first usage update, and
+again after a session restore until the next one.
+
+```lua
+{
+  "carlos-algms/agentic.nvim",
+  --- @type agentic.PartialUserConfig
+  opts = {
+    headers = {
+      chat = function(parts, session_state)
+        local header = parts.title
+        if session_state then
+          local used = session_state:get_context_used()
+          if used then
+            header = header .. " | " .. used .. " tok"
+          end
+          local cost = session_state:get_cost_amount()
+          if cost then
+            header = header .. " | $" .. string.format("%.2f", cost)
+          end
+        end
+        return header
+      end,
+    },
+  },
+}
+```
+
 ### Customizing Buffer Names
 
 By default, buffer names mirror the window header titles. You can override them
@@ -508,6 +565,11 @@ You can also use a function that receives the header parts and returns a string:
   },
 }
 ```
+
+`buffer_name` functions also receive the optional `session_state` second
+argument (chat and input panels only, `nil` elsewhere). See
+[Live Session State](#live-session-state) for the getter list and nil-check
+rules.
 
 When a panel has no `buffer_name` set, it falls back to the header title.
 

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -308,6 +308,9 @@ windows ~
   `stack_width_ratio`  Ratio for stacked panels. Default: `0.4`.
   `buffer_name`        Name of the window buffer. String title
                        or function returning string title.
+                       Functions receive the header parts and an
+                       optional live session state second argument
+                       (|agentic-session-state|).
                        Default: window header title.
                        See |agentic-config-headers|.
 
@@ -351,6 +354,9 @@ headers ~
   table with `title` and `suffix` fields, or a function that receives
   header parts and returns a custom string.
 
+  Header functions receive an optional second argument, the live
+  session state. See |agentic-session-state|.
+
 >lua
   --- @type agentic.PartialUserConfig
   opts = {
@@ -361,6 +367,62 @@ headers ~
       },
       input = function(parts)
         return parts.title .. " | custom"
+      end,
+    },
+  }
+<
+
+                                          *agentic-session-state*
+Session state ~
+
+  Header functions (|agentic-config-headers|) and `buffer_name`
+  functions (|agentic-configuration|) receive an optional second
+  argument exposing live session data: current model, mode, thought
+  level, context-window usage, cost, and provider name.
+
+  The session-state argument is provided for the `chat` and `input`
+  panels only. For every other panel it is `nil`. It is also `nil`
+  on the very first frame and after a session restore until the next
+  usage update arrives.
+
+  Every getter is nil-able by contract; always nil-check before use.
+
+  Getters: ~
+
+  `get_model_id()`            (string|nil)  Current model id.
+  `get_model_name()`          (string|nil)  Current model display name.
+  `get_mode_id()`             (string|nil)  Current mode id.
+  `get_mode_name()`           (string|nil)  Current mode display name.
+  `get_thought_level_id()`    (string|nil)  Current thought level id.
+  `get_thought_level_name()`  (string|nil)  Thought level display name.
+  `get_context_used()`        (number|nil)  Tokens currently in context.
+  `get_context_size()`        (number|nil)  Total context window size.
+  `get_cost_amount()`         (number|nil)  Cumulative session cost amount.
+  `get_cost_currency()`       (string|nil)  Cost currency code (e.g. "USD").
+  `get_provider_name()`       (string|nil)  Provider display name.
+
+  Usage getters (`get_context_used`, `get_context_size`,
+  `get_cost_amount`, `get_cost_currency`) stay `nil` until the agent
+  emits the first usage update, and again after a session restore
+  until the next one.
+
+>lua
+  --- @type agentic.PartialUserConfig
+  opts = {
+    headers = {
+      chat = function(parts, session_state)
+        local header = parts.title
+        if session_state then
+          local used = session_state:get_context_used()
+          if used then
+            header = header .. " | " .. used .. " tok"
+          end
+          local cost = session_state:get_cost_amount()
+          if cost then
+            header = header .. " | $" .. string.format("%.2f", cost)
+          end
+        end
+        return header
       end,
     },
   }

--- a/doc/tags
+++ b/doc/tags
@@ -50,6 +50,7 @@ agentic-permission-icons	agentic.txt	/*agentic-permission-icons*
 agentic-render-markdown	agentic.txt	/*agentic-render-markdown*
 agentic-requirements	agentic.txt	/*agentic-requirements*
 agentic-session-restore	agentic.txt	/*agentic-session-restore*
+agentic-session-state	agentic.txt	/*agentic-session-state*
 agentic-slash-commands	agentic.txt	/*agentic-slash-commands*
 agentic-spinner-chars	agentic.txt	/*agentic-spinner-chars*
 agentic-status-icons	agentic.txt	/*agentic-status-icons*

--- a/lua/agentic/acp/agent_config_options.lua
+++ b/lua/agentic/acp/agent_config_options.lua
@@ -130,12 +130,14 @@ function AgentConfigOptions:set_options(configOptions)
         local raw = type(option.category) == "string" and option.category or ""
         local cat = CATEGORY_ALIASES[raw] or raw
 
+        local stored_option = vim.deepcopy(option)
+
         if cat == "mode" then
-            self.mode = option
+            self.mode = stored_option
         elseif cat == "model" then
-            self.model = option
+            self.model = stored_option
         elseif cat == "thought_level" then
-            self.thought_level = option
+            self.thought_level = stored_option
         elseif cat:sub(1, 1) ~= "_" then
             Logger.debug("Unknown config option", option)
         end
@@ -536,6 +538,9 @@ function AgentConfigOptions:handle_mode_change(mode_id, is_legacy)
         function(result)
             -- keep legacy state in sync so legacy selectors reflect the change
             self.legacy_agent_modes.current_mode_id = mode_id
+            if not is_legacy and self.mode then
+                self.mode.currentValue = mode_id
+            end
 
             if result and type(result.configOptions) == "table" then
                 Logger.debug("received result after setting mode")
@@ -583,12 +588,15 @@ function AgentConfigOptions:handle_model_change(model_id, is_legacy, on_done)
         function(result)
             -- keep legacy state in sync so legacy selectors reflect the change
             self.legacy_agent_models.current_model_id = model_id
+            if not is_legacy and self.model then
+                self.model.currentValue = model_id
+            end
 
             if result and type(result.configOptions) == "table" then
                 Logger.debug("received result after setting model")
                 self:set_options(result.configOptions)
-                self.callbacks.on_config_options_applied()
             end
+            self.callbacks.on_config_options_applied()
 
             Logger.notify(
                 "Model changed to: " .. model_id,
@@ -636,11 +644,15 @@ function AgentConfigOptions:handle_thought_level_change(value)
         "thought effort level",
         value,
         function(result)
+            if self.thought_level then
+                self.thought_level.currentValue = value
+            end
+
             if result and type(result.configOptions) == "table" then
                 Logger.debug("received result after setting thought_level")
                 self:set_options(result.configOptions)
-                self.callbacks.on_config_options_applied()
             end
+            self.callbacks.on_config_options_applied()
 
             Logger.notify(
                 "Thought effort level changed to: " .. value,

--- a/lua/agentic/acp/agent_config_options.lua
+++ b/lua/agentic/acp/agent_config_options.lua
@@ -174,9 +174,7 @@ function AgentConfigOptions:set_initial_mode(target_mode)
     end
 
     if not found then
-        local current = self.mode and self.mode.currentValue
-            or self.legacy_agent_modes.current_mode_id
-            or "unknown"
+        local current = self:get_mode_id() or "unknown"
         Logger.notify(
             string.format(
                 "Configured default_mode ‘%s’ not available."
@@ -223,9 +221,7 @@ function AgentConfigOptions:set_initial_model(target_model, on_done)
     end
 
     if not found then
-        local current = self.model and self.model.currentValue
-            or self.legacy_agent_models.current_model_id
-            or "unknown"
+        local current = self:get_model_id() or "unknown"
         Logger.notify(
             string.format(
                 "Configured initial_model '%s' not available."
@@ -267,6 +263,20 @@ local function getter(target, value)
     end
 
     return nil
+end
+
+--- Current mode id, config option first, legacy state as fallback.
+--- @return string|nil mode_id
+function AgentConfigOptions:get_mode_id()
+    return self.mode and self.mode.currentValue
+        or self.legacy_agent_modes.current_mode_id
+end
+
+--- Current model id, config option first, legacy state as fallback.
+--- @return string|nil model_id
+function AgentConfigOptions:get_model_id()
+    return self.model and self.model.currentValue
+        or self.legacy_agent_models.current_model_id
 end
 
 --- @param mode_value string

--- a/lua/agentic/acp/agent_config_options.test.lua
+++ b/lua/agentic/acp/agent_config_options.test.lua
@@ -735,6 +735,72 @@ describe("agentic.acp.AgentConfigOptions", function()
         end)
     end
 
+    --- get_model_id / get_mode_id resolve the current id across config options
+    --- and legacy state in ONE place: config currentValue wins, legacy id is
+    --- the fallback, nil when neither source is populated.
+    for _, case in ipairs({
+        {
+            method = "get_model_id",
+            option = model_option,
+            config_id = "claude-sonnet",
+            set_legacy = function(target)
+                target.legacy_agent_models:set_models({
+                    availableModels = {
+                        {
+                            modelId = "legacy-opus",
+                            name = "Legacy",
+                            description = "",
+                        },
+                    },
+                    currentModelId = "legacy-opus",
+                })
+            end,
+            legacy_id = "legacy-opus",
+        },
+        {
+            method = "get_mode_id",
+            option = mode_option,
+            config_id = "normal",
+            set_legacy = function(target)
+                target.legacy_agent_modes:set_modes({
+                    availableModes = {
+                        {
+                            id = "legacy-plan",
+                            name = "Legacy",
+                            description = "",
+                        },
+                    },
+                    currentModeId = "legacy-plan",
+                })
+            end,
+            legacy_id = "legacy-plan",
+        },
+    }) do
+        describe(case.method, function()
+            it("returns config currentValue when config option set", function()
+                config_options:set_options({ case.option })
+
+                assert.equal(
+                    case.config_id,
+                    config_options[case.method](config_options)
+                )
+            end)
+
+            it("returns legacy current id when only legacy set", function()
+                case.set_legacy(config_options)
+
+                assert.equal(
+                    case.legacy_id,
+                    config_options[case.method](config_options)
+                )
+            end)
+
+            it("returns nil when neither source is populated", function()
+                assert.is_nil(config_options[case.method](config_options))
+            end)
+        end)
+    end
+
     describe("set_legacy_models", function()
         it("stores legacy models info", function()
             config_options:set_legacy_models({

--- a/lua/agentic/acp/agent_config_options.test.lua
+++ b/lua/agentic/acp/agent_config_options.test.lua
@@ -547,6 +547,76 @@ describe("agentic.acp.AgentConfigOptions", function()
         )
     end)
 
+    describe("successful changes without returned configOptions", function()
+        --- @type TestStub
+        local notify_stub
+
+        before_each(function()
+            notify_stub = spy.stub(require("agentic.utils.logger"), "notify")
+        end)
+
+        after_each(function()
+            notify_stub:revert()
+        end)
+
+        it("updates modern mode currentValue", function()
+            --- @type any
+            local agent = {
+                set_config_option = function(_self, _sid, _cid, _val, cb)
+                    cb({}, nil)
+                end,
+            }
+            local config = make_with_agent(agent, { id = "s1" })
+            config:set_options({ mode_option })
+
+            config:handle_mode_change("plan", false)
+
+            assert.equal("plan", config:get_mode_id())
+        end)
+
+        it("updates modern model currentValue and refreshes headers", function()
+            local applied = spy.new(function() end)
+            --- @type any
+            local agent = {
+                set_config_option = function(_self, _sid, _cid, _val, cb)
+                    cb({}, nil)
+                end,
+            }
+            local config =
+                make_with_agent(agent, { id = "s1" }, applied --[[@as fun()]])
+            config:set_options({ model_option })
+
+            config:handle_model_change("claude-opus", false)
+
+            assert.equal("claude-opus", config:get_model_id())
+            assert.equal(1, applied.call_count)
+        end)
+
+        it(
+            "updates thought_level currentValue and refreshes headers",
+            function()
+                local applied = spy.new(function() end)
+                --- @type any
+                local agent = {
+                    set_config_option = function(_self, _sid, _cid, _val, cb)
+                        cb({}, nil)
+                    end,
+                }
+                local config = make_with_agent(
+                    agent,
+                    { id = "s1" },
+                    applied --[[@as fun()]]
+                )
+                config:set_options({ multi_thought })
+
+                config:handle_thought_level_change("max")
+
+                assert.equal("max", config.thought_level.currentValue)
+                assert.equal(1, applied.call_count)
+            end
+        )
+    end)
+
     --- _show_mode_selector and _show_model_selector share legacy-fallback
     --- behavior. The selectors take no handler — they route the pick to
     --- `self:handle_*_change` internally, so a fake agent observes the

--- a/lua/agentic/acp/session_state.lua
+++ b/lua/agentic/acp/session_state.lua
@@ -13,6 +13,22 @@
 local SessionState = {}
 SessionState.__index = SessionState
 
+--- ceil to 1 decimal: 27649 -> "27.7K", 1000000 -> "1M"
+local function to_human(n)
+    n = n or 0
+    if n >= 1000000 then
+        return string.format("%gM", math.ceil(n / 100000) / 10)
+    elseif n >= 1000 then
+        return string.format("%gK", math.ceil(n / 100) / 10)
+    end
+    return tostring(n)
+end
+
+--- ceil to 2 decimals: 0.004 -> 0.01
+local function to_formatted_cost(n)
+    return string.format("%.2f", math.ceil((n or 0) * 100) / 100)
+end
+
 --- @param config_options agentic.acp.AgentConfigOptions
 --- @param provider_name string|nil
 --- @return agentic.acp.SessionState
@@ -99,18 +115,42 @@ function SessionState:get_thought_level_name()
 end
 
 --- @return number|nil context_used Tokens currently in context
-function SessionState:get_context_used()
+function SessionState:get_context_used_raw()
     return self._usage and self._usage.used
 end
 
+--- Human-readable `get_context_used_raw`: 27649 -> "27.7K"
+--- @return string|nil context_used
+function SessionState:get_context_used()
+    local used = self:get_context_used_raw()
+
+    return used and to_human(used)
+end
+
 --- @return number|nil context_size Total context window size in tokens
-function SessionState:get_context_size()
+function SessionState:get_context_size_raw()
     return self._usage and self._usage.size
 end
 
+--- Human-readable `get_context_size_raw`: 1000000 -> "1M"
+--- @return string|nil context_size
+function SessionState:get_context_size()
+    local size = self:get_context_size_raw()
+
+    return size and to_human(size)
+end
+
 --- @return number|nil cost_amount Cumulative session cost amount
-function SessionState:get_cost_amount()
+function SessionState:get_cost_amount_raw()
     return self._usage and self._usage.cost and self._usage.cost.amount
+end
+
+--- Human-readable `get_cost_amount_raw`: 0.004 -> "0.01"
+--- @return string|nil cost_amount
+function SessionState:get_cost_amount()
+    local amount = self:get_cost_amount_raw()
+
+    return amount and to_formatted_cost(amount)
 end
 
 --- @return string|nil cost_currency Cumulative session cost currency
@@ -125,16 +165,16 @@ end
 
 --- @param update agentic.acp.UsageUpdate
 function SessionState:set_usage(update)
-    local cost = update.cost
+    local cost_update = update.cost
 
-    if cost == vim.NIL then
-        cost = nil
+    if cost_update == vim.NIL then
+        cost_update = nil
     end
 
     self._usage = {
         used = update.used,
         size = update.size,
-        cost = cost,
+        cost = cost_update,
     }
 end
 

--- a/lua/agentic/acp/session_state.lua
+++ b/lua/agentic/acp/session_state.lua
@@ -19,7 +19,11 @@ local function to_human(n)
     if n >= 1000000 then
         return string.format("%gM", math.ceil(n / 100000) / 10)
     elseif n >= 1000 then
-        return string.format("%gK", math.ceil(n / 100) / 10)
+        local k = math.ceil(n / 100) / 10
+        if k >= 1000 then
+            return string.format("%gM", math.ceil(n / 100000) / 10)
+        end
+        return string.format("%gK", k)
     end
     return tostring(n)
 end
@@ -165,16 +169,10 @@ end
 
 --- @param update agentic.acp.UsageUpdate
 function SessionState:set_usage(update)
-    local cost_update = update.cost
-
-    if cost_update == vim.NIL then
-        cost_update = nil
-    end
-
     self._usage = {
         used = update.used,
         size = update.size,
-        cost = cost_update,
+        cost = update.cost,
     }
 end
 

--- a/lua/agentic/acp/session_state.lua
+++ b/lua/agentic/acp/session_state.lua
@@ -1,0 +1,145 @@
+--- Live, read-through facade over the per-tab session state.
+---
+--- Delegates model/mode id reads to `AgentConfigOptions` (single source of the
+--- config→legacy resolution) and resolves names locally. Owns ONLY the token
+--- usage fed from the ACP `usage_update` session update. Every getter is
+--- nil-able by contract; consumers MUST nil-check (usage stays nil until the
+--- first `usage_update`, and after a session restore).
+---
+--- @class agentic.acp.SessionState
+--- @field _config_options agentic.acp.AgentConfigOptions
+--- @field _provider_name? string
+--- @field _usage? { used?: number, size?: number, cost?: { amount: number, currency: string } }
+local SessionState = {}
+SessionState.__index = SessionState
+
+--- @param config_options agentic.acp.AgentConfigOptions
+--- @param provider_name string|nil
+--- @return agentic.acp.SessionState
+function SessionState:new(config_options, provider_name)
+    self = setmetatable({
+        _config_options = config_options,
+        _provider_name = provider_name,
+        _usage = nil,
+    }, self)
+
+    return self
+end
+
+--- @return string|nil model_id
+function SessionState:get_model_id()
+    return self._config_options:get_model_id()
+end
+
+--- @return string|nil model_name
+function SessionState:get_model_name()
+    local id = self:get_model_id()
+
+    if not id then
+        return nil
+    end
+
+    local co = self._config_options
+
+    if co.model then
+        for _, option in ipairs(co.model.options or {}) do
+            if option.value == id then
+                return option.name
+            end
+        end
+
+        return nil
+    end
+
+    local legacy = co.legacy_agent_models:get_model(id)
+
+    return legacy and legacy.name
+end
+
+--- @return string|nil mode_id
+function SessionState:get_mode_id()
+    return self._config_options:get_mode_id()
+end
+
+--- @return string|nil mode_name
+function SessionState:get_mode_name()
+    local id = self:get_mode_id()
+
+    if not id then
+        return nil
+    end
+
+    return self._config_options:get_mode_name(id)
+end
+
+--- @return string|nil thought_level_id
+function SessionState:get_thought_level_id()
+    local thought_level = self._config_options.thought_level
+
+    return thought_level and thought_level.currentValue
+end
+
+--- @return string|nil thought_level_name
+function SessionState:get_thought_level_name()
+    local thought_level = self._config_options.thought_level
+
+    if not thought_level then
+        return nil
+    end
+
+    local id = self:get_thought_level_id()
+
+    for _, option in ipairs(thought_level.options or {}) do
+        if option.value == id then
+            return option.name
+        end
+    end
+
+    return nil
+end
+
+--- @return number|nil context_used Tokens currently in context
+function SessionState:get_context_used()
+    return self._usage and self._usage.used
+end
+
+--- @return number|nil context_size Total context window size in tokens
+function SessionState:get_context_size()
+    return self._usage and self._usage.size
+end
+
+--- @return number|nil cost_amount Cumulative session cost amount
+function SessionState:get_cost_amount()
+    return self._usage and self._usage.cost and self._usage.cost.amount
+end
+
+--- @return string|nil cost_currency Cumulative session cost currency
+function SessionState:get_cost_currency()
+    return self._usage and self._usage.cost and self._usage.cost.currency
+end
+
+--- @return string|nil provider_name
+function SessionState:get_provider_name()
+    return self._provider_name
+end
+
+--- @param update agentic.acp.UsageUpdate
+function SessionState:set_usage(update)
+    local cost = update.cost
+
+    if cost == vim.NIL then
+        cost = nil
+    end
+
+    self._usage = {
+        used = update.used,
+        size = update.size,
+        cost = cost,
+    }
+end
+
+function SessionState:clear()
+    self._usage = nil
+end
+
+return SessionState

--- a/lua/agentic/acp/session_state.lua
+++ b/lua/agentic/acp/session_state.lua
@@ -14,6 +14,7 @@ local SessionState = {}
 SessionState.__index = SessionState
 
 --- ceil to 1 decimal: 27649 -> "27.7K", 1000000 -> "1M"
+--- @return string
 local function to_human(n)
     n = n or 0
     if n >= 1000000 then
@@ -29,6 +30,7 @@ local function to_human(n)
 end
 
 --- ceil to 2 decimals: 0.004 -> 0.01
+--- @return string
 local function to_formatted_cost(n)
     return string.format("%.2f", math.ceil((n or 0) * 100) / 100)
 end

--- a/lua/agentic/acp/session_state.test.lua
+++ b/lua/agentic/acp/session_state.test.lua
@@ -133,15 +133,6 @@ describe("agentic.acp.SessionState", function()
             assert.equal(state:get_cost_currency(), "USD")
         end)
 
-        it("normalizes cost arriving as vim.NIL to nil", function()
-            local state = SessionState:new(config_provider_fake(), "Claude")
-
-            state:set_usage({ used = 1, size = 2, cost = vim.NIL })
-
-            assert.is_nil(state:get_cost_amount())
-            assert.is_nil(state:get_cost_currency())
-        end)
-
         it("stores zero used/size values", function()
             local state = SessionState:new(config_provider_fake(), "Claude")
 
@@ -205,6 +196,13 @@ describe("agentic.acp.SessionState", function()
 
             assert.equal(state:get_context_used(), "1M")
             assert.equal(state:get_context_size(), "1.6M")
+        end)
+
+        it("crosses to M when K rounding hits 1000, not 1000K", function()
+            local state = state_with({ used = 999999, size = 999500 })
+
+            assert.equal(state:get_context_used(), "1M")
+            assert.equal(state:get_context_size(), "999.5K")
         end)
 
         it("formats cost as a 2-decimal string, ceil to cents", function()

--- a/lua/agentic/acp/session_state.test.lua
+++ b/lua/agentic/acp/session_state.test.lua
@@ -114,9 +114,9 @@ describe("agentic.acp.SessionState", function()
 
             state:set_usage({ used = 1000, size = 200000 })
 
-            assert.equal(state:get_context_used(), 1000)
-            assert.equal(state:get_context_size(), 200000)
-            assert.is_nil(state:get_cost_amount())
+            assert.equal(state:get_context_used_raw(), 1000)
+            assert.equal(state:get_context_size_raw(), 200000)
+            assert.is_nil(state:get_cost_amount_raw())
             assert.is_nil(state:get_cost_currency())
         end)
 
@@ -129,7 +129,7 @@ describe("agentic.acp.SessionState", function()
                 cost = { amount = 0.5, currency = "USD" },
             })
 
-            assert.equal(state:get_cost_amount(), 0.5)
+            assert.equal(state:get_cost_amount_raw(), 0.5)
             assert.equal(state:get_cost_currency(), "USD")
         end)
 
@@ -147,8 +147,8 @@ describe("agentic.acp.SessionState", function()
 
             state:set_usage({ used = 0, size = 0 })
 
-            assert.equal(state:get_context_used(), 0)
-            assert.equal(state:get_context_size(), 0)
+            assert.equal(state:get_context_used_raw(), 0)
+            assert.equal(state:get_context_size_raw(), 0)
         end)
 
         it("overwrites prior usage on a later set_usage", function()
@@ -161,10 +161,60 @@ describe("agentic.acp.SessionState", function()
             })
             state:set_usage({ used = 5, size = 6 })
 
-            assert.equal(state:get_context_used(), 5)
-            assert.equal(state:get_context_size(), 6)
-            assert.is_nil(state:get_cost_amount())
+            assert.equal(state:get_context_used_raw(), 5)
+            assert.equal(state:get_context_size_raw(), 6)
+            assert.is_nil(state:get_cost_amount_raw())
             assert.is_nil(state:get_cost_currency())
+        end)
+    end)
+
+    describe("human-readable usage getters", function()
+        --- @param usage table
+        --- @return agentic.acp.SessionState
+        local function state_with(usage)
+            local state = SessionState:new(config_provider_fake(), "Claude")
+            state:set_usage(usage)
+
+            return state
+        end
+
+        it("returns nil on a fresh instance", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            assert.is_nil(state:get_context_used())
+            assert.is_nil(state:get_context_size())
+            assert.is_nil(state:get_cost_amount())
+        end)
+
+        it("formats sub-thousand counts as plain numbers", function()
+            local state = state_with({ used = 0, size = 999 })
+
+            assert.equal(state:get_context_used(), "0")
+            assert.equal(state:get_context_size(), "999")
+        end)
+
+        it("formats thousands with a K suffix, ceil to 1 decimal", function()
+            local state = state_with({ used = 1000, size = 27649 })
+
+            assert.equal(state:get_context_used(), "1K")
+            assert.equal(state:get_context_size(), "27.7K")
+        end)
+
+        it("formats millions with an M suffix, ceil to 1 decimal", function()
+            local state = state_with({ used = 1000000, size = 1550000 })
+
+            assert.equal(state:get_context_used(), "1M")
+            assert.equal(state:get_context_size(), "1.6M")
+        end)
+
+        it("formats cost as a 2-decimal string, ceil to cents", function()
+            local state = state_with({
+                used = 1,
+                size = 2,
+                cost = { amount = 0.004, currency = "USD" },
+            })
+
+            assert.equal(state:get_cost_amount(), "0.01")
         end)
     end)
 

--- a/lua/agentic/acp/session_state.test.lua
+++ b/lua/agentic/acp/session_state.test.lua
@@ -1,0 +1,241 @@
+--- @diagnostic disable: missing-fields, param-type-mismatch
+
+local assert = require("tests.helpers.assert")
+
+local SessionState = require("agentic.acp.session_state")
+
+describe("agentic.acp.SessionState", function()
+    --- Fake config_options whose id getters mimic the Task 1 accessors.
+    --- @return table fake
+    local function config_provider_fake()
+        return {
+            get_model_id = function()
+                return "sonnet"
+            end,
+            get_mode_id = function()
+                return "ask"
+            end,
+            get_mode_name = function(_, _id)
+                return "Ask"
+            end,
+            model = {
+                options = {
+                    { value = "sonnet", name = "Sonnet" },
+                },
+            },
+            thought_level = {
+                currentValue = "high",
+                options = {
+                    { value = "high", name = "High" },
+                },
+            },
+            legacy_agent_models = {
+                get_model = function(_, _id)
+                    return nil
+                end,
+            },
+            legacy_agent_modes = {
+                get_mode = function(_, _id)
+                    return nil
+                end,
+            },
+        }
+    end
+
+    --- Legacy provider: config name source absent, legacy holders supply names.
+    --- @return table fake
+    local function legacy_provider_fake()
+        return {
+            get_model_id = function()
+                return "gpt"
+            end,
+            get_mode_id = function()
+                return "plan"
+            end,
+            get_mode_name = function(_, _id)
+                return "Plan"
+            end,
+            model = nil,
+            thought_level = nil,
+            legacy_agent_models = {
+                get_model = function(_, _id)
+                    return { modelId = "gpt", name = "GPT" }
+                end,
+            },
+            legacy_agent_modes = {
+                get_mode = function(_, _id)
+                    return { id = "plan", name = "Plan" }
+                end,
+            },
+        }
+    end
+
+    --- Real shape: legacy holders ALWAYS exist; all ids nil.
+    --- @return table fake
+    local function empty_fake()
+        return {
+            get_model_id = function()
+                return nil
+            end,
+            get_mode_id = function()
+                return nil
+            end,
+            get_mode_name = function(_, _id)
+                return nil
+            end,
+            model = nil,
+            mode = nil,
+            thought_level = nil,
+            legacy_agent_models = {
+                get_model = function(_, _id)
+                    return nil
+                end,
+            },
+            legacy_agent_modes = {
+                get_mode = function(_, _id)
+                    return nil
+                end,
+            },
+        }
+    end
+
+    describe("usage getters", function()
+        it("are nil on a fresh instance", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            assert.is_nil(state:get_context_used())
+            assert.is_nil(state:get_context_size())
+            assert.is_nil(state:get_cost_amount())
+            assert.is_nil(state:get_cost_currency())
+        end)
+
+        it("returns used/size after set_usage without cost", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            state:set_usage({ used = 1000, size = 200000 })
+
+            assert.equal(state:get_context_used(), 1000)
+            assert.equal(state:get_context_size(), 200000)
+            assert.is_nil(state:get_cost_amount())
+            assert.is_nil(state:get_cost_currency())
+        end)
+
+        it("returns cost when the update includes it", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            state:set_usage({
+                used = 10,
+                size = 20,
+                cost = { amount = 0.5, currency = "USD" },
+            })
+
+            assert.equal(state:get_cost_amount(), 0.5)
+            assert.equal(state:get_cost_currency(), "USD")
+        end)
+
+        it("normalizes cost arriving as vim.NIL to nil", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            state:set_usage({ used = 1, size = 2, cost = vim.NIL })
+
+            assert.is_nil(state:get_cost_amount())
+            assert.is_nil(state:get_cost_currency())
+        end)
+
+        it("stores zero used/size values", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            state:set_usage({ used = 0, size = 0 })
+
+            assert.equal(state:get_context_used(), 0)
+            assert.equal(state:get_context_size(), 0)
+        end)
+
+        it("overwrites prior usage on a later set_usage", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            state:set_usage({
+                used = 1,
+                size = 2,
+                cost = { amount = 9, currency = "EUR" },
+            })
+            state:set_usage({ used = 5, size = 6 })
+
+            assert.equal(state:get_context_used(), 5)
+            assert.equal(state:get_context_size(), 6)
+            assert.is_nil(state:get_cost_amount())
+            assert.is_nil(state:get_cost_currency())
+        end)
+    end)
+
+    describe("clear", function()
+        it("resets usage but keeps provider_name", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            state:set_usage({
+                used = 1,
+                size = 2,
+                cost = { amount = 3, currency = "USD" },
+            })
+            state:clear()
+
+            assert.is_nil(state:get_context_used())
+            assert.is_nil(state:get_context_size())
+            assert.is_nil(state:get_cost_amount())
+            assert.is_nil(state:get_cost_currency())
+            assert.equal(state:get_provider_name(), "Claude")
+        end)
+    end)
+
+    describe("provider name", function()
+        it("returns the name passed to new", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            assert.equal(state:get_provider_name(), "Claude")
+        end)
+    end)
+
+    describe("config-provider delegation", function()
+        it("delegates ids and resolves names from config options", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            assert.equal(state:get_model_id(), "sonnet")
+            assert.equal(state:get_model_name(), "Sonnet")
+            assert.equal(state:get_mode_id(), "ask")
+            assert.equal(state:get_mode_name(), "Ask")
+            assert.equal(state:get_thought_level_id(), "high")
+            assert.equal(state:get_thought_level_name(), "High")
+        end)
+    end)
+
+    describe("legacy-provider delegation", function()
+        it("resolves model name via the legacy scan branch", function()
+            local state = SessionState:new(legacy_provider_fake(), "Codex")
+
+            assert.equal(state:get_model_id(), "gpt")
+            assert.equal(state:get_model_name(), "GPT")
+            assert.equal(state:get_mode_id(), "plan")
+            assert.equal(state:get_mode_name(), "Plan")
+        end)
+
+        it("has nil thought level (no legacy path)", function()
+            local state = SessionState:new(legacy_provider_fake(), "Codex")
+
+            assert.is_nil(state:get_thought_level_id())
+            assert.is_nil(state:get_thought_level_name())
+        end)
+    end)
+
+    describe("missing config and legacy", function()
+        it("returns nil for every getter without crashing", function()
+            local state = SessionState:new(empty_fake(), "None")
+
+            assert.is_nil(state:get_model_id())
+            assert.is_nil(state:get_model_name())
+            assert.is_nil(state:get_mode_id())
+            assert.is_nil(state:get_mode_name())
+            assert.is_nil(state:get_thought_level_id())
+            assert.is_nil(state:get_thought_level_name())
+        end)
+    end)
+end)

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -91,7 +91,7 @@
 --- Overrides default options (wrap, linebreak, winfixheight)
 --- @alias agentic.UserConfig.WinOpts table<string, any>
 
---- @alias agentic.UserConfig.BufferNameFn fun(header: agentic.ui.ChatWidget.HeaderParts, session_state: agentic.acp.SessionState?): string|nil
+--- @alias agentic.UserConfig.BufferNameFn fun(header: agentic.ui.ChatWidget.HeaderParts, session_state: agentic.acp.SessionState|nil): string|nil
 
 --- @class agentic.UserConfig.Windows.Chat
 --- @field buffer_name? string|agentic.UserConfig.BufferNameFn

--- a/lua/agentic/config_default.lua
+++ b/lua/agentic/config_default.lua
@@ -13,7 +13,7 @@
 --- | "kiro-acp"
 --- | "pi-acp"
 
---- @alias agentic.UserConfig.HeaderRenderFn fun(parts: agentic.ui.ChatWidget.HeaderParts): string|nil
+--- @alias agentic.UserConfig.HeaderRenderFn fun(parts: agentic.ui.ChatWidget.HeaderParts, session_state: agentic.acp.SessionState?): string|nil
 
 --- User config headers - each panel can have either config parts or a custom render function
 --- Customize window headers for each panel in the chat widget.
@@ -91,7 +91,7 @@
 --- Overrides default options (wrap, linebreak, winfixheight)
 --- @alias agentic.UserConfig.WinOpts table<string, any>
 
---- @alias agentic.UserConfig.BufferNameFn fun(header: agentic.ui.ChatWidget.HeaderParts): string|nil
+--- @alias agentic.UserConfig.BufferNameFn fun(header: agentic.ui.ChatWidget.HeaderParts, session_state: agentic.acp.SessionState?): string|nil
 
 --- @class agentic.UserConfig.Windows.Chat
 --- @field buffer_name? string|agentic.UserConfig.BufferNameFn

--- a/lua/agentic/config_selector.test.lua
+++ b/lua/agentic/config_selector.test.lua
@@ -394,7 +394,7 @@ describe("config selector", function()
             end
         )
 
-        it("does NOT fire when the response omits configOptions", function()
+        it("fires when the response omits configOptions", function()
             local applied = spy.new(function() end)
             --- @type any
             local agent = {
@@ -411,7 +411,7 @@ describe("config selector", function()
 
             config:handle_model_change("m2", false)
 
-            assert.equal(0, applied.call_count)
+            assert.equal(1, applied.call_count)
         end)
 
         it("does NOT fire when the change errors", function()

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -149,6 +149,7 @@ function SessionManager:new(tab_page_id)
 
     self.session_state =
         SessionState:new(self.config_options, self.agent.provider_config.name)
+    self.widget.session_state = self.session_state
 
     self.file_list = FileList:new(self.widget.buf_nrs.files, function(file_list)
         if file_list:is_empty() then

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -335,6 +335,7 @@ function SessionManager:_on_session_update(update)
             )
         then
             self:_set_mode_to_chat_header(update.currentModeId)
+            self.widget:schedule_header_refresh()
         end
     elseif update.sessionUpdate == "config_option_update" then
         self:_handle_new_config_options(update.configOptions)

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -130,7 +130,10 @@ function SessionManager:new(tab_page_id)
             self:_set_mode_to_chat_header(mode_id)
         end,
         on_config_options_applied = function()
-            self:_refresh_mode_header()
+            local mode_id = self.config_options:get_mode_id()
+            if mode_id then
+                self:_set_mode_to_chat_header(mode_id)
+            end
         end,
         get_agent_instance = function()
             return self.agent
@@ -873,17 +876,13 @@ function SessionManager:add_buffer_diagnostics_to_context(bufnr)
     return self.diagnostics_list:add_many(diagnostics)
 end
 
---- Refresh the chat header from the live mode option, when one is present.
-function SessionManager:_refresh_mode_header()
-    if self.config_options.mode and self.config_options.mode.currentValue then
-        self:_set_mode_to_chat_header(self.config_options.mode.currentValue)
-    end
-end
-
 --- @param new_config_options agentic.acp.ConfigOption[]
 function SessionManager:_handle_new_config_options(new_config_options)
     self.config_options:set_options(new_config_options)
-    self:_refresh_mode_header()
+    local mode_id = self.config_options:get_mode_id()
+    if mode_id then
+        self:_set_mode_to_chat_header(mode_id)
+    end
 end
 
 function SessionManager:destroy()
@@ -969,9 +968,7 @@ function SessionManager:load_acp_session(session_id, title, timestamp)
             self._is_first_message = false
 
             -- Re-render mode in chat header from preserved config_options
-            local current_mode = self.config_options.mode
-                    and self.config_options.mode.currentValue
-                or self.config_options.legacy_agent_modes.current_mode_id
+            local current_mode = self.config_options:get_mode_id()
             if current_mode then
                 self:_set_mode_to_chat_header(current_mode)
             end

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -891,6 +891,8 @@ function SessionManager:_handle_new_config_options(new_config_options)
     if mode_id then
         self:_set_mode_to_chat_header(mode_id)
     end
+
+    self.widget:schedule_header_refresh()
 end
 
 function SessionManager:destroy()

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -12,6 +12,7 @@ local DiagnosticsList = require("agentic.ui.diagnostics_list")
 local FileSystem = require("agentic.utils.file_system")
 local Logger = require("agentic.utils.logger")
 local SlashCommands = require("agentic.acp.slash_commands")
+local SessionState = require("agentic.acp.session_state")
 local EnvironmentInfo = require("agentic.utils.environment_info")
 local Hooks = require("agentic.utils.hooks")
 
@@ -29,6 +30,7 @@ local Hooks = require("agentic.utils.hooks")
 --- @field code_selection agentic.ui.CodeSelection
 --- @field diagnostics_list agentic.ui.DiagnosticsList
 --- @field config_options agentic.acp.AgentConfigOptions
+--- @field session_state agentic.acp.SessionState
 --- @field diff_coordinator agentic.ui.DiffCoordinator
 --- @field todo_list agentic.ui.TodoList
 --- @field chat_history agentic.ui.ChatHistory
@@ -128,12 +130,14 @@ function SessionManager:new(tab_page_id)
     self.config_options = AgentConfigOptions:new(self.widget.buf_nrs, {
         on_set_mode_success = function(mode_id)
             self:_set_mode_to_chat_header(mode_id)
+            self.widget:schedule_header_refresh()
         end,
         on_config_options_applied = function()
             local mode_id = self.config_options:get_mode_id()
             if mode_id then
                 self:_set_mode_to_chat_header(mode_id)
             end
+            self.widget:schedule_header_refresh()
         end,
         get_agent_instance = function()
             return self.agent
@@ -142,6 +146,9 @@ function SessionManager:new(tab_page_id)
             return self.session_id
         end,
     })
+
+    self.session_state =
+        SessionState:new(self.config_options, self.agent.provider_config.name)
 
     self.file_list = FileList:new(self.widget.buf_nrs.files, function(file_list)
         if file_list:is_empty() then
@@ -331,9 +338,8 @@ function SessionManager:_on_session_update(update)
     elseif update.sessionUpdate == "config_option_update" then
         self:_handle_new_config_options(update.configOptions)
     elseif update.sessionUpdate == "usage_update" then
-        -- Usage updates contain token/cost information - currently informational only
-        -- Fields: used (tokens), size (context window), cost (optional: amount, currency)
-        -- Keeping silent for now to avoid "press any key" prompts on large JSON output
+        self.session_state:set_usage(update)
+        self.widget:schedule_header_refresh()
     elseif update.sessionUpdate == "session_info_update" then
         -- Session metadata is currently informational only
     else
@@ -819,6 +825,7 @@ function SessionManager:_cancel_session()
         self.code_selection:clear()
         self.diagnostics_list:clear()
         self.config_options:clear()
+        self.session_state:clear()
     end
 
     self.session_id = nil

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -123,7 +123,6 @@ describe("agentic.SessionManager", function()
                 },
                 _on_session_update = SessionManager._on_session_update,
                 _set_mode_to_chat_header = SessionManager._set_mode_to_chat_header,
-                _refresh_mode_header = SessionManager._refresh_mode_header,
                 _handle_new_config_options = SessionManager._handle_new_config_options,
             } --[[@as agentic.SessionManager]]
         end)

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -698,6 +698,307 @@ describe("agentic.SessionManager", function()
         end)
     end)
 
+    describe("config-change header refresh wiring", function()
+        --- @type TestStub
+        local get_instance_stub
+        --- @type TestStub
+        local notify_stub
+        --- @type TestStub
+        local schedule_stub
+        --- @type TestStub
+        local health_check_stub
+        --- @type TestStub
+        local config_options_new_stub
+        --- @type agentic.acp.AgentConfigOptions.Callbacks
+        local captured_callbacks
+
+        before_each(function()
+            local AgentInstance = require("agentic.acp.agent_instance")
+            local ACPHealth = require("agentic.acp.acp_health")
+            local AgentConfigOptions =
+                require("agentic.acp.agent_config_options")
+            local Config = require("agentic.config")
+
+            notify_stub = spy.stub(Logger, "notify")
+            schedule_stub = spy.stub(vim, "schedule")
+            schedule_stub:invokes(function() end)
+            health_check_stub = spy.stub(ACPHealth, "check_configured_provider")
+            health_check_stub:returns(true)
+
+            local real_new = AgentConfigOptions.new
+            config_options_new_stub = spy.stub(AgentConfigOptions, "new")
+            config_options_new_stub:invokes(function(s, buffers, callbacks)
+                captured_callbacks = callbacks
+                return real_new(s, buffers, callbacks)
+            end)
+
+            get_instance_stub = spy.stub(AgentInstance, "get_instance")
+            get_instance_stub:invokes(function(provider_name, callback)
+                --- @type agentic.acp.ACPClient
+                local fake = {}
+                fake.state = "ready"
+                fake.provider_config = {
+                    name = provider_name or "Test",
+                    initial_model = nil,
+                    default_mode = nil,
+                }
+                fake.agent_info = {}
+                function fake:create_session(_h, cb)
+                    cb({
+                        sessionId = "test-session",
+                        configOptions = nil,
+                        modes = nil,
+                        models = nil,
+                    })
+                end
+                function fake:cancel_session() end
+                if callback then
+                    callback(fake)
+                end
+                return fake
+            end)
+            Config.provider = "TestProvider"
+        end)
+
+        after_each(function()
+            notify_stub:revert()
+            schedule_stub:revert()
+            health_check_stub:revert()
+            get_instance_stub:revert()
+            config_options_new_stub:revert()
+
+            local SessionRegistry = require("agentic.session_registry")
+            local tab_ids = {}
+            for tab_id, _ in pairs(SessionRegistry.sessions) do
+                table.insert(tab_ids, tab_id)
+            end
+            for _, tab_id in ipairs(tab_ids) do
+                SessionRegistry.destroy_session(tab_id)
+            end
+        end)
+
+        it("schedules a refresh from on_config_options_applied", function()
+            local tab_page_id = vim.api.nvim_get_current_tabpage()
+            local session = SessionManager:new(tab_page_id) --[[@as agentic.SessionManager]]
+            local refresh_spy = spy.new(function() end)
+            session.widget.schedule_header_refresh = refresh_spy
+
+            captured_callbacks.on_config_options_applied()
+
+            assert.spy(refresh_spy).was.called(1)
+        end)
+
+        it("schedules a refresh from on_set_mode_success", function()
+            local tab_page_id = vim.api.nvim_get_current_tabpage()
+            local session = SessionManager:new(tab_page_id) --[[@as agentic.SessionManager]]
+            local refresh_spy = spy.new(function() end)
+            session.widget.schedule_header_refresh = refresh_spy
+
+            captured_callbacks.on_set_mode_success("plan")
+
+            assert.spy(refresh_spy).was.called(1)
+        end)
+    end)
+
+    describe("_on_session_update: usage_update", function()
+        local SessionState = require("agentic.acp.session_state")
+        --- @type TestSpy
+        local refresh_spy
+        --- @type agentic.SessionManager
+        local session
+
+        before_each(function()
+            refresh_spy = spy.new(function() end)
+
+            local config_options = {
+                get_model_id = function() end,
+                get_mode_id = function() end,
+            }
+
+            session = {
+                session_id = "session-1",
+                tab_page_id = 7,
+                _is_restoring_session = false,
+                config_options = config_options,
+                session_state = SessionState:new(config_options, "Test"),
+                widget = {
+                    schedule_header_refresh = refresh_spy,
+                },
+                agent = { provider_config = { name = "Test" } },
+                _on_session_update = SessionManager._on_session_update,
+            } --[[@as agentic.SessionManager]]
+        end)
+
+        it("feeds used/size into session_state", function()
+            session:_on_session_update({
+                sessionUpdate = "usage_update",
+                used = 1000,
+                size = 200000,
+            })
+
+            assert.equal(1000, session.session_state:get_context_used())
+            assert.equal(200000, session.session_state:get_context_size())
+        end)
+
+        it("schedules a header refresh", function()
+            session:_on_session_update({
+                sessionUpdate = "usage_update",
+                used = 10,
+                size = 20,
+            })
+
+            assert.spy(refresh_spy).was.called(1)
+        end)
+    end)
+
+    describe("_cancel_session: session_state clear", function()
+        local SessionState = require("agentic.acp.session_state")
+        --- @type TestStub
+        local slash_commands_stub
+
+        before_each(function()
+            local SlashCommands = require("agentic.acp.slash_commands")
+            slash_commands_stub = spy.stub(SlashCommands, "setCommands")
+        end)
+
+        after_each(function()
+            slash_commands_stub:revert()
+        end)
+
+        --- @param session_id string|nil
+        --- @return agentic.SessionManager
+        local function make_session(session_id)
+            local ChatHistory = require("agentic.ui.chat_history")
+            local config_options = {
+                get_model_id = function() end,
+                get_mode_id = function() end,
+                clear = function() end,
+            }
+            local session_state = SessionState:new(config_options, "Test")
+            session_state:set_usage({ used = 500, size = 1000 })
+
+            return {
+                is_generating = true,
+                _is_restoring_session = true,
+                session_id = session_id,
+                config_options = config_options,
+                session_state = session_state,
+                permission_manager = { clear = function() end },
+                agent = { cancel_session = function() end },
+                widget = {
+                    clear = function() end,
+                    buf_nrs = { input = 1 },
+                },
+                todo_list = { clear = function() end },
+                file_list = { clear = function() end },
+                code_selection = { clear = function() end },
+                diagnostics_list = { clear = function() end },
+                status_animation = { stop = function() end },
+                chat_history = ChatHistory:new(),
+                history_to_send = {},
+                message_writer = {
+                    reset_sender_tracking = function() end,
+                },
+                _cancel_session = SessionManager._cancel_session,
+            } --[[@as agentic.SessionManager]]
+        end
+
+        it("clears usage when a session_id is set", function()
+            local session = make_session("session-1")
+
+            session:_cancel_session()
+
+            assert.is_nil(session.session_state:get_context_used())
+            assert.is_nil(session.session_state:get_context_size())
+        end)
+    end)
+
+    describe("load_acp_session: usage not restored", function()
+        local SessionState = require("agentic.acp.session_state")
+        --- @type TestStub
+        local slash_commands_stub
+
+        before_each(function()
+            local SlashCommands = require("agentic.acp.slash_commands")
+            slash_commands_stub = spy.stub(SlashCommands, "setCommands")
+        end)
+
+        after_each(function()
+            slash_commands_stub:revert()
+        end)
+
+        it("leaves usage nil after snapshot/cancel/restore", function()
+            local ChatHistory = require("agentic.ui.chat_history")
+            local AgentConfigOptions =
+                require("agentic.acp.agent_config_options")
+            local BufHelpers = require("agentic.utils.buf_helpers")
+            local test_bufnr = vim.api.nvim_create_buf(false, true)
+
+            local keymap_stub = spy.stub(BufHelpers, "multi_keymap_set")
+            local config_options = AgentConfigOptions:new(
+                { chat = test_bufnr },
+                {
+                    set_mode = function() end,
+                    set_model = function() end,
+                    set_thought_level = function() end,
+                }
+            )
+            keymap_stub:revert()
+
+            local session_state = SessionState:new(config_options, "Test")
+            session_state:set_usage({ used = 9000, size = 10000 })
+
+            --- @type agentic.SessionManager
+            local session = {
+                is_generating = false,
+                _is_restoring_session = false,
+                session_id = "old-session",
+                config_options = config_options,
+                session_state = session_state,
+                permission_manager = { clear = function() end },
+                agent = {
+                    agent_capabilities = { loadSession = true },
+                    agent_info = nil,
+                    provider_config = { name = "Test" },
+                    cancel_session = function() end,
+                    load_session = function() end,
+                },
+                widget = {
+                    clear = function() end,
+                    buf_nrs = { input = 1, chat = test_bufnr },
+                },
+                todo_list = { clear = function() end },
+                file_list = { clear = function() end },
+                code_selection = { clear = function() end },
+                diagnostics_list = { clear = function() end },
+                status_animation = {
+                    start = function() end,
+                    stop = function() end,
+                },
+                chat_history = ChatHistory:new(),
+                history_to_send = {},
+                message_writer = {
+                    reset_sender_tracking = function() end,
+                    generate_welcome_header = function()
+                        return ""
+                    end,
+                    write_structural_message = function() end,
+                },
+                _cancel_session = SessionManager._cancel_session,
+                _build_handlers = function()
+                    return {}
+                end,
+                load_acp_session = SessionManager.load_acp_session,
+            } --[[@as agentic.SessionManager]]
+
+            session:load_acp_session("new-session", "title", nil)
+
+            assert.is_nil(session.session_state:get_context_used())
+
+            vim.api.nvim_buf_delete(test_bufnr, { force = true })
+        end)
+    end)
+
     describe("_on_session_update: user_message_chunk", function()
         --- @type TestSpy
         local write_message_spy

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -836,8 +836,8 @@ describe("agentic.SessionManager", function()
                 size = 200000,
             })
 
-            assert.equal(1000, session.session_state:get_context_used())
-            assert.equal(200000, session.session_state:get_context_size())
+            assert.equal(1000, session.session_state:get_context_used_raw())
+            assert.equal(200000, session.session_state:get_context_size_raw())
         end)
 
         it("schedules a header refresh", function()

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -93,6 +93,8 @@ describe("agentic.SessionManager", function()
     describe("_on_session_update: config_option_update", function()
         --- @type TestSpy
         local render_header_spy
+        --- @type TestSpy
+        local refresh_spy
         --- @type agentic.SessionManager
         local session
         --- @type integer
@@ -100,6 +102,7 @@ describe("agentic.SessionManager", function()
 
         before_each(function()
             render_header_spy = spy.new(function() end)
+            refresh_spy = spy.new(function() end)
             test_bufnr = vim.api.nvim_create_buf(false, true)
 
             local AgentConfigOptions =
@@ -119,6 +122,7 @@ describe("agentic.SessionManager", function()
                 config_options = config_opts,
                 widget = {
                     render_header = render_header_spy,
+                    schedule_header_refresh = refresh_spy,
                     buf_nrs = { chat = test_bufnr },
                 },
                 _on_session_update = SessionManager._on_session_update,
@@ -159,6 +163,7 @@ describe("agentic.SessionManager", function()
             assert.equal("plan", session.config_options.mode.currentValue)
             assert.spy(render_header_spy).was.called(1)
             assert.equal("Mode: Plan", render_header_spy.calls[1][3])
+            assert.spy(refresh_spy).was.called(1)
         end)
     end)
 

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -18,6 +18,8 @@ describe("agentic.SessionManager", function()
         local notify_stub
         --- @type TestSpy
         local render_header_spy
+        --- @type TestSpy
+        local refresh_spy
         --- @type agentic.SessionManager
         local session
         --- @type integer
@@ -26,6 +28,7 @@ describe("agentic.SessionManager", function()
         before_each(function()
             notify_stub = spy.stub(Logger, "notify")
             render_header_spy = spy.new(function() end)
+            refresh_spy = spy.new(function() end)
             test_bufnr = vim.api.nvim_create_buf(false, true)
 
             local legacy_modes = AgentModes:new()
@@ -47,6 +50,7 @@ describe("agentic.SessionManager", function()
                 },
                 widget = {
                     render_header = render_header_spy,
+                    schedule_header_refresh = refresh_spy,
                     buf_nrs = { chat = test_bufnr },
                 },
                 _on_session_update = SessionManager._on_session_update,
@@ -70,6 +74,7 @@ describe("agentic.SessionManager", function()
             assert.spy(render_header_spy).was.called(1)
             assert.equal("chat", render_header_spy.calls[1][2])
             assert.equal("Mode: Code", render_header_spy.calls[1][3])
+            assert.spy(refresh_spy).was.called(1)
 
             assert.spy(notify_stub).was.called(1)
             assert.equal("Mode changed to: code", notify_stub.calls[1][1])
@@ -84,6 +89,7 @@ describe("agentic.SessionManager", function()
                 session.config_options.legacy_agent_modes.current_mode_id
             )
             assert.spy(render_header_spy).was.called(0)
+            assert.spy(refresh_spy).was.called(0)
 
             assert.spy(notify_stub).was.called(1)
             assert.equal(vim.log.levels.WARN, notify_stub.calls[1][2])
@@ -809,15 +815,40 @@ describe("agentic.SessionManager", function()
         local SessionState = require("agentic.acp.session_state")
         --- @type TestSpy
         local refresh_spy
+        --- @type TestSpy
+        local render_header_spy
         --- @type agentic.SessionManager
         local session
 
         before_each(function()
             refresh_spy = spy.new(function() end)
+            render_header_spy = spy.new(function() end)
+
+            local legacy_modes = AgentModes:new()
+            legacy_modes:set_modes({
+                availableModes = {
+                    { id = "plan", name = "Plan", description = "Planning" },
+                    { id = "code", name = "Code", description = "Coding" },
+                },
+                currentModeId = "plan",
+            })
 
             local config_options = {
-                get_model_id = function() end,
-                get_mode_id = function() end,
+                legacy_agent_modes = legacy_modes,
+                mode = nil,
+                set_options = function(self, config_options_update)
+                    self.mode = config_options_update[1]
+                end,
+                get_model_id = function(_self)
+                    return nil
+                end,
+                get_mode_id = function(self)
+                    return self.mode and self.mode.currentValue or nil
+                end,
+                get_mode_name = function(_self, mode_id)
+                    local mode = legacy_modes:get_mode(mode_id)
+                    return mode and mode.name or mode_id
+                end,
             }
 
             session = {
@@ -828,9 +859,12 @@ describe("agentic.SessionManager", function()
                 session_state = SessionState:new(config_options, "Test"),
                 widget = {
                     schedule_header_refresh = refresh_spy,
+                    render_header = render_header_spy,
                 },
                 agent = { provider_config = { name = "Test" } },
                 _on_session_update = SessionManager._on_session_update,
+                _set_mode_to_chat_header = SessionManager._set_mode_to_chat_header,
+                _handle_new_config_options = SessionManager._handle_new_config_options,
             } --[[@as agentic.SessionManager]]
         end)
 
@@ -850,6 +884,39 @@ describe("agentic.SessionManager", function()
                 sessionUpdate = "usage_update",
                 used = 10,
                 size = 20,
+            })
+
+            assert.spy(refresh_spy).was.called(1)
+        end)
+
+        it("schedules a header refresh for config_option_update", function()
+            session:_on_session_update({
+                sessionUpdate = "config_option_update",
+                configOptions = {
+                    {
+                        id = "mode-1",
+                        category = "mode",
+                        currentValue = "plan",
+                        description = "Mode",
+                        name = "Mode",
+                        options = {
+                            {
+                                value = "plan",
+                                name = "Plan",
+                                description = "",
+                            },
+                        },
+                    },
+                },
+            })
+
+            assert.spy(refresh_spy).was.called(1)
+        end)
+
+        it("schedules a header refresh for current_mode_update", function()
+            session:_on_session_update({
+                sessionUpdate = "current_mode_update",
+                currentModeId = "code",
             })
 
             assert.spy(refresh_spy).was.called(1)

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -46,6 +46,7 @@ local WidgetLayout = require("agentic.ui.widget_layout")
 --- @field _avoid_auto_close_cmd fun(self: agentic.ui.ChatWidget, fn: fun())
 --- @field _hidden_chat_winid? integer
 --- @field _header_refresh_scheduled boolean Guards coalesced header refresh
+--- @field session_state? agentic.acp.SessionState Live session state forwarded to header/buffer_name callbacks; set by SessionManager
 local ChatWidget = {}
 ChatWidget.__index = ChatWidget
 
@@ -57,6 +58,7 @@ function ChatWidget:new(tab_page_id, on_submit_input)
     self.win_nrs = {}
     self.current_position = Config.windows.position
     self._header_refresh_scheduled = false
+    self.session_state = nil
 
     self.on_submit_input = on_submit_input
     self.tab_page_id = tab_page_id
@@ -596,7 +598,12 @@ function ChatWidget:render_header(window_name, context)
         return
     end
 
-    WindowDecoration.render_header(bufnr, window_name, context)
+    WindowDecoration.render_header(
+        bufnr,
+        window_name,
+        context,
+        self.session_state
+    )
 end
 
 --- @param panel_name agentic.ui.ChatWidget.PanelNames

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -538,10 +538,58 @@ local function find_keymap(keymaps, mode)
     end
 end
 
+--- Computes the mode-aware submit/change-mode hint for the input header.
+--- Both hints live on the input header only. Returns nil for modes with no
+--- relevant binding (e.g. command mode) so callers keep the last shown hint.
+--- @param mode string
+--- @return string|nil suffix
+function ChatWidget._compute_input_suffix(mode)
+    local submit_key = find_keymap(Config.keymaps.prompt.submit, mode)
+    local change_mode_key = find_keymap(Config.keymaps.widget.change_mode, mode)
+
+    local hints = {}
+    if submit_key ~= nil then
+        hints[#hints + 1] = string.format("submit: %s", submit_key)
+    end
+    if change_mode_key ~= nil then
+        hints[#hints + 1] = string.format("change mode: %s", change_mode_key)
+    end
+
+    if #hints == 0 then
+        return nil
+    end
+
+    return table.concat(hints, " | ")
+end
+
+--- Persists the input header suffix for the current mode and re-renders it.
+--- @param mode string
+function ChatWidget:_apply_input_suffix(mode)
+    if not vim.api.nvim_tabpage_is_valid(self.tab_page_id) then
+        return
+    end
+
+    local suffix = ChatWidget._compute_input_suffix(mode)
+    if suffix == nil then
+        return
+    end
+
+    -- Get headers from tabpage-local storage (must reassign after modification)
+    local headers = WindowDecoration.get_headers_state(self.tab_page_id)
+    headers.input.suffix = suffix
+
+    -- Reassign to persist changes
+    WindowDecoration.set_headers_state(self.tab_page_id, headers)
+
+    self:render_header("input")
+end
+
 --- Binds events to change the suffix header texts based on current mode keymaps
 --- For the Chat and Input buffers only
 function ChatWidget:_bind_events_to_change_headers()
-    local tab_page_id = self.tab_page_id
+    -- Seed the input header with the normal-mode hints immediately so it does
+    -- not show the hard-coded default keys until the first mode change.
+    self:_apply_input_suffix("n")
 
     for _, bufnr in ipairs({ self.buf_nrs.chat, self.buf_nrs.input }) do
         vim.api.nvim_create_autocmd("ModeChanged", {
@@ -550,43 +598,7 @@ function ChatWidget:_bind_events_to_change_headers()
                 vim.schedule(function()
                     -- Check if tabpage is still valid before accessing vim.t
                     -- I couldn't test it, it seems to only happen from command -> normal, not from insert -> normal
-                    if not vim.api.nvim_tabpage_is_valid(tab_page_id) then
-                        return
-                    end
-
-                    -- Get headers from tabpage-local storage (must reassign after modification)
-                    local headers =
-                        WindowDecoration.get_headers_state(tab_page_id)
-
-                    local mode = vim.fn.mode()
-                    local submit_key =
-                        find_keymap(Config.keymaps.prompt.submit, mode)
-                    local change_mode_key =
-                        find_keymap(Config.keymaps.widget.change_mode, mode)
-
-                    -- Both hints live on the input header only.
-                    local hints = {}
-                    if submit_key ~= nil then
-                        hints[#hints + 1] =
-                            string.format("submit: %s", submit_key)
-                    end
-                    if change_mode_key ~= nil then
-                        hints[#hints + 1] =
-                            string.format("change mode: %s", change_mode_key)
-                    end
-
-                    -- Modes with no relevant binding (e.g. command mode) keep
-                    -- the last shown hint instead of going bare.
-                    if #hints == 0 then
-                        return
-                    end
-
-                    headers.input.suffix = table.concat(hints, " | ")
-
-                    -- Reassign to persist changes
-                    WindowDecoration.set_headers_state(tab_page_id, headers)
-
-                    self:render_header("input")
+                    self:_apply_input_suffix(vim.fn.mode())
                 end)
             end,
         })

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -559,30 +559,33 @@ function ChatWidget:_bind_events_to_change_headers()
                         WindowDecoration.get_headers_state(tab_page_id)
 
                     local mode = vim.fn.mode()
+                    local submit_key =
+                        find_keymap(Config.keymaps.prompt.submit, mode)
                     local change_mode_key =
                         find_keymap(Config.keymaps.widget.change_mode, mode)
 
-                    if change_mode_key ~= nil then
-                        headers.chat.suffix =
-                            string.format("%s: change mode", change_mode_key)
-                    else
-                        headers.chat.suffix = nil
-                    end
-
-                    local submit_key =
-                        find_keymap(Config.keymaps.prompt.submit, mode)
-
+                    -- Both hints live on the input header only.
+                    local hints = {}
                     if submit_key ~= nil then
-                        headers.input.suffix =
-                            string.format("%s: submit", submit_key)
-                    else
-                        headers.input.suffix = nil
+                        hints[#hints + 1] =
+                            string.format("submit: %s", submit_key)
                     end
+                    if change_mode_key ~= nil then
+                        hints[#hints + 1] =
+                            string.format("change mode: %s", change_mode_key)
+                    end
+
+                    -- Modes with no relevant binding (e.g. command mode) keep
+                    -- the last shown hint instead of going bare.
+                    if #hints == 0 then
+                        return
+                    end
+
+                    headers.input.suffix = table.concat(hints, " ")
 
                     -- Reassign to persist changes
                     WindowDecoration.set_headers_state(tab_page_id, headers)
 
-                    self:render_header("chat")
                     self:render_header("input")
                 end)
             end,
@@ -787,18 +790,29 @@ function ChatWidget:schedule_header_refresh()
     -- re-renders when multiple updates come in quick succession
     vim.defer_fn(function()
         self._header_refresh_scheduled = false
+        self:_render_dynamic_headers()
+    end, 150)
+end
 
-        local headers = Config.headers
-        if type(headers) ~= "table" then
-            return
-        end
+--- Re-render every session-driven header. The chat and input panels are
+--- always dynamic (their default headers consume session_state), plus any
+--- panel the user configured as a header function.
+function ChatWidget:_render_dynamic_headers()
+    --- @type table<agentic.ui.ChatWidget.PanelNames, boolean>
+    local panels = { chat = true, input = true }
 
+    local headers = Config.headers
+    if type(headers) == "table" then
         for panel_name, header_config in pairs(headers) do
             if type(header_config) == "function" then
-                self:render_header(panel_name)
+                panels[panel_name] = true
             end
         end
-    end, 150)
+    end
+
+    for panel_name in pairs(panels) do
+        self:render_header(panel_name)
+    end
 end
 
 return ChatWidget

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -581,7 +581,7 @@ function ChatWidget:_bind_events_to_change_headers()
                         return
                     end
 
-                    headers.input.suffix = table.concat(hints, " ")
+                    headers.input.suffix = table.concat(hints, " | ")
 
                     -- Reassign to persist changes
                     WindowDecoration.set_headers_state(tab_page_id, headers)

--- a/lua/agentic/ui/chat_widget.test.lua
+++ b/lua/agentic/ui/chat_widget.test.lua
@@ -953,4 +953,66 @@ describe("agentic.ui.ChatWidget", function()
             assert.is_true(vim.api.nvim_win_is_valid(widget._hidden_chat_winid))
         end)
     end)
+
+    describe("_render_dynamic_headers", function()
+        local tab_page_id
+        local widget
+        local original_headers
+
+        before_each(function()
+            original_headers = Config.headers
+            vim.cmd("tabnew")
+            tab_page_id = vim.api.nvim_get_current_tabpage()
+            widget = ChatWidget:new(
+                tab_page_id,
+                spy.new(function() end) --[[@as function]]
+            )
+        end)
+
+        after_each(function()
+            Config.headers = original_headers
+            pcall(function()
+                widget:destroy()
+            end)
+            pcall(function()
+                vim.cmd("tabclose")
+            end)
+        end)
+
+        it(
+            "refreshes chat and input with default (empty) Config.headers",
+            function()
+                Config.headers = {}
+                local render_spy = spy.new(function() end)
+                widget.render_header = render_spy
+
+                widget:_render_dynamic_headers()
+
+                local panels = {}
+                for _, call in ipairs(render_spy.calls) do
+                    panels[call[2]] = true
+                end
+                assert.is_true(panels.chat)
+                assert.is_true(panels.input)
+            end
+        )
+
+        it("refreshes a user-function panel too", function()
+            Config.headers = {
+                files = function(parts)
+                    return parts.title
+                end,
+            }
+            local render_spy = spy.new(function() end)
+            widget.render_header = render_spy
+
+            widget:_render_dynamic_headers()
+
+            local panels = {}
+            for _, call in ipairs(render_spy.calls) do
+                panels[call[2]] = true
+            end
+            assert.is_true(panels.files)
+        end)
+    end)
 end)

--- a/lua/agentic/ui/chat_widget.test.lua
+++ b/lua/agentic/ui/chat_widget.test.lua
@@ -2,6 +2,7 @@ local assert = require("tests.helpers.assert")
 local spy = require("tests.helpers.spy")
 local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
+local WindowDecoration = require("agentic.ui.window_decoration")
 
 describe("agentic.ui.ChatWidget", function()
     --- @type agentic.ui.ChatWidget
@@ -951,6 +952,37 @@ describe("agentic.ui.ChatWidget", function()
             assert.is_false(vim.api.nvim_win_is_valid(first_hidden))
             assert.is_not_nil(widget._hidden_chat_winid)
             assert.is_true(vim.api.nvim_win_is_valid(widget._hidden_chat_winid))
+        end)
+    end)
+
+    describe("input header suffix", function()
+        local tab_page_id
+        local widget
+
+        before_each(function()
+            vim.cmd("tabnew")
+            tab_page_id = vim.api.nvim_get_current_tabpage()
+            widget = ChatWidget:new(
+                tab_page_id,
+                spy.new(function() end) --[[@as function]]
+            )
+        end)
+
+        after_each(function()
+            pcall(function()
+                widget:destroy()
+            end)
+            pcall(function()
+                vim.cmd("tabclose")
+            end)
+        end)
+
+        it("seeds normal-mode hints at construction time", function()
+            local headers = WindowDecoration.get_headers_state(tab_page_id)
+            assert.equal(
+                "submit: <CR> | change mode: <S-Tab>",
+                headers.input.suffix
+            )
         end)
     end)
 

--- a/lua/agentic/ui/file_picker.test.lua
+++ b/lua/agentic/ui/file_picker.test.lua
@@ -180,6 +180,12 @@ describe("FilePicker:scan_files", function()
             )
             -- Local headless Neovim runs can create nvim.log after rg scanned.
             table.insert(FilePicker.GLOB_EXCLUDE_PATTERNS, "nvim%.log$")
+            -- Scheduled-task runs create .claude/scheduled_tasks.lock; gitignored
+            -- but glob fallback doesn't respect .gitignore.
+            table.insert(
+                FilePicker.GLOB_EXCLUDE_PATTERNS,
+                "scheduled_tasks%.lock$"
+            )
             -- .opencode/.gitignore ignores specific files (bun.lock, package.json, etc.)
             -- rg/fd/git respect nested .gitignore but glob fallback doesn't
             table.insert(FilePicker.GLOB_EXCLUDE_PATTERNS, "%.opencode/bun")

--- a/lua/agentic/ui/window_decoration.lua
+++ b/lua/agentic/ui/window_decoration.lua
@@ -100,13 +100,14 @@ end
 --- Calls a user-supplied function expected to return `string|nil`, capturing
 --- runtime errors and type violations as a formatted message.
 --- @param fn fun(...): any User function to call
---- @param arg any Single argument passed to the function
+--- @param arg any First argument passed to the function
 --- @param label string Identifier (e.g. "custom header"/"buffer_name") for error text
 --- @param name string Window name for error text
+--- @param extra_arg any Second argument passed to the function (session_state, nil allowed)
 --- @return string|nil result The returned string, or nil on error/nil-return
 --- @return string|nil error_message Formatted error, or nil when valid
-local function call_string_fn(fn, arg, label, name)
-    local ok, result = pcall(fn, arg)
+local function call_string_fn(fn, arg, label, name, extra_arg)
+    local ok, result = pcall(fn, arg, extra_arg)
     if not ok then
         return nil,
             string.format(
@@ -135,9 +136,10 @@ end
 --- Returns the header text and an error message if user function failed
 --- @param dynamic_header agentic.ui.ChatWidget.HeaderParts Runtime header parts
 --- @param window_name string Window name for Config.headers lookup and error messages
+--- @param session_state agentic.acp.SessionState|nil Live session state passed as 2nd arg to user header fn
 --- @return string|nil header_text The resolved header text or nil for empty
 --- @return string|nil error_message Error message if user function failed
-local function resolve_header_text(dynamic_header, window_name)
+local function resolve_header_text(dynamic_header, window_name, session_state)
     local user_header = Config.headers and Config.headers[window_name]
     -- No user customization: use default parts
     if user_header == nil then
@@ -150,7 +152,8 @@ local function resolve_header_text(dynamic_header, window_name)
             user_header,
             dynamic_header,
             "custom header",
-            window_name
+            window_name,
+            session_state
         )
         if err then
             return concat_header_parts(dynamic_header), err
@@ -281,8 +284,14 @@ end
 --- @param window_name string Window name for Config.windows[name].buffer_name lookup
 --- @param header_parts agentic.ui.ChatWidget.HeaderParts Header parts passed to function-type buffer_name
 --- @param fallback string|nil Fallback name (resolved header text) when buffer_name is not set
+--- @param session_state agentic.acp.SessionState|nil Live session state passed as 2nd arg to user buffer_name fn
 --- @return string|nil name
-local function resolve_buffer_name(window_name, header_parts, fallback)
+local function resolve_buffer_name(
+    window_name,
+    header_parts,
+    fallback,
+    session_state
+)
     local win_cfg = Config.windows[window_name]
     local buffer_name = win_cfg and win_cfg.buffer_name
 
@@ -299,7 +308,8 @@ local function resolve_buffer_name(window_name, header_parts, fallback)
             buffer_name,
             header_parts,
             "buffer_name",
-            window_name
+            window_name,
+            session_state
         )
         if err then
             Logger.notify(err)
@@ -326,14 +336,21 @@ end
 --- @param tab_page_id integer Tab page ID for suffix
 --- @param window_name string Window name for Config.windows[name].buffer_name lookup
 --- @param header_parts agentic.ui.ChatWidget.HeaderParts Header parts for function-type buffer_name
+--- @param session_state agentic.acp.SessionState|nil Live session state passed as 2nd arg to user buffer_name fn
 local function set_buffer_name(
     bufnr,
     header_text,
     tab_page_id,
     window_name,
-    header_parts
+    header_parts,
+    session_state
 )
-    local name = resolve_buffer_name(window_name, header_parts, header_text)
+    local name = resolve_buffer_name(
+        window_name,
+        header_parts,
+        header_text,
+        session_state
+    )
     if not name or name == "" then
         return
     end
@@ -357,7 +374,13 @@ end
 --- @param bufnr integer Buffer number - stable reference to derive window and tab context
 --- @param window_name string Name of the window (for Config.headers lookup and error messages)
 --- @param context string|nil Optional context to set in header (e.g., "Mode: chat", "3 files")
-function WindowDecoration.render_header(bufnr, window_name, context)
+--- @param session_state agentic.acp.SessionState|nil Live session state forwarded to user header/buffer_name callbacks as their 2nd arg
+function WindowDecoration.render_header(
+    bufnr,
+    window_name,
+    context,
+    session_state
+)
     vim.schedule(function()
         local winid = vim.fn.bufwinid(bufnr)
         if winid == -1 then
@@ -388,7 +411,7 @@ function WindowDecoration.render_header(bufnr, window_name, context)
         end
 
         local header_text, err =
-            resolve_header_text(dynamic_header, window_name)
+            resolve_header_text(dynamic_header, window_name, session_state)
 
         if err then
             Logger.notify(err)
@@ -402,7 +425,8 @@ function WindowDecoration.render_header(bufnr, window_name, context)
             header_text,
             tab_page_id,
             window_name,
-            dynamic_header
+            dynamic_header,
+            session_state
         )
     end)
 end

--- a/lua/agentic/ui/window_decoration.lua
+++ b/lua/agentic/ui/window_decoration.lua
@@ -90,9 +90,16 @@ end
 local function build_chat_header(parts, session_state)
     --- @type string[]
     local segments = {}
-    segments[#segments + 1] = session_state:get_provider_name()
-    segments[#segments + 1] = session_state:get_model_name() or "unknown"
-    segments[#segments + 1] = session_state:get_mode_name()
+    --- @param value string|nil
+    local function add_segment(value)
+        if value ~= nil and value ~= "" then
+            segments[#segments + 1] = value
+        end
+    end
+
+    add_segment(session_state:get_provider_name())
+    add_segment(session_state:get_model_name() or "unknown")
+    add_segment(session_state:get_mode_name())
 
     local header =
         string.format("%s | %s", parts.title, table.concat(segments, " - "))

--- a/lua/agentic/ui/window_decoration.lua
+++ b/lua/agentic/ui/window_decoration.lua
@@ -100,7 +100,13 @@ local function build_chat_header(parts, session_state)
 
     local cost = session_state:get_cost_amount_raw()
     if cost ~= nil and cost ~= 0 then
-        header = header .. " $" .. (session_state:get_cost_amount() or "")
+        local amount = session_state:get_cost_amount() or ""
+        local currency = session_state:get_cost_currency()
+        if currency then
+            header = header .. " " .. currency .. " " .. amount
+        else
+            header = header .. " " .. amount
+        end
     end
 
     return header
@@ -433,7 +439,7 @@ end
 --- @param bufnr integer Buffer number - stable reference to derive window and tab context
 --- @param window_name string Name of the window (for Config.headers lookup and error messages)
 --- @param context string|nil Optional context to set in header (e.g., "Mode: chat", "3 files")
---- @param session_state agentic.acp.SessionState|nil Live session state forwarded to user header/buffer_name callbacks as their 2nd arg
+--- @param session_state agentic.acp.SessionState|nil Live session state forwarded to chat/input header/buffer_name callbacks as their 2nd arg
 function WindowDecoration.render_header(
     bufnr,
     window_name,
@@ -469,8 +475,16 @@ function WindowDecoration.render_header(
             WindowDecoration.set_headers_state(tab_page_id, headers)
         end
 
-        local header_text, err =
-            resolve_header_text(dynamic_header, window_name, session_state)
+        local callback_session_state = nil
+        if window_name == "chat" or window_name == "input" then
+            callback_session_state = session_state
+        end
+
+        local header_text, err = resolve_header_text(
+            dynamic_header,
+            window_name,
+            callback_session_state
+        )
 
         if err then
             Logger.notify(err)
@@ -487,7 +501,7 @@ function WindowDecoration.render_header(
             tab_page_id,
             window_name,
             dynamic_header,
-            session_state
+            callback_session_state
         )
     end)
 end

--- a/lua/agentic/ui/window_decoration.lua
+++ b/lua/agentic/ui/window_decoration.lua
@@ -34,9 +34,11 @@ local WindowDecoration = {}
 local WINDOW_HEADERS = {
     chat = {
         title = "󰻞 Agentic Chat",
-        suffix = "<S-Tab>: change mode",
     },
-    input = { title = "󰦨 Prompt", suffix = "<C-s>: submit" },
+    input = {
+        title = "󰦨 Prompt",
+        suffix = "submit: <C-s> change mode: <S-Tab>",
+    },
     code = {
         title = "󰪸 Selected Code Snippets",
         suffix = "d: remove block",
@@ -68,14 +70,65 @@ local default_config = {
 --- @param parts agentic.ui.ChatWidget.HeaderParts
 --- @return string header_text
 local function concat_header_parts(parts)
+    --- @type string[]
     local pieces = { parts.title }
     if parts.context ~= nil then
-        table.insert(pieces, parts.context)
+        pieces[#pieces + 1] = parts.context
     end
     if parts.suffix ~= nil then
-        table.insert(pieces, parts.suffix)
+        pieces[#pieces + 1] = parts.suffix
     end
     return table.concat(pieces, " | ")
+end
+
+--- Builds the rich default header for the chat panel from live session state:
+--- `title | provider - model - mode (used/size) $cost`. The chat panel carries
+--- no key hint; submit/change-mode hints live on the input header.
+--- @param parts agentic.ui.ChatWidget.HeaderParts
+--- @param session_state agentic.acp.SessionState
+--- @return string header_text
+local function build_chat_header(parts, session_state)
+    local header = string.format(
+        "%s | %s - %s - %s (%s/%s)",
+        parts.title,
+        session_state:get_provider_name() or "",
+        session_state:get_model_name() or "unknown",
+        session_state:get_mode_name() or "",
+        session_state:get_context_used() or "0",
+        session_state:get_context_size() or "0"
+    )
+
+    local cost = session_state:get_cost_amount_raw()
+    if cost ~= nil and cost ~= 0 then
+        header = header .. " $" .. (session_state:get_cost_amount() or "")
+    end
+
+    return header
+end
+
+--- Builds the default header from live session state. The chat panel gets the
+--- rich provider/model/mode/usage/cost line. Every other panel (including
+--- input, whose `parts.suffix` carries the mode-aware submit/change-mode
+--- hints), and any panel with a nil session_state, falls back to the plain
+--- title|context|suffix concatenation.
+--- @param window_name string
+--- @param parts agentic.ui.ChatWidget.HeaderParts
+--- @param session_state agentic.acp.SessionState|nil
+--- @return string header_text
+function WindowDecoration._build_default_header(
+    window_name,
+    parts,
+    session_state
+)
+    if session_state == nil then
+        return concat_header_parts(parts)
+    end
+
+    if window_name == "chat" then
+        return build_chat_header(parts, session_state)
+    end
+
+    return concat_header_parts(parts)
 end
 
 --- Gets or initializes headers for a tabpage
@@ -141,9 +194,15 @@ end
 --- @return string|nil error_message Error message if user function failed
 local function resolve_header_text(dynamic_header, window_name, session_state)
     local user_header = Config.headers and Config.headers[window_name]
-    -- No user customization: use default parts
+    -- No user customization: build the default header (rich for chat/input
+    -- when a session is live, plain concat otherwise)
     if user_header == nil then
-        return concat_header_parts(dynamic_header), nil
+        return WindowDecoration._build_default_header(
+            window_name,
+            dynamic_header,
+            session_state
+        ),
+            nil
     end
 
     -- User function: call it and validate return
@@ -420,9 +479,11 @@ function WindowDecoration.render_header(
         local text = (header_text and header_text ~= "") and header_text or ""
 
         set_winbar(winid, text)
+        -- Buffer name mirrors the header title, not the rich winbar text:
+        -- the rich format embeds "/" and "$" which corrupt buffer basenames.
         set_buffer_name(
             bufnr,
-            header_text,
+            concat_header_parts(dynamic_header),
             tab_page_id,
             window_name,
             dynamic_header,

--- a/lua/agentic/ui/window_decoration.lua
+++ b/lua/agentic/ui/window_decoration.lua
@@ -88,13 +88,14 @@ end
 --- @param session_state agentic.acp.SessionState
 --- @return string header_text
 local function build_chat_header(parts, session_state)
-    local header = string.format(
-        "%s | %s - %s - %s",
-        parts.title,
-        session_state:get_provider_name() or "",
-        session_state:get_model_name() or "unknown",
-        session_state:get_mode_name() or ""
-    )
+    --- @type string[]
+    local segments = {}
+    segments[#segments + 1] = session_state:get_provider_name()
+    segments[#segments + 1] = session_state:get_model_name() or "unknown"
+    segments[#segments + 1] = session_state:get_mode_name()
+
+    local header =
+        string.format("%s | %s", parts.title, table.concat(segments, " - "))
 
     local used = session_state:get_context_used()
     local size = session_state:get_context_size()

--- a/lua/agentic/ui/window_decoration.lua
+++ b/lua/agentic/ui/window_decoration.lua
@@ -37,7 +37,7 @@ local WINDOW_HEADERS = {
     },
     input = {
         title = "󰦨 Prompt",
-        suffix = "submit: <C-s> change mode: <S-Tab>",
+        suffix = "submit: <C-s> | change mode: <S-Tab>",
     },
     code = {
         title = "󰪸 Selected Code Snippets",
@@ -89,14 +89,18 @@ end
 --- @return string header_text
 local function build_chat_header(parts, session_state)
     local header = string.format(
-        "%s | %s - %s - %s (%s/%s)",
+        "%s | %s - %s - %s",
         parts.title,
         session_state:get_provider_name() or "",
         session_state:get_model_name() or "unknown",
-        session_state:get_mode_name() or "",
-        session_state:get_context_used() or "0",
-        session_state:get_context_size() or "0"
+        session_state:get_mode_name() or ""
     )
+
+    local used = session_state:get_context_used()
+    local size = session_state:get_context_size()
+    if used ~= nil and size ~= nil then
+        header = header .. string.format(" (%s/%s)", used, size)
+    end
 
     local cost = session_state:get_cost_amount_raw()
     if cost ~= nil and cost ~= 0 then

--- a/lua/agentic/ui/window_decoration.test.lua
+++ b/lua/agentic/ui/window_decoration.test.lua
@@ -141,8 +141,9 @@ describe("WindowDecoration._build_default_header", function()
 
     --- Stub session_state exposing only the getters the header consumes.
     --- @param cost_raw number|nil Cumulative cost; nil/0 omits the cost segment
+    --- @param currency string|nil Cost currency
     --- @return agentic.acp.SessionState
-    local function fake_session_state(cost_raw)
+    local function fake_session_state(cost_raw, currency)
         --- @type any
         local stub = {
             get_provider_name = function()
@@ -166,6 +167,9 @@ describe("WindowDecoration._build_default_header", function()
             get_cost_amount = function()
                 return cost_raw and string.format("%.2f", cost_raw) or nil
             end,
+            get_cost_currency = function()
+                return currency or "USD"
+            end,
         }
         return stub
     end
@@ -183,7 +187,22 @@ describe("WindowDecoration._build_default_header", function()
         )
 
         assert.equal(
-            "Agentic Chat | Claude - Sonnet - Ask (1K/200K) $0.50",
+            "Agentic Chat | Claude - Sonnet - Ask (1K/200K) USD 0.50",
+            text
+        )
+    end)
+
+    it("shows the reported cost currency", function()
+        local parts = { title = "Agentic Chat" }
+
+        local text = WindowDecoration._build_default_header(
+            "chat",
+            parts,
+            fake_session_state(0.5, "EUR")
+        )
+
+        assert.equal(
+            "Agentic Chat | Claude - Sonnet - Ask (1K/200K) EUR 0.50",
             text
         )
     end)
@@ -256,9 +275,11 @@ describe("WindowDecoration.render_header", function()
     --- Build a buffer displayed in a window, install header + buffer_name
     --- function configs that record their 2nd arg, then render_header with a
     --- session_state carrying a unique marker. Returns recorded markers.
+    --- @param window_name string
     --- @return integer bufnr the buffer rendered into; recorded markers are read via _G globals
-    local function render_with_session_state()
-        return child.lua([[
+    local function render_with_session_state(window_name)
+        return child.lua(string.format(
+            [[
             local WindowDecoration = require("agentic.ui.window_decoration")
             local Config = require("agentic.config")
 
@@ -266,40 +287,79 @@ describe("WindowDecoration.render_header", function()
             vim.api.nvim_win_set_buf(0, bufnr)
 
             Config.headers = Config.headers or {}
-            Config.headers.chat = function(parts, session_state)
+            Config.headers.%s = function(parts, session_state)
                 _G.recorded_header_marker =
                     session_state and session_state.marker or nil
                 return parts.title
             end
 
-            Config.windows.chat.buffer_name = function(parts, session_state)
+            Config.windows.%s.buffer_name = function(parts, session_state)
                 _G.recorded_buffer_name_marker =
                     session_state and session_state.marker or nil
-                return "chat-buf-name"
+                return "%s-buf-name"
             end
 
             local session_state = { marker = "SS_MARKER" }
-            WindowDecoration.render_header(bufnr, "chat", nil, session_state)
+            WindowDecoration.render_header(bufnr, "%s", nil, session_state)
 
             return bufnr
-        ]])
+        ]],
+            window_name,
+            window_name,
+            window_name,
+            window_name
+        ))
     end
 
     it("passes session_state as 2nd arg to header function", function()
-        render_with_session_state()
+        render_with_session_state("chat")
         child.flush()
 
         assert.equal("SS_MARKER", child.lua_get("_G.recorded_header_marker"))
     end)
 
     it("passes session_state as 2nd arg to buffer_name function", function()
-        render_with_session_state()
+        render_with_session_state("chat")
         child.flush()
 
         assert.equal(
             "SS_MARKER",
             child.lua_get("_G.recorded_buffer_name_marker")
         )
+    end)
+
+    it("passes session_state as 2nd arg to input header function", function()
+        render_with_session_state("input")
+        child.flush()
+
+        assert.equal("SS_MARKER", child.lua_get("_G.recorded_header_marker"))
+    end)
+
+    it(
+        "passes session_state as 2nd arg to input buffer_name function",
+        function()
+            render_with_session_state("input")
+            child.flush()
+
+            assert.equal(
+                "SS_MARKER",
+                child.lua_get("_G.recorded_buffer_name_marker")
+            )
+        end
+    )
+
+    it("passes nil session_state to non-chat header function", function()
+        render_with_session_state("code")
+        child.flush()
+
+        assert.is_true(child.lua_get("_G.recorded_header_marker == nil"))
+    end)
+
+    it("passes nil session_state to non-chat buffer_name function", function()
+        render_with_session_state("code")
+        child.flush()
+
+        assert.is_true(child.lua_get("_G.recorded_buffer_name_marker == nil"))
     end)
 
     it("legacy single-arg header fn still works", function()

--- a/lua/agentic/ui/window_decoration.test.lua
+++ b/lua/agentic/ui/window_decoration.test.lua
@@ -301,6 +301,44 @@ describe("WindowDecoration._build_default_header", function()
         assert.equal("Agentic Chat | Sonnet - Ask (1K/200K)", text)
     end)
 
+    it("omits provider and mode segments when names are empty", function()
+        --- @type any
+        local stub = {
+            get_provider_name = function()
+                return ""
+            end,
+            get_model_name = function()
+                return "Sonnet"
+            end,
+            get_mode_name = function()
+                return ""
+            end,
+            get_context_used = function()
+                return nil
+            end,
+            get_context_size = function()
+                return nil
+            end,
+            get_cost_amount_raw = function()
+                return nil
+            end,
+            get_cost_amount = function()
+                return nil
+            end,
+            get_cost_currency = function()
+                return nil
+            end,
+        }
+
+        local text = WindowDecoration._build_default_header(
+            "chat",
+            { title = "Agentic Chat" },
+            stub
+        )
+
+        assert.equal("Agentic Chat | Sonnet", text)
+    end)
+
     it("omits the mode segment when mode name is nil", function()
         --- @type any
         local stub = {

--- a/lua/agentic/ui/window_decoration.test.lua
+++ b/lua/agentic/ui/window_decoration.test.lua
@@ -130,6 +130,118 @@ describe("WindowDecoration._set_buffer_name", function()
     end)
 end)
 
+describe("WindowDecoration._build_default_header", function()
+    --- @type agentic.ui.WindowDecoration
+    local WindowDecoration
+
+    before_each(function()
+        package.loaded["agentic.ui.window_decoration"] = nil
+        WindowDecoration = require("agentic.ui.window_decoration")
+    end)
+
+    --- Stub session_state exposing only the getters the header consumes.
+    --- @param cost_raw number|nil Cumulative cost; nil/0 omits the cost segment
+    --- @return agentic.acp.SessionState
+    local function fake_session_state(cost_raw)
+        --- @type any
+        local stub = {
+            get_provider_name = function()
+                return "Claude"
+            end,
+            get_model_name = function()
+                return "Sonnet"
+            end,
+            get_mode_name = function()
+                return "Ask"
+            end,
+            get_context_used = function()
+                return "1K"
+            end,
+            get_context_size = function()
+                return "200K"
+            end,
+            get_cost_amount_raw = function()
+                return cost_raw
+            end,
+            get_cost_amount = function()
+                return cost_raw and string.format("%.2f", cost_raw) or nil
+            end,
+        }
+        return stub
+    end
+
+    it("builds rich chat header without any key-hint suffix", function()
+        -- suffix is present but the chat panel must ignore it; the hints
+        -- belong on the input header.
+        local parts =
+            { title = "Agentic Chat", suffix = "change mode: <S-Tab>" }
+
+        local text = WindowDecoration._build_default_header(
+            "chat",
+            parts,
+            fake_session_state(0.5)
+        )
+
+        assert.equal(
+            "Agentic Chat | Claude - Sonnet - Ask (1K/200K) $0.50",
+            text
+        )
+    end)
+
+    it("omits cost segment when cost is nil", function()
+        local parts = { title = "Agentic Chat" }
+
+        local text = WindowDecoration._build_default_header(
+            "chat",
+            parts,
+            fake_session_state(nil)
+        )
+
+        assert.equal("Agentic Chat | Claude - Sonnet - Ask (1K/200K)", text)
+    end)
+
+    it("omits cost segment when cost is zero", function()
+        local parts = { title = "Agentic Chat" }
+
+        local text = WindowDecoration._build_default_header(
+            "chat",
+            parts,
+            fake_session_state(0)
+        )
+
+        assert.equal("Agentic Chat | Claude - Sonnet - Ask (1K/200K)", text)
+    end)
+
+    it("keeps the input header carrying both key hints", function()
+        local parts =
+            { title = "Prompt", suffix = "submit: <C-s> change mode: <S-Tab>" }
+
+        local text = WindowDecoration._build_default_header(
+            "input",
+            parts,
+            fake_session_state(0.5)
+        )
+
+        assert.equal("Prompt | submit: <C-s> change mode: <S-Tab>", text)
+    end)
+
+    it("falls back to plain concat when session_state is nil", function()
+        local chat = WindowDecoration._build_default_header(
+            "chat",
+            { title = "Agentic Chat", suffix = "change mode: <S-Tab>" },
+            nil
+        )
+        assert.equal("Agentic Chat | change mode: <S-Tab>", chat)
+
+        local input = WindowDecoration._build_default_header(
+            "input",
+            { title = "Prompt", suffix = "submit: <C-s>" },
+            nil
+        )
+        assert.equal("Prompt | submit: <C-s>", input)
+    end)
+end)
+
 describe("WindowDecoration.render_header", function()
     local child = Child:new()
 

--- a/lua/agentic/ui/window_decoration.test.lua
+++ b/lua/agentic/ui/window_decoration.test.lua
@@ -142,8 +142,16 @@ describe("WindowDecoration._build_default_header", function()
     --- Stub session_state exposing only the getters the header consumes.
     --- @param cost_raw number|nil Cumulative cost; nil/0 omits the cost segment
     --- @param currency string|nil Cost currency
+    --- @param context { used: string|nil, size: string|nil }|nil Overrides the
+    ---   human-readable context getters; defaults to "1K"/"200K"
     --- @return agentic.acp.SessionState
-    local function fake_session_state(cost_raw, currency)
+    local function fake_session_state(cost_raw, currency, context)
+        --- @type string|nil, string|nil
+        local used, size = "1K", "200K"
+        if context ~= nil then
+            used = context.used
+            size = context.size
+        end
         --- @type any
         local stub = {
             get_provider_name = function()
@@ -156,10 +164,10 @@ describe("WindowDecoration._build_default_header", function()
                 return "Ask"
             end,
             get_context_used = function()
-                return "1K"
+                return used
             end,
             get_context_size = function()
-                return "200K"
+                return size
             end,
             get_cost_amount_raw = function()
                 return cost_raw
@@ -229,6 +237,30 @@ describe("WindowDecoration._build_default_header", function()
         )
 
         assert.equal("Agentic Chat | Claude - Sonnet - Ask (1K/200K)", text)
+    end)
+
+    it("omits usage segment when context is not reported yet", function()
+        local parts = { title = "Agentic Chat" }
+
+        local text = WindowDecoration._build_default_header(
+            "chat",
+            parts,
+            fake_session_state(nil, nil, { used = nil, size = nil })
+        )
+
+        assert.equal("Agentic Chat | Claude - Sonnet - Ask", text)
+    end)
+
+    it("omits usage segment when only one usage value is present", function()
+        local parts = { title = "Agentic Chat" }
+
+        local text = WindowDecoration._build_default_header(
+            "chat",
+            parts,
+            fake_session_state(nil, nil, { used = "1K", size = nil })
+        )
+
+        assert.equal("Agentic Chat | Claude - Sonnet - Ask", text)
     end)
 
     it("keeps the input header carrying both key hints", function()

--- a/lua/agentic/ui/window_decoration.test.lua
+++ b/lua/agentic/ui/window_decoration.test.lua
@@ -144,7 +144,7 @@ describe("WindowDecoration.render_header", function()
     --- Build a buffer displayed in a window, install header + buffer_name
     --- function configs that record their 2nd arg, then render_header with a
     --- session_state carrying a unique marker. Returns recorded markers.
-    --- @return table recorded { header = any, buffer_name = any, header_text = string }
+    --- @return integer bufnr the buffer rendered into; recorded markers are read via _G globals
     local function render_with_session_state()
         return child.lua([[
             local WindowDecoration = require("agentic.ui.window_decoration")

--- a/lua/agentic/ui/window_decoration.test.lua
+++ b/lua/agentic/ui/window_decoration.test.lua
@@ -263,6 +263,82 @@ describe("WindowDecoration._build_default_header", function()
         assert.equal("Agentic Chat | Claude - Sonnet - Ask", text)
     end)
 
+    it("omits the provider segment when provider name is nil", function()
+        --- @type any
+        local stub = {
+            get_provider_name = function()
+                return nil
+            end,
+            get_model_name = function()
+                return "Sonnet"
+            end,
+            get_mode_name = function()
+                return "Ask"
+            end,
+            get_context_used = function()
+                return "1K"
+            end,
+            get_context_size = function()
+                return "200K"
+            end,
+            get_cost_amount_raw = function()
+                return nil
+            end,
+            get_cost_amount = function()
+                return nil
+            end,
+            get_cost_currency = function()
+                return nil
+            end,
+        }
+
+        local text = WindowDecoration._build_default_header(
+            "chat",
+            { title = "Agentic Chat" },
+            stub
+        )
+
+        assert.equal("Agentic Chat | Sonnet - Ask (1K/200K)", text)
+    end)
+
+    it("omits the mode segment when mode name is nil", function()
+        --- @type any
+        local stub = {
+            get_provider_name = function()
+                return "Claude"
+            end,
+            get_model_name = function()
+                return "Sonnet"
+            end,
+            get_mode_name = function()
+                return nil
+            end,
+            get_context_used = function()
+                return nil
+            end,
+            get_context_size = function()
+                return nil
+            end,
+            get_cost_amount_raw = function()
+                return nil
+            end,
+            get_cost_amount = function()
+                return nil
+            end,
+            get_cost_currency = function()
+                return nil
+            end,
+        }
+
+        local text = WindowDecoration._build_default_header(
+            "chat",
+            { title = "Agentic Chat" },
+            stub
+        )
+
+        assert.equal("Agentic Chat | Claude - Sonnet", text)
+    end)
+
     it("keeps the input header carrying both key hints", function()
         local parts =
             { title = "Prompt", suffix = "submit: <C-s> change mode: <S-Tab>" }

--- a/lua/agentic/ui/window_decoration.test.lua
+++ b/lua/agentic/ui/window_decoration.test.lua
@@ -1,5 +1,6 @@
 --- @diagnostic disable: invisible
 local assert = require("tests.helpers.assert")
+local Child = require("tests.helpers.child")
 
 local function normalize(p)
     return vim.fn.resolve(vim.fn.fnamemodify(p, ":p"))
@@ -126,5 +127,94 @@ describe("WindowDecoration._set_buffer_name", function()
         WindowDecoration._set_buffer_name(bufnr, name)
 
         assert_buf_name(name, bufnr)
+    end)
+end)
+
+describe("WindowDecoration.render_header", function()
+    local child = Child:new()
+
+    before_each(function()
+        child.setup()
+    end)
+
+    after_each(function()
+        child.stop()
+    end)
+
+    --- Build a buffer displayed in a window, install header + buffer_name
+    --- function configs that record their 2nd arg, then render_header with a
+    --- session_state carrying a unique marker. Returns recorded markers.
+    --- @return table recorded { header = any, buffer_name = any, header_text = string }
+    local function render_with_session_state()
+        return child.lua([[
+            local WindowDecoration = require("agentic.ui.window_decoration")
+            local Config = require("agentic.config")
+
+            local bufnr = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_win_set_buf(0, bufnr)
+
+            Config.headers = Config.headers or {}
+            Config.headers.chat = function(parts, session_state)
+                _G.recorded_header_marker =
+                    session_state and session_state.marker or nil
+                return parts.title
+            end
+
+            Config.windows.chat.buffer_name = function(parts, session_state)
+                _G.recorded_buffer_name_marker =
+                    session_state and session_state.marker or nil
+                return "chat-buf-name"
+            end
+
+            local session_state = { marker = "SS_MARKER" }
+            WindowDecoration.render_header(bufnr, "chat", nil, session_state)
+
+            return bufnr
+        ]])
+    end
+
+    it("passes session_state as 2nd arg to header function", function()
+        render_with_session_state()
+        child.flush()
+
+        assert.equal("SS_MARKER", child.lua_get("_G.recorded_header_marker"))
+    end)
+
+    it("passes session_state as 2nd arg to buffer_name function", function()
+        render_with_session_state()
+        child.flush()
+
+        assert.equal(
+            "SS_MARKER",
+            child.lua_get("_G.recorded_buffer_name_marker")
+        )
+    end)
+
+    it("legacy single-arg header fn still works", function()
+        child.lua([[
+            local WindowDecoration = require("agentic.ui.window_decoration")
+            local Config = require("agentic.config")
+
+            local bufnr = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_win_set_buf(0, bufnr)
+
+            Config.headers = Config.headers or {}
+            -- Single-arg fn: ignores the new 2nd arg entirely.
+            Config.headers.chat = function(parts)
+                _G.legacy_returned = parts.title
+                return parts.title
+            end
+
+            WindowDecoration.render_header(
+                bufnr,
+                "chat",
+                nil,
+                { marker = "SS_MARKER" }
+            )
+        ]])
+        child.flush()
+
+        local returned = child.lua_get("_G.legacy_returned")
+        assert.is_true(returned:find("Agentic Chat", 1, true) ~= nil)
     end)
 end)


### PR DESCRIPTION
Allow users to consume standard Session data such: 
- model
- mode
- thought level
- provider name 
- context window size and usage 
- Costs

---

- related #228 