### PR TITLE
refactor: deduplicate buf_helpers keymap and option handling

### DIFF
--- a/lua/agentic/utils/buf_helpers.lua
+++ b/lua/agentic/utils/buf_helpers.lua
@@ -6,7 +6,9 @@ local BufHelpers = {}
 --- @generic T
 --- @param bufnr integer
 --- @param callback fun(bufnr: integer): T|nil
---- @return T|false result false when the buffer is invalid or the callback errors
+--- @return T|false result the callback's own result, returned unchanged, or `false`
+--- when the buffer is invalid or the callback errors. A callback that itself
+--- returns `false` is therefore indistinguishable from those two failures.
 function BufHelpers.with_modifiable(bufnr, callback)
     if not vim.api.nvim_buf_is_valid(bufnr) then
         return false

--- a/lua/agentic/utils/buf_helpers.lua
+++ b/lua/agentic/utils/buf_helpers.lua
@@ -3,13 +3,10 @@ local Logger = require("agentic.utils.logger")
 --- @class agentic.utils.BufHelpers
 local BufHelpers = {}
 
---- Executes a callback with the buffer set to modifiable.
---- Returns false when the buffer is invalid or the callback errors.
---- Otherwise returns the callback's own return value.
 --- @generic T
 --- @param bufnr integer
 --- @param callback fun(bufnr: integer): T|nil
---- @return T|false result
+--- @return T|false result false when the buffer is invalid or the callback errors
 function BufHelpers.with_modifiable(bufnr, callback)
     if not vim.api.nvim_buf_is_valid(bufnr) then
         return false
@@ -52,6 +49,21 @@ function BufHelpers.execute_on_buffer(bufnr, callback)
     end)
 end
 
+--- `buffer` was renamed to `buf` in neovim#38360 (0.12.0 final, `buffer` removed
+--- in 0.15). Gated on 0.12.1 so 0.12.0-dev nightlies built before the rename —
+--- which answer `has("nvim-0.12") == 1` but reject `buf` — still work.
+--- @param opts table
+--- @param bufnr integer
+local function set_buffer_opt(opts, bufnr)
+    --- @diagnostic disable: inject-field
+    if vim.fn.has("nvim-0.12.1") == 1 then
+        opts.buf = bufnr
+    else
+        opts.buffer = bufnr
+    end
+    --- @diagnostic enable: inject-field
+end
+
 --- Sets a keymap for a specific buffer.
 --- @param bufnr integer
 --- @param mode string|string[]
@@ -60,17 +72,7 @@ end
 --- @param opts vim.keymap.set.Opts|nil
 function BufHelpers.keymap_set(bufnr, mode, lhs, rhs, opts)
     opts = opts or {}
-    -- `buffer` was renamed to `buf` in neovim#38360, shipped in 0.12.0 final.
-    -- Gate on 0.12.1 to skip 0.12.0-dev nightlies built before the rename
-    -- (they answer `has('nvim-0.12') == 1` but reject `buf`).
-    -- `buffer` is removed in 0.15.
-    --- @diagnostic disable: inject-field
-    if vim.fn.has("nvim-0.12.1") == 1 then
-        opts.buf = bufnr
-    else
-        opts.buffer = bufnr
-    end
-    --- @diagnostic enable: inject-field
+    set_buffer_opt(opts, bufnr)
     vim.keymap.set(mode, lhs, rhs, opts)
 end
 
@@ -80,86 +82,51 @@ end
 --- @param lhs string
 function BufHelpers.keymap_del(bufnr, mode, lhs)
     --- @type table
-    local opts
-    -- See keymap_set for the buffer/buf rename rationale.
-    if vim.fn.has("nvim-0.12.1") == 1 then
-        opts = { buf = bufnr }
-    else
-        opts = { buffer = bufnr }
-    end
+    local opts = {}
+    set_buffer_opt(opts, bufnr)
     pcall(vim.keymap.del, mode, lhs, opts)
 end
 
---- Sets multiple keymaps from a KeymapValue config entry for a specific buffer.
---- Normalizes the config value (string, string[], or array of string/KeymapEntry)
---- and calls keymap_set for each binding.
+--- Normalizes a KeymapValue (string, string[], or array of string/KeymapEntry)
+--- into `(modes, lhs)` pairs.
+--- @param keymaps agentic.UserConfig.KeymapValue
+--- @param fn fun(modes: string|string[], lhs: string)
+local function each_keymap(keymaps, fn)
+    if type(keymaps) == "string" then
+        keymaps = { keymaps }
+    end
+
+    for _, key in ipairs(keymaps) do
+        if type(key) == "table" and key.mode then
+            fn(key.mode, key[1])
+        else
+            fn("n", key --[[@as string]])
+        end
+    end
+end
+
 --- @param keymaps agentic.UserConfig.KeymapValue
 --- @param bufnr integer
 --- @param callback fun():any
 --- @param opts vim.keymap.set.Opts|nil
 function BufHelpers.multi_keymap_set(keymaps, bufnr, callback, opts)
