### PR TITLE
fix: answer cancelled when permission dispatch throws

### DIFF
--- a/lua/agentic/acp/AGENTS.md
+++ b/lua/agentic/acp/AGENTS.md
@@ -90,6 +90,44 @@ keep returning silently.
 Regression:
 `lua/agentic/acp/acp_client.test.lua::"answers cancelled when the subscriber is gone"`.
 
+### The dispatch body MUST answer even when it throws
+
+A missing subscriber is not the only way to strand the `id`. The pre-dispatch
+type guard in `__handle_request_permission` only validates the payload's **top
+level**; everything below it runs unchecked inside the `vim.schedule` body, where
+three reachable throws left the `id` unanswered:
+
+- `subscriber.on_request_permission` throws (a UI defect)
+- `subscriber.on_tool_call_update` throws (same)
+- `__build_tool_call_message` throws on a payload the type guard accepts.
+  `update.content` is type-checked but its **elements** are not, so
+  `toolCall = { toolCallId = "t1", content = { 5 } }` indexes a number.
+
+`vim.schedule` swallows the error, so the transport read loop survives — which is
+why this failed silently rather than crashing. The shared subprocess (ADR 0004)
+just waits, and every session hangs with it.
+
+The dispatch body is therefore wrapped in a `pcall` that answers
+`{ outcome = "cancelled" }` on failure. Two rules govern it:
+
+- It MUST `Logger.notify` the error. A silent cancel hides genuine UI bugs in
+  `on_request_permission` behind a permission prompt that merely "didn't appear".
+- `answer` MUST be idempotent. The subscriber can invoke its callback and _then_
+  throw; the `id` is already answered at that point, and a second `__send_result`
+  on one `id` is a protocol violation. The guard's cancel is a no-op once
+  answered, so a real `selected` outcome is never overwritten.
+
+Do NOT harden `__build_tool_call_message` instead. One guard at the dispatch
+boundary closes all three variants; hardening the builder is a larger diff for
+the same bug and still would not cover a throwing subscriber callback.
+
+Regressions:
+
+- `lua/agentic/acp/acp_client.test.lua::"answers cancelled when on_request_permission throws"`
+- `lua/agentic/acp/acp_client.test.lua::"answers cancelled when on_tool_call_update throws"`
+- `lua/agentic/acp/acp_client.test.lua::"answers cancelled when the nested tool call content is malformed"`
+- `lua/agentic/acp/acp_client.test.lua::"answers once when the handler answers and then throws"`
+
 ## Protocol flow details
 
 The full event pipeline, ACPClient lifecycle, stdio framing, sync/async

--- a/lua/agentic/acp/AGENTS.md
+++ b/lua/agentic/acp/AGENTS.md
@@ -110,8 +110,9 @@ just waits, and every session hangs with it.
 The dispatch body is therefore wrapped in a `pcall` that answers
 `{ outcome = "cancelled" }` on failure. Two rules govern it:
 
-- It MUST `Logger.notify` the error. A silent cancel hides genuine UI bugs in
-  `on_request_permission` behind a permission prompt that merely "didn't appear".
+- It MUST `Logger.notify` the error, **including when `answer` is already a
+  no-op**. A silent cancel hides genuine UI bugs in `on_request_permission`
+  behind a permission prompt that merely "didn't appear".
 - `answer` MUST be idempotent. The subscriber can invoke its callback and _then_
   throw; the `id` is already answered at that point, and a second `__send_result`
   on one `id` is a protocol violation. The guard's cancel is a no-op once
@@ -127,6 +128,32 @@ Regressions:
 - `lua/agentic/acp/acp_client.test.lua::"answers cancelled when on_tool_call_update throws"`
 - `lua/agentic/acp/acp_client.test.lua::"answers cancelled when the nested tool call content is malformed"`
 - `lua/agentic/acp/acp_client.test.lua::"answers once when the handler answers and then throws"`
