### PR TITLE
fix: answer cancelled when the ACP subscriber is gone

### DIFF
--- a/lua/agentic/acp/AGENTS.md
+++ b/lua/agentic/acp/AGENTS.md
@@ -59,6 +59,37 @@ acp_providers = {
 }
 ```
 
+## A request handler MUST always answer; a notification handler need not
+
+`ACPClient:_handle_notification` dispatches two shapes of inbound JSON-RPC
+message, and they carry opposite obligations:
+
+- A **notification** (`session/update`) has no `id`. Nothing is waiting on it, so
+  dropping it when the subscriber is gone is correct.
+- A **request** (`session/request_permission`) has an `id`. The provider blocks
+  until that `id` is answered, and the subprocess is **shared across every
+  session** (ADR 0004), so one unanswered request hangs the agent for all of them.
+  Every exit path owes a `__send_result`.
+
+`ACPClient:__with_subscriber` therefore takes an `on_missing` callback:
+
+```lua
+--- @param on_missing fun()|nil Runs when no subscriber answers
+function ACPClient:__with_subscriber(session_id, callback, on_missing)
+```
+
+It fires on **both** misses — the synchronous one (no subscriber when the message
+arrives) and the deferred one (the subscriber was dropped while the `vim.schedule`
+body sat in the queue). The subscriber is re-resolved **inside** the schedule for
+exactly that reason; `cancel_session` nils it mid-flight.
+
+Only `__handle_request_permission` passes `on_missing`, answering
+`{ outcome = "cancelled" }`. The three notification call sites pass nothing and
+keep returning silently.
+
+Regression:
+`lua/agentic/acp/acp_client.test.lua::"answers cancelled when the subscriber is gone"`.
+
 ## Protocol flow details
 
 The full event pipeline, ACPClient lifecycle, stdio framing, sync/async

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -539,13 +539,6 @@ end
 --- @param message_id number
 --- @param request agentic.acp.RequestPermission
 function ACPClient:__handle_request_permission(message_id, request)
-    if not request.sessionId or not request.toolCall then
-        error("Invalid request_permission")
-        return
-    end
-
-    local session_id = request.sessionId
-
     --- @param option_id string|nil nil is a cancellation, not a selection
     local function answer(option_id)
         --- @type agentic.acp.RequestPermissionOutcome
@@ -557,6 +550,20 @@ function ACPClient:__handle_request_permission(message_id, request)
             outcome = outcome,
         })
     end
+
+    if not request.sessionId or not request.toolCall then
+        -- The `id` is owed an answer even when the payload is unusable, and
+        -- `error()` here would throw through the transport read loop.
+        -- Regression: acp_client.test.lua::"answers cancelled when the request is invalid"
+        Logger.notify(
+            "Invalid session/request_permission: " .. vim.inspect(request)
+        )
+        answer(nil)
+
+        return
+    end
+
+    local session_id = request.sessionId
 
     self:__with_subscriber(session_id, function(subscriber)
         local message = self:__build_tool_call_message(request.toolCall)

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -555,15 +555,20 @@ function ACPClient:__handle_request_permission(message_id, request)
 
     if
         type(request) ~= "table"
-        or not request.sessionId
-        or not request.toolCall
+        or type(request.sessionId) ~= "string"
+        or type(request.toolCall) ~= "table"
     then
         -- The `id` is owed an answer even when the payload is unusable, and
         -- `error()` here would throw through the transport read loop. A frame
         -- with no `params` arrives here as a nil request, so the type check
         -- must come before any indexing.
+        -- The nested checks are by TYPE, not truthiness: `sessionId` indexes
+        -- `self.subscribers`, so a non-string silently matches no subscriber,
+        -- and a truthy non-table `toolCall` throws inside the scheduled
+        -- `__build_tool_call_message`, leaving the `id` unanswered.
         -- Regression: acp_client.test.lua::"answers cancelled when the request is invalid"
         -- Regression: acp_client.test.lua::"answers cancelled when the request payload is missing"
+        -- Regression: acp_client.test.lua::"answers cancelled when the tool call is malformed"
         Logger.notify(
             "Invalid session/request_permission: " .. vim.inspect(request)
         )

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -334,6 +334,8 @@ function ACPClient:_handle_notification(message_id, method, params)
     if method == "session/update" then
         self:__handle_session_update(params)
     elseif method == "session/request_permission" then
+        -- `params` is declared as a bare `table`, which cannot satisfy the
+        -- structured `RequestPermission` shape. The callee guards the payload.
         --- @diagnostic disable-next-line: param-type-mismatch
         self:__handle_request_permission(message_id, params)
     elseif method == "fs/read_text_file" or method == "fs/write_text_file" then
@@ -537,7 +539,7 @@ end
 
 --- @protected
 --- @param message_id number
---- @param request agentic.acp.RequestPermission
+--- @param request agentic.acp.RequestPermission|nil
 function ACPClient:__handle_request_permission(message_id, request)
     --- @param option_id string|nil nil is a cancellation, not a selection
     local function answer(option_id)
@@ -551,10 +553,17 @@ function ACPClient:__handle_request_permission(message_id, request)
         })
     end
 
-    if not request.sessionId or not request.toolCall then
+    if
+        type(request) ~= "table"
+        or not request.sessionId
+        or not request.toolCall
+    then
         -- The `id` is owed an answer even when the payload is unusable, and
-        -- `error()` here would throw through the transport read loop.
+        -- `error()` here would throw through the transport read loop. A frame
+        -- with no `params` arrives here as a nil request, so the type check
+        -- must come before any indexing.
         -- Regression: acp_client.test.lua::"answers cancelled when the request is invalid"
+        -- Regression: acp_client.test.lua::"answers cancelled when the request payload is missing"
         Logger.notify(
             "Invalid session/request_permission: " .. vim.inspect(request)
         )

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -2,8 +2,6 @@ local Logger = require("agentic.utils.logger")
 local JsonFormat = require("agentic.utils.json_format")
 local transport_module = require("agentic.acp.acp_transport")
 
---- Known ACP protocol tool call kinds.
---- Used to detect unknown kinds from providers we don't use daily.
 local KNOWN_ACP_KINDS = {
     read = true,
     edit = true,
@@ -19,9 +17,7 @@ local KNOWN_ACP_KINDS = {
     switch_mode = true,
 }
 
---- Data fields set in the constructor. Separated from the full class
---- so LuaLS validates instance fields without requiring methods that
---- live on the prototype via __index.
+--- Split from the class so LuaLS validates instance fields without the prototype methods.
 --- @class agentic.acp.ACPClientData
 --- @field provider_config agentic.acp.ACPProviderConfig
 --- @field id_counter number
@@ -117,22 +113,47 @@ end
 --- @param session_id string
 --- @param handlers agentic.acp.ClientHandlers
 function ACPClient:_subscribe(session_id, handlers)
+    -- One subscriber per session ID: a replacement reroutes every update and permission
+    -- prompt to the newer handlers. Legitimate on a reconnect replay, a defect when two
+    -- managers claim one ID. Logged, not blocked: refusing the write would strand a
+    -- reconnect's fresh handlers.
+    if
+        self.subscribers[session_id]
+        and self.subscribers[session_id] ~= handlers
+    then
+        Logger.debug(
+            "Replacing existing subscriber for session_id: " .. session_id
+        )
+    end
+
     self.subscribers[session_id] = handlers
 end
 
 --- @protected
 --- @param session_id string
 --- @param callback fun(sub: agentic.acp.ClientHandlers): nil
-function ACPClient:__with_subscriber(session_id, callback)
-    local subscriber = self.subscribers[session_id]
-
-    if not subscriber then
+--- @param on_missing fun()|nil Runs when no subscriber answers; a JSON-RPC request needs it
+function ACPClient:__with_subscriber(session_id, callback, on_missing)
+    if not self.subscribers[session_id] then
         Logger.debug("No subscriber found for session_id: " .. session_id)
+
+        if on_missing then
+            on_missing()
+        end
+
         return
     end
 
     vim.schedule(function()
-        callback(subscriber)
+        -- Re-resolved here: `cancel_session` can drop the subscriber while this
+        -- callback sits in the queue.
+        local subscriber = self.subscribers[session_id]
+
+        if subscriber then
+            callback(subscriber)
+        elseif on_missing then
+            on_missing()
+        end
     end)
 end
 
@@ -186,7 +207,6 @@ function ACPClient:_set_state(state)
     end
 end
 
---- Reject all pending RPC callbacks when the connection drops.
 --- @protected
 --- @param reason string
 function ACPClient:_drain_pending_callbacks(reason)
@@ -270,10 +290,9 @@ function ACPClient:__send_result(id, result)
     self.transport:send(data)
 end
 
---- Handles raw JSON-RPC message received from the transport
 --- @param message agentic.acp.ResponseRaw
 function ACPClient:_handle_message(message)
-    -- NOT log agent messages chunk to avoid huge logs file
+    -- Chunks are not logged: they would flood the log file.
     if
         not (
             message.params
@@ -288,9 +307,7 @@ function ACPClient:_handle_message(message)
         Logger.debug_to_file(self.provider_config.name, "response: ", message)
     end
 
-    -- Check if this is a notification (has method but no id, or has both method and id for notifications)
     if message.method and not message.result and not message.error then
-        -- This is a notification
         self:_handle_notification(message.id, message.method, message.params)
     elseif message.id and (message.result or message.error) then
         local callback = self.callbacks[message.id]
@@ -351,8 +368,7 @@ function ACPClient:__handle_session_update(params)
         update.status = update.status or "pending"
 
         if not KNOWN_ACP_KINDS[update.kind] then
-            -- Using notify intentionally so users of providers
-            -- we don't use daily report unknown kinds as issues
+            -- notify, not debug: we want users to report these as issues.
             Logger.notify(
                 "Unknown ACP tool call kind: "
                     .. tostring(update.kind)
@@ -373,8 +389,7 @@ function ACPClient:__handle_session_update(params)
     end
 end
 
---- Safely split a string into an array of lines
---- Some agents send `nil` other send `vim.NIL` for empty content
+--- Agents send either `nil` or `vim.NIL` for empty content.
 --- @param possible_string string|nil|vim.NIL
 --- @return string[] lines
 function ACPClient:safe_split(possible_string)
@@ -385,7 +400,6 @@ function ACPClient:safe_split(possible_string)
     return {}
 end
 
---- Build the message for a tool_call. it's usually the first update received for a tool call
 --- @protected
 --- @param update agentic.acp.ToolCallBase
 --- @return agentic.ui.MessageWriter.ToolCallBlock message
@@ -447,7 +461,7 @@ function ACPClient:__build_tool_call_message(update)
         end
     end
 
-    -- Fallback: build diff from rawInput when content is missing (e.g. OpenCode)
+    -- Fallback for providers that send no `content` (OpenCode).
     local raw_input = type(update.rawInput) == "table" and update.rawInput
         or nil
 
@@ -475,9 +489,7 @@ function ACPClient:__build_tool_call_message(update)
         end
     end
 
-    -- Surface rawInput for tool calls with no content and no diff (e.g.
-    -- OpenCode's bash command lives only in rawInput). Skip `read` -- its
-    -- renderer treats #body as a line count and would print a bogus number.
+    -- `read` is skipped: its renderer treats `#body` as a line count.
     if
         not message.body
         and not message.diff
