### PR TITLE
feat: add window resize and lookup helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,22 @@ Subsystem-specific traps live in nested `AGENTS.md`. These apply everywhere:
   -> `buf` compatibility rationale.
 - **FORBIDDEN: `vim.api.nvim_list_wins()` for tab-scoped lookups** -> use
   `vim.api.nvim_tabpage_list_wins(self.tab_page_id)`.
+- **FORBIDDEN: `vim.fn.bufwinid`** -> use `BufHelpers.find_visible_win`.
+  `bufwinid` "Only deals with the current tabpage"
+  (`$VIMRUNTIME/doc/vimfn.txt`), so it finds nothing for a session visible
+  elsewhere, and it returns the hidden chat float. The helper filters
+  non-focusable and `hide` windows and takes an optional tabpage. Regression:
+  `lua/agentic/utils/buf_helpers.test.lua::"restricts the search to a given tabpage"`.
+- **FORBIDDEN: `nvim_win_set_width` / `nvim_win_set_height`** -> use
+  `BufHelpers.win_set_width` / `BufHelpers.win_set_height`. Both are deprecated
+  on nightly for `nvim_win_resize` (0.13+ only), and CI runs a nightly matrix job,
+  so the call needs the helper's version gate. Coverage:
+  `lua/agentic/utils/buf_helpers.test.lua`.
+- **FORBIDDEN: bare `nvim_win_is_valid` on a handle held across an event
+  boundary** -> use `BufHelpers.is_win_usable`. On 0.11.x `tabclose` leaves
+  handles that answer valid but segfault in `nvim_win_close`; the helper also
+  requires a live tabpage. Bare validity stays fine for reads. Regression:
+  `lua/agentic/utils/buf_helpers.test.lua::"returns false for a valid window whose tabpage is gone"`.
 - **FORBIDDEN: `:set`-style writes for window-local options** -> use
   `vim.wo[winid][0].opt = val`, never `vim.wo[winid].opt = val` or
   `nvim_set_option_value(opt, val, { win = winid })`. `[0]` is the `:setlocal`

--- a/lua/agentic/utils/buf_helpers.lua
+++ b/lua/agentic/utils/buf_helpers.lua
@@ -37,6 +37,67 @@ function BufHelpers.start_insert_on_last_char()
     vim.cmd("startinsert!")
 end
 
+--- `focusable` is checked alongside `hide` because a focusable hidden float
+--- would otherwise win the lookup and absorb a winbar nobody can see.
+--- @param winid integer
+--- @param tabpage integer|nil
+--- @return boolean
+local function is_visible_win(winid, tabpage)
+    local config = vim.api.nvim_win_get_config(winid)
+    if not config.focusable or config.hide then
+        return false
+    end
+
+    if tabpage == nil then
+        return true
+    end
+
+    local ok, win_tab = pcall(vim.api.nvim_win_get_tabpage, winid)
+    return ok and win_tab == tabpage
+end
+
+--- Safe to act on: valid AND sitting in a live tabpage.
+---
+--- `nvim_win_is_valid` alone is not enough: on 0.11.x `tabclose` leaves handles that
+--- answer valid but segfault in `nvim_win_close`, and post-tabclose background updates
+--- reach exactly those. Use before any write on a handle held across an event boundary
+--- (`nvim_win_close`, `nvim_win_call`, `nvim_win_set_config`); bare validity is fine for
+--- reads and for deciding whether to open a new window.
+--- @param winid integer|nil
+--- @return boolean
+function BufHelpers.is_win_usable(winid)
+    if not winid or not vim.api.nvim_win_is_valid(winid) then
+        return false
+    end
+
+    local ok, win_tab = pcall(vim.api.nvim_win_get_tabpage, winid)
+    return ok and vim.api.nvim_tabpage_is_valid(win_tab)
+end
+
+--- Use instead of `vim.fn.bufwinid`, which only deals with the current tabpage and returns the hidden chat float.
+--- @param bufnr integer
+--- @param preferred_winid integer|nil The owner's own window, preferred over any other match
+--- @param tabpage integer|nil Restrict the search to this tabpage
+--- @return integer|nil winid
+function BufHelpers.find_visible_win(bufnr, preferred_winid, tabpage)
+    if
+        preferred_winid
+        and vim.api.nvim_win_is_valid(preferred_winid)
+        and vim.api.nvim_win_get_buf(preferred_winid) == bufnr
+        and is_visible_win(preferred_winid, tabpage)
+    then
+        return preferred_winid
+    end
+
+    for _, winid in ipairs(vim.fn.win_findbuf(bufnr)) do
+        if is_visible_win(winid, tabpage) then
+            return winid
+        end
+    end
+
+    return nil
+end
+
 --- @generic T
 --- @param bufnr integer
 --- @param callback fun(bufnr: integer): T|nil