+
+### Permission state is per-`id`, never shared
+
+An agent can leave several `session/request_permission` requests outstanding at
+once, and the user may answer them in any order — or never answer some. The
+`PermissionManager` keys `pending` by `tool_call_id` and supports out-of-order
+`resolve`, so the ACP layer must match it.
+
+`answered` and `answer` are therefore **locals of each
+`__handle_request_permission` invocation**, closing over that invocation's
+`message_id`. Hoisting either onto `self` (or any module-level table) crosses the
+wires: a shared `answered` swallows the second answer, and a shared `message_id`
+pairs one request's `optionId` with another's `id`.
+
+Each outstanding request also owns its failures. A throw in one dispatch cancels
+only that `id`, and a subscriber dropped between two dispatches cancels only the
+one still queued — the sibling holding a live `answer` closure resolves normally.
+
+`PermissionManager:clear()` fires **every** pending callback with `nil`, so all
+outstanding `id`s answer `cancelled`. That is correct on teardown: each `answer`
+is a distinct closure, so the manager's fan-out maps one-to-one onto the
+outstanding requests with no double-send.
+
+Regressions in
+`lua/agentic/acp/acp_client.test.lua::"__handle_request_permission concurrency"`,
+notably `"answers two outstanding requests in reverse order"`.
 
 ## Protocol flow details
 

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -541,8 +541,19 @@ end
 --- @param message_id number
 --- @param request agentic.acp.RequestPermission|nil
 function ACPClient:__handle_request_permission(message_id, request)
+    local answered = false
+
+    --- Idempotent: the dispatch guard below cancels on a throw, and the
+    --- subscriber may already have answered before throwing. A second
+    --- `__send_result` on one `id` is a protocol violation.
     --- @param option_id string|nil nil is a cancellation, not a selection
     local function answer(option_id)
+        if answered then
+            return
+        end
+
+        answered = true
+
         --- @type agentic.acp.RequestPermissionOutcome
         local outcome = option_id
                 and { outcome = "selected", optionId = option_id }