-    if type(keymaps) == "string" then
-        keymaps = { keymaps }
-    end
-
-    for _, key in ipairs(keymaps) do
-        --- @type string|string[]
-        local modes = "n"
-        --- @type string
-        local keymap
-
-        if type(key) == "table" and key.mode then
-            modes = key.mode
-            keymap = key[1]
-        else
-            keymap = key --[[@as string]]
-        end
-
-        BufHelpers.keymap_set(bufnr, modes, keymap, callback, opts)
-    end
+    each_keymap(keymaps, function(modes, lhs)
+        BufHelpers.keymap_set(bufnr, modes, lhs, callback, opts)
+    end)
 end
 
---- Deletes multiple keymaps from a KeymapValue config entry for a specific buffer.
 --- @param keymaps agentic.UserConfig.KeymapValue
 --- @param bufnr integer
 function BufHelpers.multi_keymap_del(keymaps, bufnr)
-    if type(keymaps) == "string" then
-        keymaps = { keymaps }
-    end
-
-    for _, key in ipairs(keymaps) do
-        --- @type string|string[]
-        local modes = "n"
-        --- @type string
-        local keymap
-
-        if type(key) == "table" and key.mode then
-            modes = key.mode
-            keymap = key[1]
-        else
-            keymap = key --[[@as string]]
-        end
-
-        BufHelpers.keymap_del(bufnr, modes, keymap)
-    end
+    each_keymap(keymaps, function(modes, lhs)
+        BufHelpers.keymap_del(bufnr, modes, lhs)
+    end)
 end
 
 --- @param bufnr integer
 --- @return boolean
 function BufHelpers.is_buffer_empty(bufnr)
-    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
-
-    if #lines == 0 then
-        return true
-    end
-
-    -- Check if buffer contains only whitespace or a single empty line
-    if #lines == 1 and lines[1]:match("^%s*$") then
-        return true
-    end
-
-    -- Check if all lines are whitespace
-    for _, line in ipairs(lines) do
+    for _, line in ipairs(vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)) do
         if line:match("%S") then
             return false
         end

