### PR TITLE
refactor: simplify diagnostics_list collection and deletion

### DIFF
--- a/lua/agentic/ui/diagnostics_list.lua
+++ b/lua/agentic/ui/diagnostics_list.lua
@@ -4,8 +4,7 @@ local WidgetLayout = require("agentic.ui.widget_layout")
 local FileSystem = require("agentic.utils.file_system")
 local BufHelpers = require("agentic.utils.buf_helpers")
 
---- Get diagnostic severity icons from config
---- @return table<number, string> Mapping of severity to icon
+--- @return table<number, string> icons Keyed by `vim.diagnostic.severity`
 local function get_diagnostic_icons()
     local icons = Config.diagnostic_icons
     return {
@@ -17,17 +16,17 @@ local function get_diagnostic_icons()
 end
 
 --- @class agentic.ui.DiagnosticsList.Diagnostic : vim.Diagnostic
---- @field file_path string Full file path
+--- @field file_path string
 
 --- @class agentic.ui.DiagnosticsList
 --- @field _diagnostics agentic.ui.DiagnosticsList.Diagnostic[]
---- @field _bufnr integer the same buffer number as the ChatWidget's diagnostics buffer
+--- @field _bufnr integer The ChatWidget's diagnostics buffer
 --- @field _on_change fun(diagnosticsList: agentic.ui.DiagnosticsList)
 local DiagnosticsList = {}
 DiagnosticsList.__index = DiagnosticsList
 
 --- @param bufnr integer The diagnostics buffer number from ChatWidget
---- @param on_change fun(diagnosticsList: agentic.ui.DiagnosticsList) Callback to trigger when diagnostics list changes (e.g., update header)
+--- @param on_change fun(diagnosticsList: agentic.ui.DiagnosticsList)
 --- @return agentic.ui.DiagnosticsList
 function DiagnosticsList:new(bufnr, on_change)
     local instance = setmetatable({
@@ -41,29 +40,23 @@ function DiagnosticsList:new(bufnr, on_change)
     return instance
 end
 
---- Add a diagnostic to the list if not already present
 --- @param diagnostic agentic.ui.DiagnosticsList.Diagnostic|nil
---- @return boolean success
+--- @return boolean success false when absent or already present
 function DiagnosticsList:_add_no_render(diagnostic)
     if not diagnostic or not diagnostic.bufnr then
         return false
     end
 
-    local file_path = diagnostic.file_path
-    if type(file_path) ~= "string" then
-        file_path = ""
-    end
+    local file_path = type(diagnostic.file_path) == "string"
+            and diagnostic.file_path
+        or ""
 
     if file_path == "" and vim.api.nvim_buf_is_valid(diagnostic.bufnr) then
         file_path = vim.api.nvim_buf_get_name(diagnostic.bufnr)
     end
 
-    if type(file_path) ~= "string" then
-        file_path = ""
-    end
     diagnostic.file_path = file_path
 
-    -- Check for duplicates
     for _, existing in ipairs(self._diagnostics) do
         if
             existing.bufnr == diagnostic.bufnr
@@ -82,7 +75,6 @@ function DiagnosticsList:_add_no_render(diagnostic)
     return true
 end
 
---- Add a diagnostic to the list if not already present
 --- @param diagnostic agentic.ui.DiagnosticsList.Diagnostic|nil
 --- @return boolean success
 function DiagnosticsList:add(diagnostic)
@@ -94,9 +86,8 @@ function DiagnosticsList:add(diagnostic)
     return true
 end
 
---- Add multiple diagnostics at once
 --- @param diagnostics agentic.ui.DiagnosticsList.Diagnostic[]
---- @return integer count Number of diagnostics added
+--- @return integer count
 function DiagnosticsList:add_many(diagnostics)
     local count = 0
     for _, diagnostic in ipairs(diagnostics) do
@@ -165,68 +156,56 @@ function DiagnosticsList:is_empty()
     return #self._diagnostics == 0
 end
 
---- Get diagnostics for a specific buffer
---- @param bufnr integer|nil If nil, uses current buffer
---- @param opts vim.diagnostic.GetOpts|nil Options passed to vim.diagnostic.get()
---- @return agentic.ui.DiagnosticsList.Diagnostic[] diagnostics Converted diagnostics
-function DiagnosticsList.get_buffer_diagnostics(bufnr, opts)
-    bufnr = bufnr or vim.api.nvim_get_current_buf()
-    opts = opts or {}
-
-    --- @type vim.Diagnostic[]
-    local vim_diagnostics = vim.diagnostic.get(bufnr, opts)
+--- Stamps each diagnostic with the buffer's path.
+--- @param bufnr integer
+--- @param opts vim.diagnostic.GetOpts
+--- @param keep (fun(d: vim.Diagnostic): boolean)|nil Keeps everything when nil
+--- @return agentic.ui.DiagnosticsList.Diagnostic[]
+local function collect_diagnostics(bufnr, opts, keep)
     local file_path = vim.api.nvim_buf_get_name(bufnr)
 
     --- @type agentic.ui.DiagnosticsList.Diagnostic[]
     local diagnostics = {}
 
-    for _, d in ipairs(vim_diagnostics) do
-        --- @type agentic.ui.DiagnosticsList.Diagnostic
-        local diagnostic = vim.tbl_extend("force", d, { file_path = file_path }) --[[@as agentic.ui.DiagnosticsList.Diagnostic]]
-        diagnostics[#diagnostics + 1] = diagnostic
+    for _, d in ipairs(vim.diagnostic.get(bufnr, opts)) do
+        if keep == nil or keep(d) then
+            diagnostics[#diagnostics + 1] =
+                vim.tbl_extend("force", d, { file_path = file_path }) --[[@as agentic.ui.DiagnosticsList.Diagnostic]]
+        end
     end
 
     return diagnostics
 end
 
---- Get diagnostics at the cursor line
---- @param bufnr integer|nil If nil, uses current buffer
---- @param opts vim.diagnostic.GetOpts|nil Options passed to vim.diagnostic.get()
---- @return agentic.ui.DiagnosticsList.Diagnostic[] diagnostics Diagnostics at the cursor line
+--- @param bufnr integer|nil Defaults to the current buffer
+--- @param opts vim.diagnostic.GetOpts|nil
+--- @return agentic.ui.DiagnosticsList.Diagnostic[] diagnostics
+function DiagnosticsList.get_buffer_diagnostics(bufnr, opts)
+    bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+    return collect_diagnostics(bufnr, opts or {}, nil)
+end
+
+--- @param bufnr integer|nil Defaults to the current buffer
+--- @param opts vim.diagnostic.GetOpts|nil
+--- @return agentic.ui.DiagnosticsList.Diagnostic[] diagnostics
 function DiagnosticsList.get_diagnostics_at_cursor(bufnr, opts)
     bufnr = bufnr or vim.api.nvim_get_current_buf()
-    opts = opts or {}
 
-    local winid = vim.fn.bufwinid(bufnr)
-    if winid == -1 then
-        local current_winid = vim.api.nvim_get_current_win()
-        if vim.api.nvim_win_get_buf(current_winid) ~= bufnr then
-            return {}
-        end
-        winid = current_winid
+    -- The invoking window is PREFERRED, not a last resort: `win_findbuf` returns tabpage
+    -- order regardless of the current tab, so an unpreferred lookup reads another tab's
+    -- cursor whenever that tab sorts earlier.
+    local winid =
+        BufHelpers.find_visible_win(bufnr, vim.api.nvim_get_current_win())
+    if not winid then
+        return {}
     end
 
-    local cursor_pos = vim.api.nvim_win_get_cursor(winid)
-    local cursor_line = cursor_pos[1] - 1 -- Convert to 0-indexed
+    local cursor_line = vim.api.nvim_win_get_cursor(winid)[1] - 1
 
-    --- @type vim.Diagnostic[]
-    local vim_diagnostics = vim.diagnostic.get(bufnr, opts)
-    local file_path = vim.api.nvim_buf_get_name(bufnr)
-
-    --- @type agentic.ui.DiagnosticsList.Diagnostic[]
-    local diagnostics = {}
-
-    for _, d in ipairs(vim_diagnostics) do
-        local end_lnum = d.end_lnum or d.lnum
-        if cursor_line >= d.lnum and cursor_line <= end_lnum then
-            --- @type agentic.ui.DiagnosticsList.Diagnostic
-            local diagnostic =
-                vim.tbl_extend("force", d, { file_path = file_path }) --[[@as agentic.ui.DiagnosticsList.Diagnostic]]
-            diagnostics[#diagnostics + 1] = diagnostic
-        end
-    end
-
-    return diagnostics
+    return collect_diagnostics(bufnr, opts or {}, function(d)
+        return cursor_line >= d.lnum and cursor_line <= (d.end_lnum or d.lnum)
+    end)
 end
 
 --- @private
@@ -235,8 +214,8 @@ function DiagnosticsList:_render()
     local icons = get_diagnostic_icons()
 
     local buf_width = WidgetLayout.calculate_width(Config.windows.width)
-    local winid = vim.fn.bufwinid(self._bufnr)
-    if winid ~= -1 then
+    local winid = BufHelpers.find_visible_win(self._bufnr, nil)
+    if winid then
         buf_width = vim.api.nvim_win_get_width(winid)
     end
 
@@ -256,14 +235,12 @@ function DiagnosticsList:_render()
             diagnostic.col + 1
         )
 
-        -- nvim_buf_set_lines rejects embedded newlines in a line item.
-        -- Keep diagnostics single-line by rendering newlines as escaped text.
+        -- `nvim_buf_set_lines` rejects embedded newlines.
         local message = type(diagnostic.message) == "string"
                 and diagnostic.message
             or tostring(diagnostic.message or "")
         message = message:gsub("\r\n", "\n"):gsub("\r", "\n"):gsub("\n", "\\n")
 
-        -- Format: ICON path:line:col - message
         local line = string.format("%s %s - %s", icon, location, message)
         lines[#lines + 1] =
             DiagnosticsContext.truncate_for_display(line, buf_width)
@@ -299,14 +276,13 @@ function DiagnosticsList:_setup_keybindings()
         local start_line = start_pos[2]
         local end_line = end_pos[2]
 
-        -- Ensure start_line is always smaller than end_line (handle backward selection)
         if start_line > end_line then
             start_line, end_line = end_line, start_line
         end
 
-        --- @type table<integer, true>
-        local indices_to_remove = {}
-        for line = start_line, end_line do
+        -- Descending, so each removal leaves the lower indices valid.
+        local removed = 0
+        for line = math.min(end_line, #self._diagnostics), start_line, -1 do
             local line_content = vim.api.nvim_buf_get_lines(
                 self._bufnr,
                 line - 1,
@@ -314,34 +290,16 @@ function DiagnosticsList:_setup_keybindings()
                 false
             )[1]
 
-            if
-                line_content
-                and line_content:match("%S")
-                and line >= 1
-                and line <= #self._diagnostics
-            then
-                indices_to_remove[line] = true
+            if line_content and line_content:match("%S") and line >= 1 then
+                table.remove(self._diagnostics, line)
+                removed = removed + 1
             end
         end
 
-        --- @type integer[]
-        local sorted_indices = {}
-        for index in pairs(indices_to_remove) do
-            sorted_indices[#sorted_indices + 1] = index
-        end
-        table.sort(sorted_indices, function(a, b)
-            return a > b
-        end)
-
-        for _, index in ipairs(sorted_indices) do
-            table.remove(self._diagnostics, index)
-        end
-
-        if #sorted_indices > 0 then
+        if removed > 0 then
             self:_render()
         end
 
-        -- Exit visual mode
         BufHelpers.feed_ESC_key()
     end, { nowait = true })
 end

--- a/lua/agentic/ui/diagnostics_list.test.lua
+++ b/lua/agentic/ui/diagnostics_list.test.lua
@@ -484,25 +484,33 @@ describe("agentic.ui.DiagnosticsList", function()
         --- @type integer
         local ns
 
-        --- @type integer
+        --- Handle set, not a count: the cross-tab cases move the current tab
+        --- around, so a count-based `tabclose!` loop can shut a baseline tab
+        --- while a test-created one survives.
+        --- @type table<integer, true>
         local base_tabs
 
         before_each(function()
-            base_tabs = #vim.api.nvim_list_tabpages()
+            base_tabs = {}
+            for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+                base_tabs[tab] = true
+            end
             test_bufnr = vim.api.nvim_create_buf(false, true)
             ns = vim.api.nvim_create_namespace("test_diag_cursor")
             vim.api.nvim_set_current_buf(test_bufnr)
         end)
 
         after_each(function()
-            -- Loop, not one `tabclose`: a red assertion in the cross-tab case
-            -- would otherwise leak a tabpage into every later test file.
-            while #vim.api.nvim_list_tabpages() > base_tabs do
-                local ok = pcall(function()
-                    vim.cmd("tabclose!")
-                end)
-                if not ok then
-                    break
+            -- Closes only tabpages absent from the baseline, so a red assertion
+            -- in a cross-tab case cannot leak one into every later test file.
+            for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+                if
+                    not base_tabs[tab] and vim.api.nvim_tabpage_is_valid(tab)
+                then
+                    pcall(function()
+                        vim.api.nvim_set_current_tabpage(tab)
+                        vim.cmd("tabclose!")
+                    end)
                 end
             end
 

--- a/lua/agentic/ui/diagnostics_list.test.lua
+++ b/lua/agentic/ui/diagnostics_list.test.lua
@@ -458,6 +458,24 @@ describe("agentic.ui.DiagnosticsList", function()
 
             assert.equal(vim.diagnostic.severity.ERROR, diagnostics[1].severity)
         end)
+
+        it("stamps file_path on every returned diagnostic", function()
+            vim.api.nvim_buf_set_name(test_bufnr, "/test/stamped.lua")
+
+            vim.diagnostic.set(ns, test_bufnr, {
+                { lnum = 0, col = 0, message = "first" },
+                { lnum = 1, col = 0, message = "second" },
+                { lnum = 2, col = 0, message = "third" },
+            })
+
+            local diagnostics =
+                DiagnosticsList.get_buffer_diagnostics(test_bufnr)
+
+            assert.equal(3, #diagnostics)
+            for _, d in ipairs(diagnostics) do
+                assert.equal("/test/stamped.lua", d.file_path)
+            end
+        end)
     end)
 
     describe("get_diagnostics_at_cursor", function()
@@ -466,13 +484,28 @@ describe("agentic.ui.DiagnosticsList", function()
         --- @type integer
         local ns
 
+        --- @type integer
+        local base_tabs
+
         before_each(function()
+            base_tabs = #vim.api.nvim_list_tabpages()
             test_bufnr = vim.api.nvim_create_buf(false, true)
             ns = vim.api.nvim_create_namespace("test_diag_cursor")
             vim.api.nvim_set_current_buf(test_bufnr)
         end)
 
         after_each(function()
+            -- Loop, not one `tabclose`: a red assertion in the cross-tab case
+            -- would otherwise leak a tabpage into every later test file.
+            while #vim.api.nvim_list_tabpages() > base_tabs do
+                local ok = pcall(function()
+                    vim.cmd("tabclose!")
+                end)
+                if not ok then
+                    break
+                end
+            end
+
             vim.diagnostic.reset(ns, test_bufnr)
             if vim.api.nvim_buf_is_valid(test_bufnr) then
                 pcall(vim.api.nvim_buf_delete, test_bufnr, { force = true })
@@ -536,6 +569,217 @@ describe("agentic.ui.DiagnosticsList", function()
                 DiagnosticsList.get_diagnostics_at_cursor(test_bufnr)
 
             assert.equal(0, #diagnostics)
+        end)
+
+        it("includes a multi-line range spanning the cursor", function()
+            vim.api.nvim_buf_set_lines(
+                test_bufnr,
+                0,
+                -1,
+                false,
+                { "line1", "line2", "line3", "line4" }
+            )
+
+            vim.diagnostic.set(ns, test_bufnr, {
+                {
+                    lnum = 0,
+                    end_lnum = 2,
+                    col = 0,
+                    severity = vim.diagnostic.severity.ERROR,
+                    message = "Spans lines 1-3",
+                },
+                {
+                    lnum = 3,
+                    col = 0,
+                    severity = vim.diagnostic.severity.WARN,
+                    message = "Only line 4",
+                },
+            })
+
+            vim.api.nvim_win_set_cursor(0, { 2, 0 })
+
+            local diagnostics =
+                DiagnosticsList.get_diagnostics_at_cursor(test_bufnr)
+
+            assert.equal(1, #diagnostics)
+            assert.equal("Spans lines 1-3", diagnostics[1].message)
+        end)
+
+        it("returns an empty array when the buffer is in no window", function()
+            local hidden_bufnr = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_buf_set_lines(hidden_bufnr, 0, -1, false, { "line1" })
+
+            vim.diagnostic.set(ns, hidden_bufnr, {
+                {
+                    lnum = 0,
+                    col = 0,
+                    severity = vim.diagnostic.severity.ERROR,
+                    message = "Error on line 1",
+                },
+            })
+
+            local diagnostics =
+                DiagnosticsList.get_diagnostics_at_cursor(hidden_bufnr)
+
+            assert.equal(0, #diagnostics)
+
+            vim.diagnostic.reset(ns, hidden_bufnr)
+            pcall(vim.api.nvim_buf_delete, hidden_bufnr, { force = true })
+        end)
+
+        it(
+            "returns diagnostics when the buffer's only window is in another tab",
+            function()
+                vim.api.nvim_buf_set_lines(
+                    test_bufnr,
+                    0,
+                    -1,
+                    false,
+                    { "line1", "line2", "line3" }
+                )
+
+                vim.diagnostic.set(ns, test_bufnr, {
+                    {
+                        lnum = 1,
+                        col = 0,
+                        severity = vim.diagnostic.severity.ERROR,
+                        message = "Error on line 2",
+                    },
+                })
+
+                -- Park the buffer's only window in its own tab, then leave.
+                -- `before_each` also put it in the starting window; that copy
+                -- must go or the lookup legitimately finds it here.
+                vim.cmd("tabnew")
+                local other_win = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(other_win, test_bufnr)
+                vim.api.nvim_win_set_cursor(other_win, { 2, 0 })
+                vim.cmd("tabprevious")
+                vim.api.nvim_win_set_buf(
+                    vim.api.nvim_get_current_win(),
+                    vim.api.nvim_create_buf(false, true)
+                )
+
+                -- Defect: the current-tab-only lookup found no window here and
+                -- silently yielded nothing.
+                local diagnostics =
+                    DiagnosticsList.get_diagnostics_at_cursor(test_bufnr)
+
+                assert.equal(1, #diagnostics)
+                assert.equal("Error on line 2", diagnostics[1].message)
+            end
+        )
+
+        it("prefers the current window's cursor over another tab's", function()
+            -- Both tabs hold the buffer at DIFFERENT lines; dropping either copy
+            -- collapses to the single-match path and stops exercising the
+            -- ambiguity. Without a preferred window `win_findbuf` order decides,
+            -- so the other tab's line 3 wins and the user gets a diagnostic they
+            -- are not sitting on.
+            vim.api.nvim_buf_set_lines(
+                test_bufnr,
+                0,
+                -1,
+                false,
+                { "line1", "line2", "line3" }
+            )
+
+            vim.diagnostic.set(ns, test_bufnr, {
+                {
+                    lnum = 1,
+                    col = 0,
+                    severity = vim.diagnostic.severity.ERROR,
+                    message = "Error on line 2",
+                },
+                {
+                    lnum = 2,
+                    col = 0,
+                    severity = vim.diagnostic.severity.WARN,
+                    message = "Warning on line 3",
+                },
+            })
+
+            -- `win_findbuf` returns tabpage order regardless of the current tab,
+            -- so the earlier tab's copy wins an unpreferred lookup. Park the
+            -- decoy FIRST and stay in the later tab.
+            local other_win = vim.api.nvim_get_current_win()
+            assert.equal(test_bufnr, vim.api.nvim_win_get_buf(other_win))
+            vim.api.nvim_win_set_cursor(other_win, { 3, 0 })
+
+            vim.cmd("tabnew")
+            local current_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(current_win, test_bufnr)
+            vim.api.nvim_win_set_cursor(current_win, { 2, 0 })
+
+            local diagnostics =
+                DiagnosticsList.get_diagnostics_at_cursor(test_bufnr)
+
+            assert.equal(1, #diagnostics)
+            assert.equal("Error on line 2", diagnostics[1].message)
+        end)
+    end)
+
+    describe("visual-mode delete", function()
+        --- Enters the diagnostics window, selects `from`..`to` linewise and presses `d`.
+        --- `V` and the motion go in ONE `normal` sequence: splitting them across
+        --- `nvim_win_set_cursor` loses the visual anchor, so only one line is
+        --- selected and the multi-line loop is never exercised.
+        --- @param from integer
+        --- @param to integer
+        local function visual_delete(from, to)
+            vim.api.nvim_set_current_win(winid)
+            vim.api.nvim_win_set_cursor(winid, { from, 0 })
+            -- `normal` (not `normal!`) so the buffer-local `v`-mode `d` mapping runs.
+            vim.cmd(string.format("normal V%dGd", to))
+        end
+
+        --- @param count integer
+        local function seed(count)
+            for i = 1, count do
+                diagnostics_list:add(create_diagnostic({
+                    bufnr = bufnr,
+                    lnum = i,
+                    message = "diag " .. i,
+                }))
+            end
+        end
+
+        --- @return string[]
+        local function messages()
+            local result = {}
+            for _, d in ipairs(diagnostics_list:get_diagnostics()) do
+                result[#result + 1] = d.message
+            end
+            return result
+        end
+
+        it("removes exactly the three selected entries", function()
+            seed(5)
+
+            visual_delete(2, 4)
+
+            assert.same({ "diag 1", "diag 5" }, messages())
+        end)
+
+        it("removes the same set for a backward selection", function()
+            seed(5)
+
+            visual_delete(4, 2)
+
+            assert.same({ "diag 1", "diag 5" }, messages())
+        end)
+
+        it("ignores a selection reaching past the end of the list", function()
+            seed(2)
+            -- Blank padding after the rendered diagnostics, so the selection can
+            -- extend past the last entry.
+            vim.bo[bufnr].modifiable = true
+            vim.api.nvim_buf_set_lines(bufnr, 2, -1, false, { "", "", "" })
+            vim.bo[bufnr].modifiable = false
+
+            visual_delete(2, 5)
+
+            assert.same({ "diag 1" }, messages())
         end)
     end)
 end)


### PR DESCRIPTION
- share one diagnostic-collection helper
- resolve cursor window via find_visible_win
- delete visual selections in one descending pass
- drop the duplicated file_path type check

The invoking window is passed as `preferred_winid`, not used as a fallback:
`win_findbuf` returns tabpage order regardless of the current tab, so an
unpreferred lookup reads another tab's cursor whenever that tab sorts earlier.