@@ -123,6 +184,38 @@ function BufHelpers.multi_keymap_del(keymaps, bufnr)
     each_keymap(keymaps, function(modes, lhs)
         BufHelpers.keymap_del(bufnr, modes, lhs)
     end)
+end
+
+--- `nvim_win_set_width`/`_set_height` are deprecated for `nvim_win_resize`, which only exists on 0.13+.
+--- @param winid integer
+--- @param width integer -1 leaves the axis unchanged
+--- @param height integer -1 leaves the axis unchanged
+local function resize_win(winid, width, height)
+    if vim.fn.has("nvim-0.13") == 1 then
+        vim.api.nvim_win_resize(winid, width, height, {})
+        return
+    end
+
+    --- @diagnostic disable: deprecated
+    if width >= 0 then
+        vim.api.nvim_win_set_width(winid, width)
+    end
+    if height >= 0 then
+        vim.api.nvim_win_set_height(winid, height)
+    end
+    --- @diagnostic enable: deprecated
+end
+
+--- @param winid integer
+--- @param width integer
+function BufHelpers.win_set_width(winid, width)
+    resize_win(winid, width, -1)
+end
+
+--- @param winid integer
+--- @param height integer
+function BufHelpers.win_set_height(winid, height)
+    resize_win(winid, -1, height)
 end
 
 --- @param bufnr integer

--- a/lua/agentic/utils/buf_helpers.lua
+++ b/lua/agentic/utils/buf_helpers.lua
@@ -80,9 +80,12 @@ end
 --- @param tabpage integer|nil Restrict the search to this tabpage
 --- @return integer|nil winid
 function BufHelpers.find_visible_win(bufnr, preferred_winid, tabpage)
+    -- `is_win_usable`, not bare `nvim_win_is_valid`: the caller's handle crossed an
+    -- event boundary, so on 0.11.x it can be stale-valid in a dead tabpage. Without
+    -- the tabpage check an unscoped call (`tabpage == nil`) hands that handle back.
     if
         preferred_winid
-        and vim.api.nvim_win_is_valid(preferred_winid)
+        and BufHelpers.is_win_usable(preferred_winid)
         and vim.api.nvim_win_get_buf(preferred_winid) == bufnr
         and is_visible_win(preferred_winid, tabpage)
     then

--- a/lua/agentic/utils/buf_helpers.test.lua
+++ b/lua/agentic/utils/buf_helpers.test.lua
@@ -1,6 +1,21 @@
 local assert = require("tests.helpers.assert")
 local spy = require("tests.helpers.spy")
 