@@ -486,8 +498,6 @@ function ACPClient:__build_tool_call_message(update)
         and not vim.tbl_isempty(raw_input)
     then
         if type(raw_input.command) == "string" and raw_input.command ~= "" then
-            -- OpenCode execute tools: the command is the meaningful title and
-            -- the optional description reads better than raw JSON.
             message.argument = raw_input.command
             if
                 type(raw_input.description) == "string"
@@ -503,8 +513,6 @@ function ACPClient:__build_tool_call_message(update)
     return message
 end
 
---- Default handler for tool_call session updates.
---- Builds a generic ToolCallBlock from standard ACP fields.
 --- @protected
 --- @param session_id string
 --- @param update agentic.acp.ToolCallMessage
@@ -516,7 +524,6 @@ function ACPClient:__handle_tool_call(session_id, update)
     end)
 end
 
---- Default handler for tool_call_update session updates.
 --- @protected
 --- @param session_id string
 --- @param update agentic.acp.ToolCallUpdate
@@ -539,18 +546,27 @@ function ACPClient:__handle_request_permission(message_id, request)
 
     local session_id = request.sessionId
 
+    --- @param option_id string|nil nil is a cancellation, not a selection
+    local function answer(option_id)
+        --- @type agentic.acp.RequestPermissionOutcome
+        local outcome = option_id
+                and { outcome = "selected", optionId = option_id }
+            or { outcome = "cancelled" }
+
+        self:__send_result(message_id, {
+            outcome = outcome,
+        })
+    end
+
     self:__with_subscriber(session_id, function(subscriber)
         local message = self:__build_tool_call_message(request.toolCall)
         subscriber.on_tool_call_update(message)
 
-        subscriber.on_request_permission(request, function(option_id)
-            --- @type agentic.acp.RequestPermissionOutcome
-            local outcome = { outcome = "selected", optionId = option_id }
-
-            self:__send_result(message_id, {
-                outcome = outcome,
-            })
-        end)
+        subscriber.on_request_permission(request, answer)
+    end, function()
+        -- The request is still outstanding on the shared provider subprocess.
+        -- Regression: acp_client.test.lua::"answers cancelled when the subscriber is gone"
+        answer(nil)
     end)
 end
 
