### PR TITLE
fix: stale StatusAnimation frame reschedules forever

### DIFF
--- a/lua/agentic/ui/status_animation.lua
+++ b/lua/agentic/ui/status_animation.lua
@@ -1,18 +1,4 @@
---- StatusAnimation module for displaying animated spinners in windows
----
---- This module provides utilities to render animated state indicators (spinners)
---- in buffers using extmarks and timers.
----
---- ## Usage
---- ```lua
---- local StatusAnimation = require("agentic.ui.status_animation")
---- local animator = StatusAnimation:new(bufnr)
---- animator:start("generating")
---- -- later...
---- animator:stop()
---- ```
----
-
+local BufHelpers = require("agentic.utils.buf_helpers")
 local Config = require("agentic.config")
 local Theme = require("agentic.theme")
 
@@ -27,11 +13,12 @@ local TIMING = {
 }
 
 --- @class agentic.ui.StatusAnimation
---- @field _bufnr number Buffer number where animation is rendered
---- @field _state? agentic.Theme.SpinnerState Current animation state
---- @field _next_frame_handle? uv.uv_timer_t One-shot deferred function handle from vim.defer_fn
---- @field _spinner_idx number Current spinner frame index
---- @field _extmark_id? number Current extmark ID
+--- @field _bufnr number
+--- @field _state? agentic.Theme.SpinnerState
+--- @field _next_frame_handle? uv.uv_timer_t
+--- @field _spinner_idx number
+--- @field _extmark_id? number
+--- @field _epoch number Bumped by every `start`; a stale frame reschedules nothing
 local StatusAnimation = {}
 StatusAnimation.__index = StatusAnimation
 
@@ -44,20 +31,23 @@ function StatusAnimation:new(bufnr)
         _next_frame_handle = nil,
         _spinner_idx = 1,
         _extmark_id = nil,
+        _epoch = 0,
     }, StatusAnimation)
 
     return instance
 end
 
---- Start the animation with the given state
---- Always stops and restarts to avoid overlapping with new content
 --- @param state agentic.Theme.SpinnerState
 function StatusAnimation:start(state)
     self:stop()
 
+    -- `stop` cannot un-queue an already-fired `vim.defer_fn` callback.
+    -- Regression: status_animation.test.lua::"drops a stale frame instead of scheduling a successor"
+    self._epoch = self._epoch + 1
+
     self._state = state
     self._spinner_idx = 1
-    self:_render_frame()
+    self:_render_frame(self._epoch)
 end
 
 function StatusAnimation:stop()
@@ -85,10 +75,13 @@ function StatusAnimation:stop()
     self._extmark_id = nil
 end
 
-function StatusAnimation:_render_frame()
+--- @param epoch number Epoch this frame was scheduled with
+function StatusAnimation:_render_frame(epoch)
+    if epoch ~= self._epoch then
+        return
+    end
+
     if not self._state or not vim.api.nvim_buf_is_valid(self._bufnr) then
-        -- return early to stop the animation in case state was cleared, or buffer is invalid
-        -- this avoids an infinite loop of deferred calls without a state and it actually renders nil in the UI
         return
     end
 
@@ -107,8 +100,9 @@ function StatusAnimation:_render_frame()
 
     local virt_text = { { display_text, hl_group } }
 
-    local winid = vim.fn.bufwinid(self._bufnr)
-    if winid ~= -1 and vim.api.nvim_win_is_valid(winid) then
+    -- A background session animates in its own tab, so the centring padding must measure that window.
+    local winid = BufHelpers.find_visible_win(self._bufnr)
+    if winid then
         local win_width = vim.api.nvim_win_get_width(winid)
         local text_width = vim.fn.strdisplaywidth(display_text)
         if win_width > text_width then
@@ -120,20 +114,20 @@ function StatusAnimation:_render_frame()
     local delay = TIMING[self._state] or TIMING.generating
 
     local virt_lines = {
-        { { "" } }, -- Empty line above
-        virt_text, -- Animation in middle
-        { { "" } }, -- Empty line below
+        { { "" } },
+        virt_text,
+        { { "" } },
     }
 
     self._extmark_id =
         vim.api.nvim_buf_set_extmark(self._bufnr, NS_ANIMATION, line_num, 0, {
-            id = self._extmark_id, -- Reuse existing extmark ID to update in-place
+            id = self._extmark_id,
             virt_lines = virt_lines,
             virt_lines_above = false,
         })
 
     self._next_frame_handle = vim.defer_fn(function()
-        self:_render_frame()
+        self:_render_frame(epoch)
     end, delay)
 end
 