+--- Closes every tabpage absent from the baseline set, leaving the baseline
+--- untouched. Counting tabpages instead and closing the *current* one can shut a
+--- baseline tab while a test-created one survives.
+--- @param base_tabs table<integer, true>
+local function close_extra_tabs(base_tabs)
+    for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+        if not base_tabs[tab] and vim.api.nvim_tabpage_is_valid(tab) then
+            pcall(function()
+                vim.api.nvim_set_current_tabpage(tab)
+                vim.cmd("tabclose!")
+            end)
+        end
+    end
+end
+
 describe("BufHelpers", function()
     --- @type agentic.utils.BufHelpers
     local BufHelpers
@@ -323,17 +338,56 @@ describe("BufHelpers", function()
 
     describe("win_set_width / win_set_height", function()
         local winid
+        --- @type table<integer, true>
+        local base_tabs
+        --- @type TestStub[]
+        local stubs
+        --- `nvim_win_resize` is absent below 0.13 and `spy.stub` cannot restore an
+        --- absent field, so that one is swapped by hand and cleared here.
+        --- @type table<string, function|nil>
+        local swapped_api
+
+        --- Tracked so `after_each` reverts it even when an assertion throws.
+        --- @param target table
+        --- @param method string
+        --- @return TestStub
+        local function stub(target, method)
+            local s = spy.stub(target, method)
+            stubs[#stubs + 1] = s
+            return s
+        end
+
+        --- @param name string
+        --- @param fn function
+        local function swap_api(name, fn)
+            swapped_api[name] = vim.api[name]
+            --- @diagnostic disable-next-line: no-unknown, assign-type-mismatch
+            vim.api[name] = fn
+        end
 
         before_each(function()
+            stubs = {}
+            swapped_api = {}
+            base_tabs = {}
+            for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+                base_tabs[tab] = true
+            end
             vim.cmd("tabnew")
             vim.cmd("vsplit")
             winid = vim.api.nvim_get_current_win()
         end)
 
         after_each(function()
-            pcall(function()
-                vim.cmd("tabclose!")
-            end)
+            -- Reverted first: the cleanup below calls the very APIs these stub.
+            for _, s in ipairs(stubs) do
+                s:revert()
+            end
+            for name, original in pairs(swapped_api) do
+                --- @diagnostic disable-next-line: no-unknown, assign-type-mismatch
+                vim.api[name] = original
+            end
+
+            close_extra_tabs(base_tabs)
         end)
 
         it("resizes the window width on the running Neovim", function()
@@ -359,27 +413,18 @@ describe("BufHelpers", function()
         -- `nvim_win_set_width`/`_set_height` are deprecated on nightly for
         -- `nvim_win_resize`, which only exists on 0.13+. CI runs a nightly
         -- matrix job, so both branches stay reachable on every version.
-        -- `spy.stub` cannot restore an absent field, so the 0.13 branch uses a
-        -- saved original cleared by hand.
         it("calls nvim_win_resize on Neovim >= 0.13", function()
-            local has_stub = spy.stub(vim.fn, "has")
-            has_stub:invokes(function(feature)
+            stub(vim.fn, "has"):invokes(function(feature)
                 return feature == "nvim-0.13" and 1 or 0
             end)
 
-            local original_resize = vim.api.nvim_win_resize
             local calls = {}
-            --- @diagnostic disable-next-line: inject-field, duplicate-set-field
-            vim.api.nvim_win_resize = function(win, width, height, opts)
+            swap_api("nvim_win_resize", function(win, width, height, opts)
                 calls[#calls + 1] = { win, width, height, opts }
-            end
+            end)
 
             BufHelpers.win_set_width(winid, 20)
             BufHelpers.win_set_height(winid, 8)
-
-            --- @diagnostic disable-next-line: inject-field
-            vim.api.nvim_win_resize = original_resize
-            has_stub:revert()
 
             assert.equal(2, #calls)
             assert.equal(winid, calls[1][1])
@@ -390,18 +435,13 @@ describe("BufHelpers", function()
         end)
 
         it("falls back to the single-axis setters on Neovim < 0.13", function()
-            local has_stub = spy.stub(vim.fn, "has")
-            has_stub:returns(0)
+            stub(vim.fn, "has"):returns(0)
             --- @diagnostic disable-next-line: deprecated
-            local set_width_stub = spy.stub(vim.api, "nvim_win_set_width")
+            local set_width_stub = stub(vim.api, "nvim_win_set_width")
             --- @diagnostic disable-next-line: deprecated
-            local set_height_stub = spy.stub(vim.api, "nvim_win_set_height")
+            local set_height_stub = stub(vim.api, "nvim_win_set_height")
 
             BufHelpers.win_set_width(winid, 20)
-
-            set_width_stub:revert()
-            set_height_stub:revert()
-            has_stub:revert()
 
             assert.equal(1, set_width_stub.call_count)
             assert.equal(winid, set_width_stub.calls[1][1])
@@ -467,22 +507,54 @@ describe("BufHelpers", function()
 
     describe("find_visible_win", function()
         local bufnr
+        --- @type table<integer, true>
         local base_tabs
+        --- @type TestStub[]
+        local stubs
+        --- @type integer[]
+        local floats
+        local original_get_tabpage = vim.api.nvim_win_get_tabpage
+
+        --- Tracked so `after_each` reverts it even when an assertion throws.
+        --- @param target table
+        --- @param method string
+        --- @return TestStub
+        local function stub(target, method)
+            local s = spy.stub(target, method)
+            stubs[#stubs + 1] = s
+            return s
+        end
+
+        --- Tracked so `after_each` closes it even when an assertion throws.
+        --- @param config vim.api.keyset.win_config
+        --- @return integer winid
+        local function open_tracked_float(config)
+            local winid = vim.api.nvim_open_win(bufnr, false, config)
+            floats[#floats + 1] = winid
+            return winid
+        end
 
         before_each(function()
-            base_tabs = #vim.api.nvim_list_tabpages()
+            stubs = {}
+            floats = {}
+            base_tabs = {}
+            for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+                base_tabs[tab] = true
+            end
             bufnr = vim.api.nvim_create_buf(false, true)
         end)
 
         after_each(function()
-            while #vim.api.nvim_list_tabpages() > base_tabs do
-                local ok = pcall(function()
-                    vim.cmd("tabclose!")
-                end)
-                if not ok then
-                    break
-                end
+            -- Reverted first: the cleanup below calls the very APIs these stub.
+            for _, s in ipairs(stubs) do
+                s:revert()
             end
+
+            for _, winid in ipairs(floats) do
+                pcall(vim.api.nvim_win_close, winid, true)
+            end
+
+            close_extra_tabs(base_tabs)
             pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
         end)
 
@@ -502,7 +574,7 @@ describe("BufHelpers", function()
         end)
 
         it("ignores a hidden, non-focusable float", function()
-            local winid = vim.api.nvim_open_win(bufnr, false, {
+            open_tracked_float({
                 relative = "editor",
                 row = 1,
                 col = 1,
@@ -515,13 +587,11 @@ describe("BufHelpers", function()
             -- Measured: the old lookup returned this float, so a widget's hidden
             -- chat float absorbed a winbar nobody sees.
             assert.is_nil(BufHelpers.find_visible_win(bufnr))
-
-            pcall(vim.api.nvim_win_close, winid, true)
         end)
 
         it("ignores a focusable float that is hidden", function()
             -- `focusable` alone is not the predicate; `hide` is.
-            local winid = vim.api.nvim_open_win(bufnr, false, {
+            open_tracked_float({
                 relative = "editor",
                 row = 1,
                 col = 1,
@@ -532,8 +602,6 @@ describe("BufHelpers", function()
             })
 
             assert.is_nil(BufHelpers.find_visible_win(bufnr))
-
-            pcall(vim.api.nvim_win_close, winid, true)
         end)
 
         it("prefers the caller's own window over another tab's", function()
@@ -626,6 +694,42 @@ describe("BufHelpers", function()
             end
         )
 
+        -- A preferred handle reaches this helper across an event boundary, so on
+        -- 0.11.x it can be valid yet sit in a closed tabpage. With `tabpage`
+        -- omitted nothing else consults the tabpage, so a bare
+        -- `nvim_win_is_valid` check returns the stale handle. Stubbed because
+        -- stale-valid post-`tabclose` handles are platform-specific.
+        it(
+            "rejects a stale-valid preferred window in a dead tabpage",
+            function()
+                vim.cmd("tabnew")
+                local real_win = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(real_win, bufnr)
+
+                vim.cmd("tabnew")
+                local stale_win = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(stale_win, bufnr)
+
+                -- Closed separately so `stale_win` stays a live handle: only the
+                -- tabpage it reports is dead, which is the state 0.11.x leaves
+                -- behind. The window is valid and still shows the buffer, so the
+                -- tabpage is the sole axis that can reject it.
+                vim.cmd("tabnew")
+                local dead_tab = vim.api.nvim_get_current_tabpage()
+                vim.cmd("tabclose!")
+
+                stub(vim.api, "nvim_win_get_tabpage"):invokes(function(winid)
+                    return winid == stale_win and dead_tab
+                        or original_get_tabpage(winid)
+                end)
+
+                assert.equal(
+                    real_win,
+                    BufHelpers.find_visible_win(bufnr, stale_win)
+                )
+            end
+        )
+
         it(
             "returns nil when the buffer is visible in no other tabpage",
             function()
@@ -652,21 +756,36 @@ describe("BufHelpers", function()
     end)
 
     describe("is_win_usable", function()
+        --- @type table<integer, true>
         local base_tabs
+        --- @type TestStub[]
+        local stubs
+
+        --- Tracked so `after_each` reverts it even when an assertion throws.
+        --- @param target table
+        --- @param method string
+        --- @return TestStub
+        local function stub(target, method)
+            local s = spy.stub(target, method)
+            stubs[#stubs + 1] = s
+            return s
+        end
 
         before_each(function()
-            base_tabs = #vim.api.nvim_list_tabpages()
+            stubs = {}
+            base_tabs = {}
+            for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+                base_tabs[tab] = true
+            end
         end)
 
         after_each(function()
-            while #vim.api.nvim_list_tabpages() > base_tabs do
-                local ok = pcall(function()
-                    vim.cmd("tabclose!")
-                end)
-                if not ok then
-                    break
-                end
+            -- Reverted first: the cleanup below calls the very APIs these stub.
+            for _, s in ipairs(stubs) do
+                s:revert()
             end
+
+            close_extra_tabs(base_tabs)
         end)
 
         it("returns true for a window in a live tabpage", function()
@@ -703,17 +822,10 @@ describe("BufHelpers", function()
             local dead_tab = vim.api.nvim_get_current_tabpage()
             vim.cmd("tabclose!")
 
-            local valid_stub = spy.stub(vim.api, "nvim_win_is_valid")
-            valid_stub:returns(true)
-            local tabpage_stub = spy.stub(vim.api, "nvim_win_get_tabpage")
-            tabpage_stub:returns(dead_tab)
+            stub(vim.api, "nvim_win_is_valid"):returns(true)
+            stub(vim.api, "nvim_win_get_tabpage"):returns(dead_tab)
 
-            local usable = BufHelpers.is_win_usable(winid)
-
-            valid_stub:revert()
-            tabpage_stub:revert()
-
-            assert.is_false(usable)
+            assert.is_false(BufHelpers.is_win_usable(winid))
         end)
     end)
 end)

--- a/lua/agentic/utils/buf_helpers.test.lua
+++ b/lua/agentic/utils/buf_helpers.test.lua
@@ -321,6 +321,96 @@ describe("BufHelpers", function()
         end)
     end)
 
+    describe("win_set_width / win_set_height", function()
+        local winid
+
+        before_each(function()
+            vim.cmd("tabnew")
+            vim.cmd("vsplit")
+            winid = vim.api.nvim_get_current_win()
+        end)
+
+        after_each(function()
+            pcall(function()
+                vim.cmd("tabclose!")
+            end)
+        end)
+
+        it("resizes the window width on the running Neovim", function()
+            BufHelpers.win_set_width(winid, 20)
+
+            assert.equal(20, vim.api.nvim_win_get_width(winid))
+        end)
+
+        it("resizes the window height on the running Neovim", function()
+            BufHelpers.win_set_height(winid, 8)
+
+            assert.equal(8, vim.api.nvim_win_get_height(winid))
+        end)
+
+        it("leaves the other axis untouched", function()
+            local original_height = vim.api.nvim_win_get_height(winid)
+
+            BufHelpers.win_set_width(winid, 20)
+
+            assert.equal(original_height, vim.api.nvim_win_get_height(winid))
+        end)
+
+        -- `nvim_win_set_width`/`_set_height` are deprecated on nightly for
+        -- `nvim_win_resize`, which only exists on 0.13+. CI runs a nightly
+        -- matrix job, so both branches stay reachable on every version.
+        -- `spy.stub` cannot restore an absent field, so the 0.13 branch uses a
+        -- saved original cleared by hand.
+        it("calls nvim_win_resize on Neovim >= 0.13", function()
+            local has_stub = spy.stub(vim.fn, "has")
+            has_stub:invokes(function(feature)
+                return feature == "nvim-0.13" and 1 or 0
+            end)
+
+            local original_resize = vim.api.nvim_win_resize
+            local calls = {}
+            --- @diagnostic disable-next-line: inject-field, duplicate-set-field
+            vim.api.nvim_win_resize = function(win, width, height, opts)
+                calls[#calls + 1] = { win, width, height, opts }
+            end
+
+            BufHelpers.win_set_width(winid, 20)
+            BufHelpers.win_set_height(winid, 8)
+
+            --- @diagnostic disable-next-line: inject-field
+            vim.api.nvim_win_resize = original_resize
+            has_stub:revert()
+
+            assert.equal(2, #calls)
+            assert.equal(winid, calls[1][1])
+            assert.equal(20, calls[1][2])
+            assert.equal(-1, calls[1][3])
+            assert.equal(-1, calls[2][2])
+            assert.equal(8, calls[2][3])
+        end)
+
+        it("falls back to the single-axis setters on Neovim < 0.13", function()
+            local has_stub = spy.stub(vim.fn, "has")
+            has_stub:returns(0)
+            --- @diagnostic disable-next-line: deprecated
+            local set_width_stub = spy.stub(vim.api, "nvim_win_set_width")
+            --- @diagnostic disable-next-line: deprecated
+            local set_height_stub = spy.stub(vim.api, "nvim_win_set_height")
+
+            BufHelpers.win_set_width(winid, 20)
+
+            set_width_stub:revert()
+            set_height_stub:revert()
+            has_stub:revert()
+
+            assert.equal(1, set_width_stub.call_count)
+            assert.equal(winid, set_width_stub.calls[1][1])
+            assert.equal(20, set_width_stub.calls[1][2])
+            -- Unset axis passes -1 and must not reach the setter.
+            assert.equal(0, set_height_stub.call_count)
+        end)
+    end)
+
     describe("is_buffer_empty", function()
         it("should return true for buffer with single empty line", function()
             local bufnr = vim.api.nvim_create_buf(false, true)
@@ -372,6 +462,258 @@ describe("BufHelpers", function()
 
             assert.is_false(BufHelpers.is_buffer_empty(bufnr))
             vim.api.nvim_buf_delete(bufnr, { force = true })
+        end)
+    end)
+
+    describe("find_visible_win", function()
+        local bufnr
+        local base_tabs
+
+        before_each(function()
+            base_tabs = #vim.api.nvim_list_tabpages()
+            bufnr = vim.api.nvim_create_buf(false, true)
+        end)
+
+        after_each(function()
+            while #vim.api.nvim_list_tabpages() > base_tabs do
+                local ok = pcall(function()
+                    vim.cmd("tabclose!")
+                end)
+                if not ok then
+                    break
+                end
+            end
+            pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+        end)
+
+        it("returns nil when no window shows the buffer", function()
+            assert.is_nil(BufHelpers.find_visible_win(bufnr))
+        end)
+
+        it("finds a window in another tabpage", function()
+            vim.cmd("tabnew")
+            local other_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(other_win, bufnr)
+            vim.cmd("tabprevious")
+
+            -- `vim.fn.bufwinid`, which this replaced, returns -1 here: it "Only
+            -- deals with the current tabpage".
+            assert.equal(other_win, BufHelpers.find_visible_win(bufnr))
+        end)
+
+        it("ignores a hidden, non-focusable float", function()
+            local winid = vim.api.nvim_open_win(bufnr, false, {
+                relative = "editor",
+                row = 1,
+                col = 1,
+                width = 5,
+                height = 2,
+                focusable = false,
+                hide = true,
+            })
+
+            -- Measured: the old lookup returned this float, so a widget's hidden
+            -- chat float absorbed a winbar nobody sees.
+            assert.is_nil(BufHelpers.find_visible_win(bufnr))
+
+            pcall(vim.api.nvim_win_close, winid, true)
+        end)
+
+        it("ignores a focusable float that is hidden", function()
+            -- `focusable` alone is not the predicate; `hide` is.
+            local winid = vim.api.nvim_open_win(bufnr, false, {
+                relative = "editor",
+                row = 1,
+                col = 1,
+                width = 5,
+                height = 2,
+                focusable = true,
+                hide = true,
+            })
+
+            assert.is_nil(BufHelpers.find_visible_win(bufnr))
+
+            pcall(vim.api.nvim_win_close, winid, true)
+        end)
+
+        it("prefers the caller's own window over another tab's", function()
+            vim.cmd("tabnew")
+            local foreign_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(foreign_win, bufnr)
+
+            vim.cmd("tabnew")
+            local own_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(own_win, bufnr)
+
+            assert.equal(own_win, BufHelpers.find_visible_win(bufnr, own_win))
+        end)
+
+        it(
+            "ignores a preferred window that no longer shows the buffer",
+            function()
+                vim.cmd("tabnew")
+                local real_win = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(real_win, bufnr)
+
+                local stale_win = vim.api.nvim_open_win(
+                    vim.api.nvim_create_buf(false, true),
+                    false,
+                    { split = "below", win = real_win }
+                )
+
+                assert.equal(
+                    real_win,
+                    BufHelpers.find_visible_win(bufnr, stale_win)
+                )
+            end
+        )
+
+        it(
+            "rejects a preferred window outside the requested tabpage",
+            function()
+                vim.cmd("tabnew")
+                local foreign_win = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(foreign_win, bufnr)
+
+                vim.cmd("tabnew")
+                local wanted_tab = vim.api.nvim_get_current_tabpage()
+                local wanted_win = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(wanted_win, bufnr)
+
+                -- Preferred window still shows the buffer, so only the tab
+                -- filter can reject it.
+                assert.equal(
+                    wanted_win,
+                    BufHelpers.find_visible_win(bufnr, foreign_win, wanted_tab)
+                )
+            end
+        )
+
+        it("restricts the search to a given tabpage", function()
+            vim.cmd("tabnew")
+            local first_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(first_win, bufnr)
+
+            vim.cmd("tabnew")
+            local second_tab = vim.api.nvim_get_current_tabpage()
+            local second_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(second_win, bufnr)
+
+            -- Same file open in two tabs must resolve to the session's own.
+            assert.equal(
+                second_win,
+                BufHelpers.find_visible_win(bufnr, nil, second_tab)
+            )
+        end)
+
+        it(
+            "falls back across tabpages when the preferred window is stale",
+            function()
+                vim.cmd("tabnew")
+                local foreign_win = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(foreign_win, bufnr)
+
+                vim.cmd("tabnew")
+                local stale_win = vim.api.nvim_get_current_win()
+
+                -- Preferred window no longer shows the buffer and its own tab
+                -- has no other holder: only a cross-tab fallback resolves the
+                -- foreign session's window. An unscoped call must not be nil.
+                assert.equal(
+                    foreign_win,
+                    BufHelpers.find_visible_win(bufnr, stale_win)
+                )
+            end
+        )
+
+        it(
+            "returns nil when the buffer is visible in no other tabpage",
+            function()
+                vim.cmd("tabnew")
+                local win = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(win, bufnr)
+                local empty_tab = vim.api.nvim_get_current_tabpage()
+
+                vim.cmd("tabnew")
+
+                assert.is_nil(
+                    BufHelpers.find_visible_win(
+                        bufnr,
+                        nil,
+                        vim.api.nvim_get_current_tabpage()
+                    )
+                )
+                assert.equal(
+                    win,
+                    BufHelpers.find_visible_win(bufnr, nil, empty_tab)
+                )
+            end
+        )
+    end)
+
+    describe("is_win_usable", function()
+        local base_tabs
+
+        before_each(function()
+            base_tabs = #vim.api.nvim_list_tabpages()
+        end)
+
+        after_each(function()
+            while #vim.api.nvim_list_tabpages() > base_tabs do
+                local ok = pcall(function()
+                    vim.cmd("tabclose!")
+                end)
+                if not ok then
+                    break
+                end
+            end
+        end)
+
+        it("returns true for a window in a live tabpage", function()
+            vim.cmd("tabnew")
+
+            assert.is_true(
+                BufHelpers.is_win_usable(vim.api.nvim_get_current_win())
+            )
+        end)
+
+        it("returns false for a nil handle", function()
+            assert.is_false(BufHelpers.is_win_usable(nil))
+        end)
+
+        it("returns false for an unknown handle", function()
+            assert.is_false(BufHelpers.is_win_usable(99999))
+        end)
+
+        it("returns false for a closed window", function()
+            vim.cmd("tabnew")
+            local winid = vim.api.nvim_get_current_win()
+            vim.cmd("tabnew")
+            pcall(vim.api.nvim_win_close, winid, true)
+
+            assert.is_false(BufHelpers.is_win_usable(winid))
+        end)
+
+        -- On 0.11.x `tabclose` leaves handles still valid per
+        -- `nvim_win_is_valid`; `nvim_win_close` on one segfaults. The tabpage is
+        -- the only axis rejecting it. Stubbed: stale-valid is platform-specific.
+        it("returns false for a valid window whose tabpage is gone", function()
+            vim.cmd("tabnew")
+            local winid = vim.api.nvim_get_current_win()
+            local dead_tab = vim.api.nvim_get_current_tabpage()
+            vim.cmd("tabclose!")
+
+            local valid_stub = spy.stub(vim.api, "nvim_win_is_valid")
+            valid_stub:returns(true)
+            local tabpage_stub = spy.stub(vim.api, "nvim_win_get_tabpage")
+            tabpage_stub:returns(dead_tab)
+
+            local usable = BufHelpers.is_win_usable(winid)
+
+            valid_stub:revert()
+            tabpage_stub:revert()
+
+            assert.is_false(usable)
         end)
     end)
 end)


### PR DESCRIPTION
- version-safe window resize over nvim_win_resize
- tabpage-aware window lookup replaces bufwinid
- is_win_usable guards the 0.11.x tabclose segfault
- ban the three unsafe APIs in AGENTS.md
- consumers are test-side, land with session work

The `nvim_win_resize` gate exists because the nightly matrix job deprecates
`nvim_win_set_width` / `nvim_win_set_height`, which is what turned CI red on the
combined branch. `main` has zero callers of any of them today, so the helpers
land here with their own tests and the consumers arrive in follow-up PRs.
