### PR TITLE
fix(acp): preserve session cost across partial usage updates

### DIFF
--- a/.agents/skills/agentic-testing/SKILL.md
+++ b/.agents/skills/agentic-testing/SKILL.md
@@ -28,8 +28,18 @@ For every bug fix or behavioral change:
 4. Implement the minimum code to pass.
 5. Re-run `make test-file FILE=<path>`.
 6. Run the relevant full check.
-7. After adding or changing tests, run `make test` and verify reported marks for
-   the changed file match the number of `it()` blocks.
+7. After adding or changing tests, reconcile the case count. This guards against
+   silently dropped OR unexpectedly generated tests. Both are failures.
+   1. Compute EXPECTED cases by reading the file, not grepping:
+      - each static `it()` = 1 case
+      - each `it()` inside a `for`/`each`/table-driven loop = the loop's
+        iteration count (a single `it(` line can emit many cases, or zero)
+      - a grep of `it(` is a lower bound, never the answer
+   2. Read ACTUAL from `Total number of cases: N` in the
+      `make test-file FILE=<path>` output.
+   3. EXPECTED MUST equal ACTUAL. Mismatch = a test was dropped, a loop is empty,
+      or a generator misfired; stop and reconcile before claiming green.
+      Eyeballing ACTUAL alone is NOT the check - you must derive EXPECTED first.
 
 Pure refactors, formatting, and docs can skip red/green, but say that in the PR.
 

--- a/lua/agentic/acp/session_state.lua
+++ b/lua/agentic/acp/session_state.lua
@@ -169,13 +169,22 @@ function SessionState:get_provider_name()
     return self._provider_name
 end
 
+--- Merges new-over-existing so a partial `usage_update` (Claude streams
+--- cost-less updates before the cost-bearing one) does not wipe known values.
+--- Absent/null `used`/`size`/`cost` keys survive; a malformed cost object
+--- without a numeric `amount` is rejected rather than overwriting a good cost.
 --- @param update agentic.acp.UsageUpdate
 function SessionState:set_usage(update)
-    self._usage = {
-        used = update.used,
-        size = update.size,
-        cost = update.cost,
-    }
+    local fields = { used = update.used, size = update.size }
+
+    if
+        type(update.cost) == "table"
+        and type(update.cost.amount) == "number"
+    then
+        fields.cost = update.cost
+    end
+
+    self._usage = vim.tbl_extend("force", self._usage or {}, fields)
 end
 
 function SessionState:clear()

--- a/lua/agentic/acp/session_state.test.lua
+++ b/lua/agentic/acp/session_state.test.lua
@@ -142,7 +142,17 @@ describe("agentic.acp.SessionState", function()
             assert.equal(state:get_context_size_raw(), 0)
         end)
 
-        it("overwrites prior usage on a later set_usage", function()
+        it("overwrites used/size on a later set_usage", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            state:set_usage({ used = 1, size = 2 })
+            state:set_usage({ used = 5, size = 6 })
+
+            assert.equal(state:get_context_used_raw(), 5)
+            assert.equal(state:get_context_size_raw(), 6)
+        end)
+
+        it("preserves prior cost when a later update omits cost", function()
             local state = SessionState:new(config_provider_fake(), "Claude")
 
             state:set_usage({
@@ -152,10 +162,22 @@ describe("agentic.acp.SessionState", function()
             })
             state:set_usage({ used = 5, size = 6 })
 
-            assert.equal(state:get_context_used_raw(), 5)
-            assert.equal(state:get_context_size_raw(), 6)
-            assert.is_nil(state:get_cost_amount_raw())
-            assert.is_nil(state:get_cost_currency())
+            assert.equal(state:get_cost_amount_raw(), 9)
+            assert.equal(state:get_cost_currency(), "EUR")
+        end)
+
+        it("preserves prior cost when a later cost has no amount", function()
+            local state = SessionState:new(config_provider_fake(), "Claude")
+
+            state:set_usage({
+                used = 1,
+                size = 2,
+                cost = { amount = 9, currency = "EUR" },
+            })
+            state:set_usage({ used = 5, size = 6, cost = { currency = "USD" } })
+
+            assert.equal(state:get_cost_amount_raw(), 9)
+            assert.equal(state:get_cost_currency(), "EUR")
         end)
     end)
 

--- a/lua/agentic/ui/diagnostics_list.test.lua
+++ b/lua/agentic/ui/diagnostics_list.test.lua
@@ -330,7 +330,7 @@ describe("agentic.ui.DiagnosticsList", function()
         end)
 
         it("truncates long lines with ellipsis to fit window width", function()
-            vim.api.nvim_win_set_width(winid, 40)
+            vim.api.nvim_win_set_config(winid, { width = 40 })
 
             diagnostics_list:add(create_diagnostic({
                 message = "A very long diagnostic message that should definitely be truncated to fit",

--- a/tests/integration/test_tool_block_borders.lua
+++ b/tests/integration/test_tool_block_borders.lua
@@ -66,7 +66,7 @@ describe("Tool block borders", function()
         local chat_winid = widget.win_nrs.chat
         ---@cast chat_winid integer
         vim.wo[chat_winid].scrolloff = 0
-        vim.api.nvim_win_set_width(chat_winid, 24)
+        vim.api.nvim_win_set_config(chat_winid, { width = 24 })
     end
 
     --- @param tool_call_id string


### PR DESCRIPTION
- claude streams cost-less usage updates before cost
- blind overwrite wiped cost, header flickered
- shallow-merge usage, keep prior on partial update
- reject cost object without numeric amount
