### PR TITLE
fix: resolve command to full exec path for Windows `PATHEXT`

### DIFF
--- a/lua/agentic/acp/acp_transport.lua
+++ b/lua/agentic/acp/acp_transport.lua
@@ -77,6 +77,15 @@ function M.create_stdio_transport(config, callbacks)
     function transport:start()
         callbacks.on_state_change("connecting")
 
+        -- Resolve command to full executable path for Windows OS PATHEXT support
+        -- vim.fn.exepath handles .CMD, .EXE and .BAT extensions on Windows
+        local command = vim.fn.exepath(vim.fn.expand(config.command))
+        if command == "" then
+            -- if exepath returns empty, the command is not found in PATH
+            callbacks.on_state_change("error")
+            error(string.format("Command not found: %s", config.command))
+        end
+
         local stdin = uv.new_pipe(false)
         local stdout = uv.new_pipe(false)
         local stderr = uv.new_pipe(false)
@@ -116,7 +125,7 @@ function M.create_stdio_transport(config, callbacks)
         end
 
         --- @diagnostic disable-next-line: missing-fields
-        local handle, pid = uv.spawn(config.command, {
+        local handle, pid = uv.spawn(command, {
             args = args,
             env = final_env,
             stdio = { stdin, stdout, stderr },
@@ -183,12 +192,21 @@ function M.create_stdio_transport(config, callbacks)
             end
         end)
 
-        Logger.debug("Spawned ACP agent process with PID ", tostring(pid))
-
         if not handle then
+            stdin:close()
+            stdout:close()
+            stderr:close()
+
             callbacks.on_state_change("error")
-            error("Failed to spawn ACP agent process")
+            error(
+                string.format(
+                    "Failed to spawn ACP agent process: %s",
+                    tostring(pid)
+                )
+            )
         end
+
+        Logger.debug("Spawned ACP agent process with PID ", tostring(pid))
 
         self.process = handle
         self.pid = tonumber(pid)


### PR DESCRIPTION
resolves #270 

On Windows, `uv.spawn()` does not automatically apply `PATHEXT` resolution. This means when the plugin tries to spawn provider commands like `claude-agent-acp`, it fails on Windows because the actual exectuable is `claude-agent-acp.CMD` but `uv.spawn()` does not know to look for the `.CMD` extension.

## Issue
The raw command name from config is being passed directly.

## Solution
`vim.fn.exepath()` function provides a cross-platform command resolver, which includes the extension on Windows.

## Risk
Low, `vim.fn.exepath()` is available in all supported Neovim versions (`0.11+`). Full paths are accepted by `uv.spawn()`.