--- a/lua/agentic/ui/status_animation.test.lua
+++ b/lua/agentic/ui/status_animation.test.lua
@@ -7,10 +7,32 @@ describe("agentic.ui.StatusAnimation", function()
 
     local bufnr
     local animation
+
+    --- Handle set, not a count: `tabclose!` closes the CURRENT tab, and the
+    --- cross-tab cases end on the original one, so a count-based loop shuts the
+    --- baseline tab and leaves the test-created one alive.
+    --- @type table<integer, true>
     local base_tabs
 
+    --- Tracked so `after_each` closes them even when an assertion throws.
+    --- Deleting a buffer only swaps the window to another buffer, so buffer
+    --- teardown cannot substitute for closing a float.
+    --- @type integer[]
+    local extra_wins
+
+    --- @param winid integer
+    --- @return integer winid
+    local function track_win(winid)
+        extra_wins[#extra_wins + 1] = winid
+        return winid
+    end
+
     before_each(function()
-        base_tabs = #vim.api.nvim_list_tabpages()
+        base_tabs = {}
+        for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+            base_tabs[tab] = true
+        end
+        extra_wins = {}
         bufnr = vim.api.nvim_create_buf(false, true)
         vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "one", "two" })
         animation = StatusAnimation:new(bufnr)
@@ -20,12 +42,18 @@ describe("agentic.ui.StatusAnimation", function()
         animation:stop()
         animation = nil
 
-        while #vim.api.nvim_list_tabpages() > base_tabs do
-            local ok = pcall(function()
-                vim.cmd("tabclose!")
-            end)
-            if not ok then
-                break
+        for _, winid in ipairs(extra_wins) do
+            if vim.api.nvim_win_is_valid(winid) then
+                pcall(vim.api.nvim_win_close, winid, true)
+            end
+        end
+
+        for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+            if not base_tabs[tab] and vim.api.nvim_tabpage_is_valid(tab) then
+                pcall(function()
+                    vim.api.nvim_set_current_tabpage(tab)
+                    vim.cmd("tabclose!")
+                end)
             end
         end
 
@@ -168,7 +196,7 @@ describe("agentic.ui.StatusAnimation", function()
         end)
 
         it("ignores a hidden float when measuring padding", function()
-            local winid = vim.api.nvim_open_win(bufnr, false, {
+            track_win(vim.api.nvim_open_win(bufnr, false, {
                 relative = "editor",
                 row = 1,
                 col = 1,
@@ -176,7 +204,7 @@ describe("agentic.ui.StatusAnimation", function()
                 height = 3,
                 focusable = false,
                 hide = true,
-            })
+            }))
 
             animation:start("generating")
 
@@ -184,8 +212,6 @@ describe("agentic.ui.StatusAnimation", function()
             assert.is_not_nil(chunks)
             ---@cast chunks table
             assert.equal(1, #chunks)
-
-            pcall(vim.api.nvim_win_close, winid, true)
         end)
     end)
 end)

--- a/lua/agentic/ui/status_animation.test.lua
+++ b/lua/agentic/ui/status_animation.test.lua
@@ -1,0 +1,191 @@
+local assert = require("tests.helpers.assert")
+local spy = require("tests.helpers.spy")
+local StatusAnimation = require("agentic.ui.status_animation")
+
+describe("agentic.ui.StatusAnimation", function()
+    local NS_ANIMATION = vim.api.nvim_create_namespace("agentic_animation")
+
+    local bufnr
+    local animation
+    local base_tabs
+
+    before_each(function()
+        base_tabs = #vim.api.nvim_list_tabpages()
+        bufnr = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "one", "two" })
+        animation = StatusAnimation:new(bufnr)
+    end)
+
+    after_each(function()
+        animation:stop()
+        animation = nil
+
+        while #vim.api.nvim_list_tabpages() > base_tabs do
+            local ok = pcall(function()
+                vim.cmd("tabclose!")
+            end)
+            if not ok then
+                break
+            end
+        end
+
+        pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+    end)
+
+    --- @return table extmarks
+    local function extmarks()
+        return vim.api.nvim_buf_get_extmarks(
+            bufnr,
+            NS_ANIMATION,
+            0,
+            -1,
+            { details = true }
+        )
+    end
+
+    --- Animation row of the rendered extmark, nil when nothing is drawn.
+    --- @return table|nil chunks
+    local function animation_chunks()
+        local marks = extmarks()
+        if #marks == 0 then
+            return nil
+        end
+        local virt_lines = marks[1][4].virt_lines
+        return virt_lines and virt_lines[2]
+    end
+
+    describe("frame scheduling", function()
+        --- @type TestStub
+        local defer_stub
+        local scheduled
+
+        before_each(function()
+            scheduled = {}
+            defer_stub = spy.stub(vim, "defer_fn")
+            defer_stub:invokes(function(callback)
+                scheduled[#scheduled + 1] = callback
+                return nil
+            end)
+        end)
+
+        after_each(function()
+            defer_stub:revert()
+        end)
+
+        it("drops a stale frame instead of scheduling a successor", function()
+            animation:start("generating")
+            assert.equal(1, #scheduled)
+
+            local stale_frame = scheduled[1]
+
+            -- `stop` inside `start` cannot un-queue an already-fired timer, so
+            -- this callback still runs. Without the epoch it passes the `_state`
+            -- check and starts a second chain at double the frame rate.
+            animation:start("generating")
+            assert.equal(2, #scheduled)
+
+            stale_frame()
+
+            assert.equal(2, #scheduled)
+        end)
+
+        it("leaves exactly one live chain after two starts", function()
+            animation:start("generating")
+            animation:start("thinking")
+
+            local stale_frame = scheduled[1]
+            local live_frame = scheduled[2]
+
+            stale_frame()
+            assert.equal(2, #scheduled)
+
+            live_frame()
+            assert.equal(3, #scheduled)
+        end)
+
+        it("stops rescheduling once stopped", function()
+            animation:start("generating")
+            local frame = scheduled[1]
+
+            animation:stop()
+            frame()
+
+            assert.equal(1, #scheduled)
+        end)
+
+        it("bails without scheduling for an invalid buffer", function()
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+
+            animation:start("generating")
+
+            assert.equal(0, #scheduled)
+        end)
+    end)
+
+    describe("rendering", function()
+        it("renders an extmark on start", function()
+            animation:start("generating")
+
+            assert.equal(1, #extmarks())
+        end)
+
+        it("clears the extmark and the state on stop", function()
+            animation:start("generating")
+            assert.equal(1, #extmarks())
+
+            animation:stop()
+
+            assert.equal(0, #extmarks())
+            assert.is_nil(animation._state)
+        end)
+
+        it(
+            "renders for a buffer whose only window is in another tab",
+            function()
+                vim.cmd("tabnew")
+                vim.api.nvim_win_set_buf(vim.api.nvim_get_current_win(), bufnr)
+                vim.cmd("tabprevious")
+
+                animation:start("generating")
+
+                local chunks = animation_chunks()
+                assert.is_not_nil(chunks)
+                ---@cast chunks table
+                -- Padding + spinner text: window measured despite living in
+                -- another tabpage.
+                assert.equal(2, #chunks)
+            end
+        )
+
+        it("renders without padding when no window shows the buffer", function()
+            animation:start("generating")
+
+            local chunks = animation_chunks()
+            assert.is_not_nil(chunks)
+            ---@cast chunks table
+            assert.equal(1, #chunks)
+            assert.is_true(chunks[1][1]:find("generating") ~= nil)
+        end)
+
+        it("ignores a hidden float when measuring padding", function()
+            local winid = vim.api.nvim_open_win(bufnr, false, {
+                relative = "editor",
+                row = 1,
+                col = 1,
+                width = 40,
+                height = 3,
+                focusable = false,
+                hide = true,
+            })
+
+            animation:start("generating")
+
+            local chunks = animation_chunks()
+            assert.is_not_nil(chunks)
+            ---@cast chunks table
+            assert.equal(1, #chunks)
+
+            pcall(vim.api.nvim_win_close, winid, true)
+        end)
+    end)
+end)


### PR DESCRIPTION
- epoch guard drops frames from a stopped loop
- stop() cannot un-queue an already-fired defer_fn
- restart no longer leaves two interleaved spinners
- centre on the session's own window, not bufwinid

`stop()` nils `_state` and closes the timer handle, but a `vim.defer_fn`
callback already in the event queue still runs. `_render_frame` re-checked
`_state` and bailed, except when `start()` ran in between and set it again: the
stale frame then rescheduled itself, leaving two spinner loops interleaved.

Regression: `drops a stale frame instead of scheduling a successor`. Verified by
mutation, removing the epoch guard turns it and
`leaves exactly one live chain after two starts` red.