@@ -603,7 +619,6 @@ function ACPClient:_connect()
         end
         self.auth_methods = auth_methods
 
-        -- Check if we need to authenticate
         local auth_method = self.provider_config.auth_method
 
         -- FIXIT: auth_method should be validated against available methods from the agent message
@@ -706,7 +721,6 @@ function ACPClient:load_session(
         mcpServers = mcp_servers or {},
     }, function(_result, err)
         if err then
-            -- Avoid dangling subscribers if there are errors
             self.subscribers[session_id] = nil
         end
 
@@ -771,7 +785,6 @@ function ACPClient:send_prompt(session_id, prompt, callback)
     self:_send_request("session/prompt", params, callback)
 end
 
---- Set the agent mode for a session
 --- @param session_id string
 --- @param mode_id string
 --- @param callback fun(result: table|nil, err: agentic.acp.ACPError|nil)
@@ -784,14 +797,12 @@ function ACPClient:set_mode(session_id, mode_id, callback)
     self:_send_request("session/set_mode", params, callback)
 end
 
---- Set a config option value for a session
 --- @param params agentic.acp.SetConfigOptionParams
 --- @param callback fun(result: table|nil, err: agentic.acp.ACPError|nil)
 function ACPClient:set_config_option(params, callback)
     self:_send_request("session/set_config_option", params, callback)
 end
 