--- a/lua/agentic/utils/buf_helpers.test.lua
+++ b/lua/agentic/utils/buf_helpers.test.lua
@@ -202,8 +202,19 @@ describe("BufHelpers", function()
         local keymap_set_stub
         --- @type TestStub
         local has_stub
+        --- @type integer[]
+        local created_bufnrs
+
+        --- Tracked so `after_each` deletes them even when an assertion fails.
+        --- @return integer bufnr
+        local function create_tracked_buf()
+            local bufnr = vim.api.nvim_create_buf(false, true)
+            created_bufnrs[#created_bufnrs + 1] = bufnr
+            return bufnr
+        end
 
         before_each(function()
+            created_bufnrs = {}
             keymap_set_stub = spy.stub(vim.keymap, "set")
             has_stub = spy.stub(vim.fn, "has")
             has_stub:returns(1)
@@ -212,10 +223,16 @@ describe("BufHelpers", function()
         after_each(function()
             keymap_set_stub:revert()
             has_stub:revert()
+
+            for _, bufnr in ipairs(created_bufnrs) do
+                if vim.api.nvim_buf_is_valid(bufnr) then
+                    vim.api.nvim_buf_delete(bufnr, { force = true })
+                end
+            end
         end)
 
         it("sets a single string keymap in normal mode", function()
-            local bufnr = vim.api.nvim_create_buf(false, true)
+            local bufnr = create_tracked_buf()
             local callback = function() end
 
             BufHelpers.multi_keymap_set("x", bufnr, callback)
@@ -224,12 +241,10 @@ describe("BufHelpers", function()
             assert.equal("n", keymap_set_stub.calls[1][1])
             assert.equal("x", keymap_set_stub.calls[1][2])
             assert.equal(callback, keymap_set_stub.calls[1][3])
-
-            vim.api.nvim_buf_delete(bufnr, { force = true })
         end)
 
         it("sets array entries with configured modes", function()
-            local bufnr = vim.api.nvim_create_buf(false, true)
+            local bufnr = create_tracked_buf()
 
             BufHelpers.multi_keymap_set({
                 "x",
@@ -241,12 +256,10 @@ describe("BufHelpers", function()
             assert.equal("x", keymap_set_stub.calls[1][2])
             assert.same({ "i", "v" }, keymap_set_stub.calls[2][1])
             assert.equal("y", keymap_set_stub.calls[2][2])
-
-            vim.api.nvim_buf_delete(bufnr, { force = true })
         end)
 
         it("forwards the caller's opts to every binding", function()
-            local bufnr = vim.api.nvim_create_buf(false, true)
+            local bufnr = create_tracked_buf()
 
             BufHelpers.multi_keymap_set(
                 { "x", "y" },
@@ -258,8 +271,6 @@ describe("BufHelpers", function()
             assert.equal(2, keymap_set_stub.call_count)
             assert.equal("shared", keymap_set_stub.calls[1][4].desc)
             assert.equal("shared", keymap_set_stub.calls[2][4].desc)
-
-            vim.api.nvim_buf_delete(bufnr, { force = true })
         end)
     end)
 

--- a/lua/agentic/utils/buf_helpers.test.lua
+++ b/lua/agentic/utils/buf_helpers.test.lua
@@ -115,10 +115,9 @@ describe("BufHelpers", function()
             has_stub:revert()
         end)
 
-        -- Regression: 0.12.0-dev nightlies built before neovim#38360 (the
-        -- `buffer` -> `buf` rename) report `has('nvim-0.12') == 1` but
-        -- reject `buf` with `invalid key: buf`. Gate on 0.12.1, the first
-        -- stable that ships `buf`.
+        -- Regression: 0.12.0-dev nightlies built before neovim#38360 (`buffer`
+        -- -> `buf` rename) report `has('nvim-0.12') == 1` but reject `buf` with
+        -- `invalid key: buf`. Gate on 0.12.1, first stable shipping `buf`.
         it("uses `buffer` opt on Neovim < 0.12.1", function()
             has_stub:invokes(function(feature)
                 return feature == "nvim-0.12.1" and 0 or 1
@@ -166,7 +165,7 @@ describe("BufHelpers", function()
             has_stub:revert()
         end)
 
-        -- See keymap_set tests for the 0.12.0-dev / 0.12.1 rename rationale.
+        -- 0.12.0-dev / 0.12.1 rename rationale: see keymap_set tests.
         it("uses `buffer` opt on Neovim < 0.12.1", function()
             has_stub:invokes(function(feature)
                 return feature == "nvim-0.12.1" and 0 or 1
@@ -193,6 +192,72 @@ describe("BufHelpers", function()
             local opts = keymap_del_stub.calls[1][3]
             assert.equal(bufnr, opts.buf)
             assert.is_nil(opts.buffer)
+
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end)
+    end)
+
+    describe("multi_keymap_set", function()
+        --- @type TestStub
+        local keymap_set_stub
+        --- @type TestStub
+        local has_stub
+
+        before_each(function()
+            keymap_set_stub = spy.stub(vim.keymap, "set")
+            has_stub = spy.stub(vim.fn, "has")
+            has_stub:returns(1)
+        end)
+
+        after_each(function()
+            keymap_set_stub:revert()
+            has_stub:revert()
+        end)
+
+        it("sets a single string keymap in normal mode", function()
+            local bufnr = vim.api.nvim_create_buf(false, true)
+            local callback = function() end
+
+            BufHelpers.multi_keymap_set("x", bufnr, callback)
+
+            assert.equal(1, keymap_set_stub.call_count)
+            assert.equal("n", keymap_set_stub.calls[1][1])
+            assert.equal("x", keymap_set_stub.calls[1][2])
+            assert.equal(callback, keymap_set_stub.calls[1][3])
+
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end)
+
+        it("sets array entries with configured modes", function()
+            local bufnr = vim.api.nvim_create_buf(false, true)
+
+            BufHelpers.multi_keymap_set({
+                "x",
+                { "y", mode = { "i", "v" } },
+            }, bufnr, function() end)
+
+            assert.equal(2, keymap_set_stub.call_count)
+            assert.equal("n", keymap_set_stub.calls[1][1])
+            assert.equal("x", keymap_set_stub.calls[1][2])
+            assert.same({ "i", "v" }, keymap_set_stub.calls[2][1])
+            assert.equal("y", keymap_set_stub.calls[2][2])
+
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end)
+
+        it("forwards the caller's opts to every binding", function()
+            local bufnr = vim.api.nvim_create_buf(false, true)
+
+            BufHelpers.multi_keymap_set(
+                { "x", "y" },
+                bufnr,
+                function() end,
+                { desc = "shared" }
+            )
+
+            assert.equal(2, keymap_set_stub.call_count)
+            assert.equal("shared", keymap_set_stub.calls[1][4].desc)
+            assert.equal("shared", keymap_set_stub.calls[2][4].desc)
 
             vim.api.nvim_buf_delete(bufnr, { force = true })
         end)


### PR DESCRIPTION
- share one keymap normalization iterator
- share the buffer/buf version gate
- single-pass buffer emptiness check
- no behaviour change
- cover multi_keymap_set, previously untested