@@ -580,10 +591,31 @@ function ACPClient:__handle_request_permission(message_id, request)
     local session_id = request.sessionId
 
     self:__with_subscriber(session_id, function(subscriber)
-        local message = self:__build_tool_call_message(request.toolCall)
-        subscriber.on_tool_call_update(message)
+        -- Any throw in here still owes the `id` an answer. The type guard above
+        -- only covers the payload's top level: nested shapes reach
+        -- `__build_tool_call_message` unchecked, and either subscriber callback
+        -- can throw on a UI defect. `vim.schedule` swallows the error, so the
+        -- read loop survives but the shared subprocess waits forever.
+        -- Notified, never silent: a swallowed throw hides real UI bugs.
+        -- Regression: acp_client.test.lua::"answers cancelled when on_request_permission throws"
+        -- Regression: acp_client.test.lua::"answers cancelled when on_tool_call_update throws"
+        -- Regression: acp_client.test.lua::"answers cancelled when the nested tool call content is malformed"
+        -- Regression: acp_client.test.lua::"answers once when the handler answers and then throws"
+        local ok, err = pcall(function()
+            local message = self:__build_tool_call_message(request.toolCall)
+            subscriber.on_tool_call_update(message)
 
-        subscriber.on_request_permission(request, answer)
+            subscriber.on_request_permission(request, answer)
+        end)
+
+        if not ok then
+            Logger.notify(
+                "Failed to dispatch session/request_permission: "
+                    .. tostring(err)
+            )
+            -- No-op when the subscriber already answered before throwing.
+            answer(nil)
+        end
     end, function()
         -- The request is still outstanding on the shared provider subprocess.
         -- Regression: acp_client.test.lua::"answers cancelled when the subscriber is gone"

--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -543,9 +543,9 @@ end
 function ACPClient:__handle_request_permission(message_id, request)
     local answered = false
 
-    --- Idempotent: the dispatch guard below cancels on a throw, and the
-    --- subscriber may already have answered before throwing. A second
-    --- `__send_result` on one `id` is a protocol violation.
+    --- Idempotent: the dispatch guard cancels on a throw that may land after
+    --- the subscriber already answered, and two results on one `id` is a
+    --- protocol violation.
     --- @param option_id string|nil nil is a cancellation, not a selection
     local function answer(option_id)
         if answered then
@@ -569,17 +569,10 @@ function ACPClient:__handle_request_permission(message_id, request)
         or type(request.sessionId) ~= "string"
         or type(request.toolCall) ~= "table"
     then
-        -- The `id` is owed an answer even when the payload is unusable, and
-        -- `error()` here would throw through the transport read loop. A frame
-        -- with no `params` arrives here as a nil request, so the type check
-        -- must come before any indexing.
-        -- The nested checks are by TYPE, not truthiness: `sessionId` indexes
-        -- `self.subscribers`, so a non-string silently matches no subscriber,
-        -- and a truthy non-table `toolCall` throws inside the scheduled
-        -- `__build_tool_call_message`, leaving the `id` unanswered.
-        -- Regression: acp_client.test.lua::"answers cancelled when the request is invalid"
-        -- Regression: acp_client.test.lua::"answers cancelled when the request payload is missing"
-        -- Regression: acp_client.test.lua::"answers cancelled when the tool call is malformed"
+        -- Checked by TYPE, not truthiness: a non-string `sessionId` silently
+        -- matches no subscriber, and a truthy non-table `toolCall` throws
+        -- inside the scheduled `__build_tool_call_message`. Either way the
+        -- `id` is owed an answer.
         Logger.notify(
             "Invalid session/request_permission: " .. vim.inspect(request)
         )
@@ -591,16 +584,11 @@ function ACPClient:__handle_request_permission(message_id, request)
     local session_id = request.sessionId
 
     self:__with_subscriber(session_id, function(subscriber)
-        -- Any throw in here still owes the `id` an answer. The type guard above
-        -- only covers the payload's top level: nested shapes reach
-        -- `__build_tool_call_message` unchecked, and either subscriber callback
-        -- can throw on a UI defect. `vim.schedule` swallows the error, so the
-        -- read loop survives but the shared subprocess waits forever.
-        -- Notified, never silent: a swallowed throw hides real UI bugs.
-        -- Regression: acp_client.test.lua::"answers cancelled when on_request_permission throws"
-        -- Regression: acp_client.test.lua::"answers cancelled when on_tool_call_update throws"
-        -- Regression: acp_client.test.lua::"answers cancelled when the nested tool call content is malformed"
-        -- Regression: acp_client.test.lua::"answers once when the handler answers and then throws"
+        -- The type guard above only covers the payload's top level; nested
+        -- shapes and both subscriber callbacks can still throw in here.
+        -- `vim.schedule` swallows that throw, so the read loop survives while
+        -- the shared subprocess waits on the `id` forever. See
+        -- `lua/agentic/acp/AGENTS.md`.
         local ok, err = pcall(function()
             local message = self:__build_tool_call_message(request.toolCall)
             subscriber.on_tool_call_update(message)
@@ -609,6 +597,8 @@ function ACPClient:__handle_request_permission(message_id, request)
         end)
 
         if not ok then
+            -- Always notified: a silent cancel hides a genuine UI bug behind a
+            -- permission prompt that merely "didn't appear".
             Logger.notify(
                 "Failed to dispatch session/request_permission: "
                     .. tostring(err)
@@ -618,7 +608,6 @@ function ACPClient:__handle_request_permission(message_id, request)
         end
     end, function()
         -- The request is still outstanding on the shared provider subprocess.
-        -- Regression: acp_client.test.lua::"answers cancelled when the subscriber is gone"
         answer(nil)
     end)
 end

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -843,6 +843,176 @@ describe("ACPClient", function()
                 outcome = { outcome = "selected", optionId = "allow_once" },
             }, sent[1].result)
         end)