---- Set the provided model to the session
 --- @param session_id string
 --- @param model_id string
 --- @param callback fun(result: table|nil, err: agentic.acp.ACPError|nil)
@@ -804,7 +815,7 @@ function ACPClient:set_model(session_id, model_id, callback)
     self:_send_request("session/set_model", params, callback)
 end
 
---- Stops current generation/tool execution, keeps session active for the next prompt
+--- Keeps the session active for the next prompt, unlike `cancel_session`.
 --- @param session_id string
 function ACPClient:stop_generation(session_id)
     if not session_id then
@@ -816,15 +827,14 @@ function ACPClient:stop_generation(session_id)
     })
 end
 
---- Cancels and destroys session (cleanup)
---- Either to create a new session or if the tabpage is closed
+--- Destroys the session, unlike `stop_generation`.
 --- @param session_id string
 function ACPClient:cancel_session(session_id)
     if not session_id then
         return
     end
 
-    -- remove subscriber first to avoid handling any further messages
+    -- Dropped first, so no further messages reach the old subscriber.
     self.subscribers[session_id] = nil
 
     self:_send_notification("session/cancel", {

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -715,6 +715,29 @@ describe("ACPClient", function()
             end
         )
 
+        -- A malformed request still carries a JSON-RPC `id`. Throwing left it
+        -- unanswered AND threw through the transport read loop, hanging the
+        -- subprocess every other session shares.
+        it("answers cancelled when the request is invalid", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            -- `pcall` so a throwing handler surfaces as the assertions below
+            -- failing, not as an error escaping the test.
+            pcall(function()
+                --- @diagnostic disable-next-line: invisible, missing-fields
+                client:__handle_request_permission(15, { sessionId = "s1" })
+            end)
+
+            -- Answered synchronously: no subscriber lookup happens at all.
+            assert.equal(0, #queue)
+
+            assert.equal(1, #sent)
+            assert.equal(15, sent[1].id)
+            assert.same({ outcome = { outcome = "cancelled" } }, sent[1].result)
+        end)
+
         it("answers selected when the user picks an option", function()
             local client = create_ready_client()
             local sent = capture_sent()

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -24,6 +24,11 @@ describe("ACPClient", function()
 
     local mock_transport
 
+    --- Reverted in `after_each`: an assertion throwing mid-test must not leave
+    --- `vim.schedule` stubbed for every later file.
+    --- @type TestStub|nil
+    local schedule_stub
+
     --- @type fun(state: agentic.acp.ClientConnectionState)|nil
     local captured_on_state_change
 
@@ -119,6 +124,39 @@ describe("ACPClient", function()
         end)
     end
 
+    --- Queues `vim.schedule` callbacks so a test can drop the subscriber
+    --- between scheduling and running, as `cancel_session` does when a session
+    --- is destroyed mid-stream. The stub is reverted in `after_each`.
+    --- @return fun()[] queue
+    local function queue_schedules()
+        --- @type fun()[]
+        local queue = {}
+        schedule_stub = spy.stub(vim, "schedule")
+        schedule_stub:invokes(function(fn)
+            queue[#queue + 1] = fn
+        end)
+
+        return queue
+    end
+
+    --- @param queue fun()[]
+    local function drain(queue)
+        for _, fn in ipairs(queue) do
+            fn()
+        end
+    end
+
+    --- @return table[] sent decoded JSON-RPC frames
+    local function capture_sent()
+        --- @type table[]
+        local sent = {}
+        transport_send_stub:invokes(function(_self, data)
+            sent[#sent + 1] = vim.json.decode(data)
+        end)
+
+        return sent
+    end
+
     before_each(function()
         package.loaded["agentic.acp.acp_client"] = nil
         package.loaded["agentic.acp.acp_transport"] = nil
@@ -147,6 +185,11 @@ describe("ACPClient", function()
     end)
 
     after_each(function()
+        if schedule_stub then
+            schedule_stub:revert()
+            schedule_stub = nil
+        end
+
         logger_debug_stub:revert()
         logger_debug_to_file_stub:revert()
         logger_notify_stub:revert()
@@ -501,6 +544,203 @@ describe("ACPClient", function()
 
             -- callbacks table should be empty after drain
             assert.equal(0, vim.tbl_count(client.callbacks))
+        end)
+    end)
+
+    describe("__with_subscriber", function()
+        it("delivers to a subscriber that is still registered", function()
+            local client = create_ready_client()
+            local queue = queue_schedules()
+            local received = spy.new(function() end)
+
+            client.subscribers["s1"] = NOOP_HANDLERS
+            --- @diagnostic disable-next-line: invisible
+            client:__with_subscriber("s1", function(sub)
+                received(sub)
+            end)
+
+            drain(queue)
+
+            assert.spy(received).was.called(1)
+            assert.equal(NOOP_HANDLERS, received.calls[1][1])
+        end)
+
+        it("skips a subscriber dropped before the callback runs", function()
+            local client = create_ready_client()
+            local queue = queue_schedules()
+            local received = spy.new(function() end)
+
+            client.subscribers["s1"] = NOOP_HANDLERS
+            --- @diagnostic disable-next-line: invisible
+            client:__with_subscriber("s1", function(sub)
+                received(sub)
+            end)
+
+            -- `cancel_session` drops the subscriber while the update is queued
+            client.subscribers["s1"] = nil
+
+            drain(queue)
+
+            assert.spy(received).was.called(0)
+        end)
+
+        it("logs when a subscriber replaces an existing one", function()
+            local client = create_ready_client()
+
+            --- @type agentic.acp.ClientHandlers
+            local replacement = {
+                on_session_update = function() end,
+                on_request_permission = function() end,
+                on_error = function() end,
+                on_tool_call = function() end,
+                on_tool_call_update = function() end,
+            }
+
+            logger_debug_stub:reset()
+
+            --- @diagnostic disable-next-line: invisible
+            client:_subscribe("s1", NOOP_HANDLERS)
+            assert.spy(logger_debug_stub).was.called(0)
+
+            --- @diagnostic disable-next-line: invisible
+            client:_subscribe("s1", replacement)
+
+            assert.spy(logger_debug_stub).was.called(1)
+            assert.truthy(
+                logger_debug_stub.calls[1][1]:match(
+                    "Replacing existing subscriber"
+                )
+            )
+
+            -- Re-subscribing the SAME handlers is a no-op, not a collision
+            --- @diagnostic disable-next-line: invisible
+            client:_subscribe("s1", replacement)
+            assert.spy(logger_debug_stub).was.called(1)
+        end)
+    end)
+
+    describe("__handle_request_permission", function()
+        local REQUEST = {
+            sessionId = "s1",
+            toolCall = { toolCallId = "tc-1", kind = "edit" },
+            options = {
+                {
+                    optionId = "allow_once",
+                    name = "Allow",
+                    kind = "allow_once",
+                },
+            },
+        }
+
+        -- `on_missing` EARLY return, distinct from the deferred drop below: no
+        -- subscriber when the request arrives, so `__with_subscriber` never
+        -- schedules. Unanswered, the JSON-RPC request hangs the subprocess every
+        -- other session shares.
+        it(
+            "answers cancelled when no subscriber was ever registered",
+            function()
+                local client = create_ready_client()
+                local sent = capture_sent()
+                local queue = queue_schedules()
+
+                assert.is_nil(client.subscribers["s1"])
+
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(13, REQUEST)
+
+                -- Answered synchronously: nothing was queued to drain.
+                assert.equal(0, #queue)
+
+                assert.equal(1, #sent)
+                assert.equal(13, sent[1].id)
+                assert.same(
+                    { outcome = { outcome = "cancelled" } },
+                    sent[1].result
+                )
+            end
+        )
+
+        it("answers cancelled when the subscriber is gone", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            client.subscribers["s1"] = NOOP_HANDLERS
+            --- @diagnostic disable-next-line: invisible
+            client:__handle_request_permission(7, REQUEST)
+
+            -- `cancel_session` drops the subscriber while the request is queued.
+            -- A response is still owed: the subprocess is shared across every
+            -- session.
+            client.subscribers["s1"] = nil
+
+            drain(queue)
+
+            assert.equal(1, #sent)
+            assert.equal(7, sent[1].id)
+            assert.same({ outcome = { outcome = "cancelled" } }, sent[1].result)
+        end)
+
+        it(
+            "answers cancelled when the handler resolves with no option",
+            function()
+                local client = create_ready_client()
+                local sent = capture_sent()
+                local queue = queue_schedules()
+
+                --- @type agentic.acp.ClientHandlers
+                local handlers = {
+                    on_session_update = function() end,
+                    on_error = function() end,
+                    on_tool_call = function() end,
+                    on_tool_call_update = function() end,
+                    -- `PermissionManager:clear` resolves pending requests with a
+                    -- nil option on teardown.
+                    on_request_permission = function(_request, callback)
+                        callback(nil)
+                    end,
+                }
+
+                client.subscribers["s1"] = handlers
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(9, REQUEST)
+
+                drain(queue)
+
+                assert.equal(1, #sent)
+                assert.same(
+                    { outcome = { outcome = "cancelled" } },
+                    sent[1].result
+                )
+            end
+        )
+
+        it("answers selected when the user picks an option", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            --- @type agentic.acp.ClientHandlers
+            local handlers = {
+                on_session_update = function() end,
+                on_error = function() end,
+                on_tool_call = function() end,
+                on_tool_call_update = function() end,
+                on_request_permission = function(_request, callback)
+                    callback("allow_once")
+                end,
+            }
+
+            client.subscribers["s1"] = handlers
+            --- @diagnostic disable-next-line: invisible
+            client:__handle_request_permission(11, REQUEST)
+
+            drain(queue)
+
+            assert.equal(1, #sent)
+            assert.same({
+                outcome = { outcome = "selected", optionId = "allow_once" },
+            }, sent[1].result)
         end)
     end)
 

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -738,6 +738,30 @@ describe("ACPClient", function()
             assert.same({ outcome = { outcome = "cancelled" } }, sent[1].result)
         end)
 
+        -- `_handle_message` dispatches on `method` alone and forwards
+        -- `message.params` unchecked, so a frame with no `params` reaches the
+        -- handler with a nil request. Indexing it threw through the transport
+        -- read loop and left the `id` unanswered.
+        it("answers cancelled when the request payload is missing", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            -- `pcall` so a throwing handler surfaces as the assertions
+            -- below failing, not as an error escaping the test.
+            pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(17, nil)
+            end)
+
+            -- Answered synchronously: no subscriber lookup happens at all.
+            assert.equal(0, #queue)
+
+            assert.equal(1, #sent)
+            assert.equal(17, sent[1].id)
+            assert.same({ outcome = { outcome = "cancelled" } }, sent[1].result)
+        end)
+
         it("answers selected when the user picks an option", function()
             local client = create_ready_client()
             local sent = capture_sent()

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -723,12 +723,15 @@ describe("ACPClient", function()
             local sent = capture_sent()
             local queue = queue_schedules()
 
-            -- `pcall` so a throwing handler surfaces as the assertions below
-            -- failing, not as an error escaping the test.
-            pcall(function()
+            -- `pcall` result is asserted: a handler that answers cancelled and
+            -- THEN throws still breaks the caller, so the throw must fail the
+            -- test loudly with its message rather than be swallowed.
+            local ok, err = pcall(function()
                 --- @diagnostic disable-next-line: invisible, missing-fields
                 client:__handle_request_permission(15, { sessionId = "s1" })
             end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
 
             -- Answered synchronously: no subscriber lookup happens at all.
             assert.equal(0, #queue)
@@ -747,12 +750,15 @@ describe("ACPClient", function()
             local sent = capture_sent()
             local queue = queue_schedules()
 
-            -- `pcall` so a throwing handler surfaces as the assertions
-            -- below failing, not as an error escaping the test.
-            pcall(function()
+            -- `pcall` result is asserted: a handler that answers cancelled and
+            -- THEN throws still breaks the caller, so the throw must fail the
+            -- test loudly with its message rather than be swallowed.
+            local ok, err = pcall(function()
                 --- @diagnostic disable-next-line: invisible
                 client:__handle_request_permission(17, nil)
             end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
 
             -- Answered synchronously: no subscriber lookup happens at all.
             assert.equal(0, #queue)
@@ -760,6 +766,54 @@ describe("ACPClient", function()
             assert.equal(1, #sent)
             assert.equal(17, sent[1].id)
             assert.same({ outcome = { outcome = "cancelled" } }, sent[1].result)
+        end)
+
+        -- A truthy non-table `toolCall` passes a `not request.toolCall` guard.
+        -- `__build_tool_call_message` then indexes it inside the scheduled
+        -- subscriber dispatch: a number throws ("attempt to index a number
+        -- value"), leaving the JSON-RPC `id` unanswered. A string would only
+        -- yield a junk-but-harmless message, so the number is the shape that
+        -- genuinely fails.
+        it("answers cancelled when the tool call is malformed", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            local asked = spy.new(function() end)
+
+            --- @type agentic.acp.ClientHandlers
+            local handlers = {
+                on_session_update = function() end,
+                on_error = function() end,
+                on_tool_call = function() end,
+                on_tool_call_update = function() end,
+                on_request_permission = function(request, callback)
+                    asked(request, callback)
+                end,
+            }
+
+            client.subscribers["s1"] = handlers
+
+            --- @type agentic.acp.RequestPermission
+            --- @diagnostic disable-next-line: assign-type-mismatch, missing-fields
+            local malformed = { sessionId = "s1", toolCall = 42 }
+
+            -- `vim.schedule` is stubbed, so a throw from the scheduled body
+            -- escapes into `drain` instead of dying on the (real) event loop.
+            -- Captured here so the payload assertions below report the failure.
+            local ok, err = pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(19, malformed)
+
+                drain(queue)
+            end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
+
+            assert.equal(#sent, 1)
+            assert.equal(sent[1].id, 19)
+            assert.equal(sent[1].result.outcome.outcome, "cancelled")
+            assert.equal(asked.call_count, 0)
         end)
 
         it("answers selected when the user picks an option", function()


### PR DESCRIPTION
- unanswered permission request hung the agent
- on_missing answers cancelled on both miss paths
- subscriber re-resolved inside the schedule body
- clear() no longer sends selected with no optionId
- notification call sites still return silently

`__with_subscriber` had no missing-subscriber path, so a permission request for a
dropped subscriber returned silently and its JSON-RPC request was never
answered. The subprocess is shared across tabpages, so that leaves an
outstanding request on the connection every other session depends on.
`_cancel_session` nils the subscriber then calls `permission_manager:clear()`,
so it can also vanish across the `vim.schedule` boundary.

Same change fixes a second defect: `PermissionManager:clear` passes `nil`, which
built `{ outcome = "selected", optionId = nil }`, encoded as
`{"outcome":"selected"}`. That violates `agentic.acp.RequestPermissionOutcome`.

Regression: `answers cancelled when the subscriber is gone`. Verified red on
`2c1864d` with 5 assertion mismatches, no import errors, and the 26 existing
cases stayed green.

Known follow-up, pre-existing and not in this PR: `fs/read_text_file` and
`fs/write_text_file` are handled as notifications but are requests carrying an
`id`, so they go unanswered. Unreachable while the client advertises
`readTextFile = false` / `writeTextFile = false`.