+
+        -- A UI defect inside `on_request_permission` must not strand the
+        -- JSON-RPC `id`: the subprocess is shared across every session, so the
+        -- throw would hang all of them, not just this one.
+        it("answers cancelled when on_request_permission throws", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            --- @type agentic.acp.ClientHandlers
+            local handlers = {
+                on_session_update = function() end,
+                on_error = function() end,
+                on_tool_call = function() end,
+                on_tool_call_update = function() end,
+                on_request_permission = function()
+                    error("boom in on_request_permission")
+                end,
+            }
+
+            client.subscribers["s1"] = handlers
+
+            -- `vim.schedule` is stubbed, so a throw from the scheduled body
+            -- escapes into `drain` instead of dying on the (real) event loop.
+            local ok, err = pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(21, REQUEST)
+
+                drain(queue)
+            end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
+
+            assert.equal(#sent, 1)
+            assert.equal(sent[1].id, 21)
+            assert.equal(sent[1].result.outcome.outcome, "cancelled")
+            assert.spy(logger_notify_stub).was.called(1)
+            assert.truthy(
+                logger_notify_stub.calls[1][1]:match(
+                    "boom in on_request_permission"
+                )
+            )
+        end)
+
+        -- The permission flow renders the tool call before prompting, so a
+        -- throw in `on_tool_call_update` aborts the dispatch before
+        -- `on_request_permission` is ever reached.
+        it("answers cancelled when on_tool_call_update throws", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            local asked = spy.new(function() end)
+
+            --- @type agentic.acp.ClientHandlers
+            local handlers = {
+                on_session_update = function() end,
+                on_error = function() end,
+                on_tool_call = function() end,
+                on_tool_call_update = function()
+                    error("boom in on_tool_call_update")
+                end,
+                on_request_permission = function(request, callback)
+                    asked(request, callback)
+                end,
+            }
+
+            client.subscribers["s1"] = handlers
+
+            local ok, err = pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(23, REQUEST)
+
+                drain(queue)
+            end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
+
+            assert.equal(#sent, 1)
+            assert.equal(sent[1].id, 23)
+            assert.equal(sent[1].result.outcome.outcome, "cancelled")
+            assert.equal(asked.call_count, 0)
+        end)
+
+        -- `toolCall` is a table, so the pre-dispatch type guard passes, but
+        -- `update.content` elements are unchecked: `content.type` on a number
+        -- throws inside the scheduled `__build_tool_call_message`.
+        it(
+            "answers cancelled when the nested tool call content is malformed",
+            function()
+                local client = create_ready_client()
+                local sent = capture_sent()
+                local queue = queue_schedules()
+
+                local asked = spy.new(function() end)
+
+                --- @type agentic.acp.ClientHandlers
+                local handlers = {
+                    on_session_update = function() end,
+                    on_error = function() end,
+                    on_tool_call = function() end,
+                    on_tool_call_update = function() end,
+                    on_request_permission = function(request, callback)
+                        asked(request, callback)
+                    end,
+                }
+
+                client.subscribers["s1"] = handlers
+
+                --- @type agentic.acp.RequestPermission
+                --- @diagnostic disable-next-line: missing-fields
+                local malformed = {
+                    sessionId = "s1",
+                    --- @diagnostic disable-next-line: assign-type-mismatch
+                    toolCall = { toolCallId = "t1", content = { 5 } },
+                }
+
+                local ok, err = pcall(function()
+                    --- @diagnostic disable-next-line: invisible
+                    client:__handle_request_permission(25, malformed)
+
+                    drain(queue)
+                end)
+                assert.equal(ok, true)
+                assert.is_nil(err)
+
+                assert.equal(#sent, 1)
+                assert.equal(sent[1].id, 25)
+                assert.equal(sent[1].result.outcome.outcome, "cancelled")
+                assert.equal(asked.call_count, 0)
+            end
+        )
+
+        -- The `id` was already answered before the throw. A second
+        -- `__send_result` on the same `id` is a protocol violation, so the
+        -- dispatch guard must not overwrite a real selection with a cancel.
+        it("answers once when the handler answers and then throws", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            --- @type agentic.acp.ClientHandlers
+            local handlers = {
+                on_session_update = function() end,
+                on_error = function() end,
+                on_tool_call = function() end,
+                on_tool_call_update = function() end,
+                on_request_permission = function(_request, callback)
+                    callback("allow_once")
+                    error("boom after answering")
+                end,
+            }
+
+            client.subscribers["s1"] = handlers
+
+            local ok, err = pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(27, REQUEST)
+
+                drain(queue)
+            end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
+
+            assert.equal(#sent, 1)
+            assert.equal(sent[1].id, 27)
+            assert.same({
+                outcome = { outcome = "selected", optionId = "allow_once" },
+            }, sent[1].result)
+        end)
     end)
 
     describe("__build_tool_call_message", function()

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -844,9 +844,8 @@ describe("ACPClient", function()
             }, sent[1].result)
         end)
 
-        -- A UI defect inside `on_request_permission` must not strand the
-        -- JSON-RPC `id`: the subprocess is shared across every session, so the
-        -- throw would hang all of them, not just this one.
+        -- The subprocess is shared across every session, so a stranded `id`
+        -- hangs all of them, not just this one.
         it("answers cancelled when on_request_permission throws", function()
             local client = create_ready_client()
             local sent = capture_sent()
@@ -865,8 +864,6 @@ describe("ACPClient", function()
 
             client.subscribers["s1"] = handlers
 
-            -- `vim.schedule` is stubbed, so a throw from the scheduled body
-            -- escapes into `drain` instead of dying on the (real) event loop.
             local ok, err = pcall(function()
                 --- @diagnostic disable-next-line: invisible
                 client:__handle_request_permission(21, REQUEST)
@@ -1012,6 +1009,256 @@ describe("ACPClient", function()
             assert.same({
                 outcome = { outcome = "selected", optionId = "allow_once" },
             }, sent[1].result)
+            assert.spy(logger_notify_stub).was.called(1)
+            assert.truthy(
+                logger_notify_stub.calls[1][1]:match("boom after answering")
+            )
+        end)
+    end)
+
+    -- An agent can leave several permission requests outstanding at once and the
+    -- user may answer them in any order, or never. `answer`/`answered` are
+    -- per-invocation locals, so each `id` must carry its own state: a shared flag
+    -- would drop the second answer, a shared `answer` would cross the wires.
+    -- Every case uses DISTINCT ids, tool_call_ids and option ids so a cross-wire
+    -- fails instead of coincidentally matching.
+    describe("__handle_request_permission concurrency", function()
+        --- @param n integer
+        --- @return agentic.acp.RequestPermission request
+        local function make_request(n)
+            --- @type agentic.acp.RequestPermission
+            --- @diagnostic disable-next-line: missing-fields
+            local request = {
+                sessionId = "s1",
+                toolCall = { toolCallId = "tc-" .. n, kind = "edit" },
+                options = {
+                    {
+                        optionId = "opt-" .. n,
+                        name = "Allow " .. n,
+                        kind = "allow_once",
+                    },
+                },
+            }
+
+            return request
+        end
+
+        --- Collects one `answer` callback per request, keyed by tool_call_id, so
+        --- a test can invoke them in an order of its choosing.
+        --- @param answers table<string, fun(option_id: string|nil)>
+        --- @return agentic.acp.ClientHandlers handlers
+        local function collecting_handlers(answers)
+            --- @type agentic.acp.ClientHandlers
+            local handlers = {
+                on_session_update = function() end,
+                on_error = function() end,
+                on_tool_call = function() end,
+                on_tool_call_update = function() end,
+                on_request_permission = function(request, callback)
+                    answers[request.toolCall.toolCallId] = callback
+                end,
+            }
+
+            return handlers
+        end
+
+        --- @param sent table[]
+        --- @return table<number, string> outcome_by_id
+        local function outcomes_by_id(sent)
+            --- @type table<number, string>
+            local by_id = {}
+
+            for _, frame in ipairs(sent) do
+                by_id[frame.id] = frame.result.outcome.optionId
+                    or frame.result.outcome.outcome
+            end
+
+            return by_id
+        end
+
+        it("answers two outstanding requests in reverse order", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            --- @type table<string, fun(option_id: string|nil)>
+            local answers = {}
+            client.subscribers["s1"] = collecting_handlers(answers)
+
+            local ok, err = pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(101, make_request(1))
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(102, make_request(2))
+
+                drain(queue)
+
+                -- Reverse order: the SECOND request is answered first.
+                answers["tc-2"]("opt-2")
+                answers["tc-1"]("opt-1")
+            end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
+
+            assert.equal(#sent, 2)
+
+            -- Frame order follows answer order, and each id keeps its OWN option.
+            assert.equal(sent[1].id, 102)
+            assert.same({
+                outcome = { outcome = "selected", optionId = "opt-2" },
+            }, sent[1].result)
+            assert.equal(sent[2].id, 101)
+            assert.same({
+                outcome = { outcome = "selected", optionId = "opt-1" },
+            }, sent[2].result)
+        end)
+
+        it("answers three outstanding requests middle-first", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            --- @type table<string, fun(option_id: string|nil)>
+            local answers = {}
+            client.subscribers["s1"] = collecting_handlers(answers)
+
+            local ok, err = pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(201, make_request(1))
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(202, make_request(2))
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(203, make_request(3))
+
+                drain(queue)
+
+                answers["tc-2"]("opt-2")
+                answers["tc-3"]("opt-3")
+                answers["tc-1"]("opt-1")
+            end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
+
+            assert.equal(#sent, 3)
+            assert.same({
+                [201] = "opt-1",
+                [202] = "opt-2",
+                [203] = "opt-3",
+            }, outcomes_by_id(sent))
+        end)
+
+        it("leaves an unanswered request outstanding", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            --- @type table<string, fun(option_id: string|nil)>
+            local answers = {}
+            client.subscribers["s1"] = collecting_handlers(answers)
+
+            local ok, err = pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(301, make_request(1))
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(302, make_request(2))
+
+                drain(queue)
+
+                answers["tc-2"]("opt-2")
+            end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
+
+            -- Answering one must not answer the other on its behalf.
+            assert.equal(#sent, 1)
+            assert.equal(sent[1].id, 302)
+            assert.same({
+                outcome = { outcome = "selected", optionId = "opt-2" },
+            }, sent[1].result)
+        end)
+
+        -- A throw is scoped to the `id` that threw: the dispatch guard cancels
+        -- only its own request, never a sibling still waiting on the user.
+        it("cancels only the request whose dispatch throws", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            --- @type table<string, fun(option_id: string|nil)>
+            local answers = {}
+
+            --- @type agentic.acp.ClientHandlers
+            local handlers = {
+                on_session_update = function() end,
+                on_error = function() end,
+                on_tool_call = function() end,
+                on_tool_call_update = function() end,
+                on_request_permission = function(request, callback)
+                    if request.toolCall.toolCallId == "tc-1" then
+                        error("boom in tc-1")
+                    end
+
+                    answers[request.toolCall.toolCallId] = callback
+                end,
+            }
+
+            client.subscribers["s1"] = handlers
+
+            local ok, err = pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(401, make_request(1))
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(402, make_request(2))
+
+                drain(queue)
+
+                answers["tc-2"]("opt-2")
+            end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
+
+            assert.equal(#sent, 2)
+            assert.same({
+                [401] = "cancelled",
+                [402] = "opt-2",
+            }, outcomes_by_id(sent))
+        end)
+
+        -- `cancel_session` nils the subscriber between the two dispatches. The
+        -- first already holds its `answer` closure and still resolves normally;
+        -- the second re-resolves inside `vim.schedule`, finds nothing, and
+        -- cancels.
+        it("cancels only the request left without a subscriber", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            --- @type table<string, fun(option_id: string|nil)>
+            local answers = {}
+            client.subscribers["s1"] = collecting_handlers(answers)
+
+            local ok, err = pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(501, make_request(1))
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(502, make_request(2))
+
+                -- Only the FIRST scheduled body runs while the subscriber lives.
+                queue[1]()
+                answers["tc-1"]("opt-1")
+
+                client.subscribers["s1"] = nil
+                queue[2]()
+            end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
+
+            assert.equal(#sent, 2)
+            assert.same({
+                [501] = "opt-1",
+                [502] = "cancelled",
+            }, outcomes_by_id(sent))
+            assert.is_nil(answers["tc-2"])
         end)
     end)
 

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -1024,12 +1024,13 @@ describe("ACPClient", function()
     -- fails instead of coincidentally matching.
     describe("__handle_request_permission concurrency", function()
         --- @param n integer
+        --- @param session_id string|nil Defaults to "s1"
         --- @return agentic.acp.RequestPermission request
-        local function make_request(n)
+        local function make_request(n, session_id)
             --- @type agentic.acp.RequestPermission
             --- @diagnostic disable-next-line: missing-fields
             local request = {
-                sessionId = "s1",
+                sessionId = session_id or "s1",
                 toolCall = { toolCallId = "tc-" .. n, kind = "edit" },
                 options = {
                     {
@@ -1258,6 +1259,58 @@ describe("ACPClient", function()
                 [501] = "opt-1",
                 [502] = "cancelled",
             }, outcomes_by_id(sent))
+            assert.is_nil(answers["tc-2"])
+        end)
+
+        -- The subprocess is shared across sessions (ADR 0004), so a request
+        -- stuck on one session must not strand another's. Answered out of
+        -- order, and `s2` throws, which is that failure expressed across the
+        -- session boundary.
+        it("keeps requests on different sessions independent", function()
+            local client = create_ready_client()
+            local sent = capture_sent()
+            local queue = queue_schedules()
+
+            --- @type table<string, fun(option_id: string|nil)>
+            local answers = {}
+            client.subscribers["s1"] = collecting_handlers(answers)
+
+            --- @type agentic.acp.ClientHandlers
+            local throwing = {
+                on_session_update = function() end,
+                on_error = function() end,
+                on_tool_call = function() end,
+                on_tool_call_update = function() end,
+                on_request_permission = function()
+                    error("boom in s2")
+                end,
+            }
+
+            client.subscribers["s2"] = throwing
+
+            local ok, err = pcall(function()
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(601, make_request(1, "s1"))
+                --- @diagnostic disable-next-line: invisible
+                client:__handle_request_permission(602, make_request(2, "s2"))
+
+                drain(queue)
+
+                -- s2 already cancelled itself by throwing; s1 answers after it.
+                answers["tc-1"]("opt-1")
+            end)
+            assert.equal(ok, true)
+            assert.is_nil(err)
+
+            assert.equal(#sent, 2)
+
+            -- s2's throw cancels only its own `id`; s1 keeps its own optionId.
+            assert.equal(sent[1].id, 602)
+            assert.same({ outcome = { outcome = "cancelled" } }, sent[1].result)
+            assert.equal(sent[2].id, 601)
+            assert.same({
+                outcome = { outcome = "selected", optionId = "opt-1" },
+            }, sent[2].result)
             assert.is_nil(answers["tc-2"])
         end)
     end)


### PR DESCRIPTION
- Closes #290
- pcall wraps permission dispatch body
- Answers cancelled on any throw
- Logger.notify surfaces the error
- answer is now idempotent
- 4 new regression cases

The pre-dispatch type guard from #289 only covers the payload top level. Three throws inside the scheduled body still stranded the JSON-RPC id: a throwing on_request_permission, a throwing on_tool_call_update, and __build_tool_call_message on content elements it never type-checks. vim.schedule swallowed the error, so the read loop survived while the shared subprocess waited forever and every session hung.

One guard at the dispatch boundary closes all three rather than hardening the builder. answer tracks whether it already fired, so a subscriber that selects an option and then throws is not overwritten by a second cancelled result on the same id.
