### PR TITLE
fix: restore all windows on a rejected new file

### DIFF
--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -439,15 +439,24 @@ function M.clear_diff(buf, is_rejection)
             -- closes each window still holding the buffer. `win_findbuf` is
             -- tab-agnostic on purpose — that window may be in another tabpage.
             for _, buf_winid in ipairs(vim.fn.win_findbuf(bufnr)) do
-                -- The TARGET window's alternate buffer, not the current one's.
-                local alt = vim.api.nvim_win_call(buf_winid, function()
-                    return vim.fn.bufnr("#")
-                end)
+                -- An earlier swap fires autocmds that can close a later window
+                -- in this snapshot; a dead window needs no swap.
+                if BufHelpers.is_win_usable(buf_winid) then
+                    -- The TARGET window's alternate buffer, not the current one's.
+                    local ok, alt = pcall(
+                        vim.api.nvim_win_call,
+                        buf_winid,
+                        function()
+                            return vim.fn.bufnr("#")
+                        end
+                    )
 
-                local target_buf = (alt ~= -1 and alt ~= bufnr) and alt
-                    or vim.api.nvim_create_buf(true, true)
+                    local target_buf = (ok and alt ~= -1 and alt ~= bufnr)
+                            and alt
+                        or vim.api.nvim_create_buf(true, true)
 
-                pcall(vim.api.nvim_win_set_buf, buf_winid, target_buf)
+                    pcall(vim.api.nvim_win_set_buf, buf_winid, target_buf)
+                end
             end
             pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
         end

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -429,25 +429,24 @@ function M.clear_diff(buf, is_rejection)
         end
     end
 
-    -- On rejection for new files, switch window to alternate buffer
+    -- A rejected new file has nothing on disk, so its windows need another buffer.
     if is_rejection then
         local file_path = vim.api.nvim_buf_get_name(bufnr)
         local stat = file_path ~= "" and vim.uv.fs_stat(file_path)
 
         if not stat then
-            local buf_winid = vim.fn.bufwinid(bufnr)
-            if buf_winid ~= -1 then
-                -- Get alternate buffer for the target window, not current window
+            -- EVERY window, not just the painted one: `nvim_buf_delete(force)`
+            -- closes each window still holding the buffer. `win_findbuf` is
+            -- tab-agnostic on purpose — that window may be in another tabpage.
+            for _, buf_winid in ipairs(vim.fn.win_findbuf(bufnr)) do
+                -- The TARGET window's alternate buffer, not the current one's.
                 local alt = vim.api.nvim_win_call(buf_winid, function()
                     return vim.fn.bufnr("#")
                 end)
 
-                local target_buf
-                if alt ~= -1 and alt ~= bufnr then
-                    target_buf = alt
-                else
-                    target_buf = vim.api.nvim_create_buf(true, true)
-                end
+                local target_buf = (alt ~= -1 and alt ~= bufnr) and alt
+                    or vim.api.nvim_create_buf(true, true)
+
                 pcall(vim.api.nvim_win_set_buf, buf_winid, target_buf)
             end
             pcall(vim.api.nvim_buf_delete, bufnr, { force = true })

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -206,6 +206,8 @@ describe("diff_preview", function()
         local created_bufs
         --- @type table<integer, true>
         local base_tabs
+        --- @type integer
+        local augroup
 
         before_each(function()
             created_wins = {}
@@ -214,9 +216,15 @@ describe("diff_preview", function()
             for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
                 base_tabs[tab] = true
             end
+            augroup = vim.api.nvim_create_augroup(
+                "agentic_diff_preview_test",
+                { clear = true }
+            )
         end)
 
         after_each(function()
+            -- A leaked autocmd corrupts every later test file.
+            pcall(vim.api.nvim_del_augroup_by_id, augroup)
             for _, winid in ipairs(created_wins) do
                 pcall(vim.api.nvim_win_close, winid, true)
             end
@@ -415,6 +423,41 @@ describe("diff_preview", function()
             assert.is_true(vim.api.nvim_win_is_valid(second_win))
             assert.equal(first_alt, vim.api.nvim_win_get_buf(first_win))
             assert.equal(second_alt, vim.api.nvim_win_get_buf(second_win))
+        end)
+
+        it("finishes the rejection when a window dies mid-loop", function()
+            local bufnr = new_named_buf("/tmp/rejected_dying_window.lua")
+            local alt = new_named_buf("/tmp/dying_alternate.lua")
+
+            local first_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(first_win, alt)
+            vim.api.nvim_win_set_buf(first_win, bufnr)
+
+            local second_win = split_showing(alt, first_win)
+            vim.api.nvim_win_set_buf(second_win, bufnr)
+
+            local third_win = split_showing(alt, first_win)
+            vim.api.nvim_win_set_buf(third_win, bufnr)
+
+            -- `win_findbuf` snapshots the window list up front; swapping the
+            -- first window fires autocmds that can kill a LATER entry.
+            vim.api.nvim_create_autocmd("BufEnter", {
+                group = augroup,
+                buffer = alt,
+                callback = function()
+                    if vim.api.nvim_win_is_valid(third_win) then
+                        vim.api.nvim_win_close(third_win, true)
+                    end
+                end,
+            })
+
+            DiffPreview.clear_diff(bufnr, true)
+
+            assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
+            assert.is_true(vim.api.nvim_win_is_valid(first_win))
+            assert.is_true(vim.api.nvim_win_is_valid(second_win))
+            assert.equal(alt, vim.api.nvim_win_get_buf(first_win))
+            assert.equal(alt, vim.api.nvim_win_get_buf(second_win))
         end)
 
         it("keeps a window on the rejected file in another tabpage", function()

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -5,6 +5,20 @@ local Config = require("agentic.config")
 local FileSystem = require("agentic.utils.file_system")
 local Logger = require("agentic.utils.logger")
 
+--- Closes every tabpage absent from the baseline set. Counting tabpages and
+--- closing the *current* one can shut a baseline tab while a created one lives.
+--- @param base_tabs table<integer, true>
+local function close_extra_tabs(base_tabs)
+    for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+        if not base_tabs[tab] and vim.api.nvim_tabpage_is_valid(tab) then
+            pcall(function()
+                vim.api.nvim_set_current_tabpage(tab)
+                vim.cmd("tabclose!")
+            end)
+        end
+    end
+end
+
 describe("diff_preview", function()
     describe("show_diff", function()
         local read_stub
@@ -186,6 +200,54 @@ describe("diff_preview", function()
     end)
 
     describe("clear_diff", function()
+        --- @type integer[]
+        local created_wins
+        --- @type integer[]
+        local created_bufs
+        --- @type table<integer, true>
+        local base_tabs
+
+        before_each(function()
+            created_wins = {}
+            created_bufs = {}
+            base_tabs = {}
+            for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+                base_tabs[tab] = true
+            end
+        end)
+
+        after_each(function()
+            for _, winid in ipairs(created_wins) do
+                pcall(vim.api.nvim_win_close, winid, true)
+            end
+            for _, bufnr in ipairs(created_bufs) do
+                pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            end
+            close_extra_tabs(base_tabs)
+        end)
+
+        --- @param name string
+        --- @return integer bufnr
+        local function new_named_buf(name)
+            local bufnr = vim.api.nvim_create_buf(false, true)
+            created_bufs[#created_bufs + 1] = bufnr
+            vim.api.nvim_buf_set_name(bufnr, name)
+            vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "content" })
+            return bufnr
+        end
+
+        --- @param bufnr integer
+        --- @param parent integer
+        --- @return integer winid
+        local function split_showing(bufnr, parent)
+            local winid = vim.api.nvim_open_win(bufnr, false, {
+                split = "below",
+                win = parent,
+            })
+            created_wins[#created_wins + 1] = winid
+            return winid
+        end
+
         it("clears the diff without any error", function()
             local bufnr = vim.api.nvim_create_buf(false, true)
 
@@ -330,6 +392,66 @@ describe("diff_preview", function()
             if vim.api.nvim_buf_is_valid(alt_bufnr) then
                 pcall(vim.api.nvim_buf_delete, alt_bufnr, { force = true })
             end
+        end)
+
+        it("keeps the user's other window open on rejection", function()
+            local bufnr = new_named_buf("/tmp/rejected_two_windows.lua")
+            local first_alt = new_named_buf("/tmp/first_alternate.lua")
+            local second_alt = new_named_buf("/tmp/second_alternate.lua")
+
+            -- Each window gets its OWN alternate, so the swap must resolve `#`
+            -- inside each window rather than reuse the current window's.
+            local first_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(first_win, first_alt)
+            vim.api.nvim_win_set_buf(first_win, bufnr)
+
+            local second_win = split_showing(second_alt, first_win)
+            vim.api.nvim_win_set_buf(second_win, bufnr)
+
+            DiffPreview.clear_diff(bufnr, true)
+
+            assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
+            assert.is_true(vim.api.nvim_win_is_valid(first_win))
+            assert.is_true(vim.api.nvim_win_is_valid(second_win))
+            assert.equal(first_alt, vim.api.nvim_win_get_buf(first_win))
+            assert.equal(second_alt, vim.api.nvim_win_get_buf(second_win))
+        end)
+
+        it("keeps a window on the rejected file in another tabpage", function()
+            local bufnr = new_named_buf("/tmp/rejected_other_tab.lua")
+
+            local first_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(first_win, bufnr)
+
+            vim.cmd("tabnew")
+            local other_tab_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(other_tab_win, bufnr)
+            vim.api.nvim_set_current_win(first_win)
+
+            DiffPreview.clear_diff(bufnr, true)
+
+            assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
+            assert.is_true(vim.api.nvim_win_is_valid(other_tab_win))
+        end)
+
+        it("deletes nothing when the rejected file exists on disk", function()
+            local file_path = vim.fn.tempname()
+            local ok = vim.fn.writefile({ "content" }, file_path)
+            assert.equal(0, ok)
+
+            local bufnr = vim.fn.bufadd(file_path)
+            created_bufs[#created_bufs + 1] = bufnr
+            vim.fn.bufload(bufnr)
+
+            local winid = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(winid, bufnr)
+
+            DiffPreview.clear_diff(bufnr, true)
+
+            assert.is_true(vim.api.nvim_buf_is_valid(bufnr))
+            assert.equal(bufnr, vim.api.nvim_win_get_buf(winid))
+
+            vim.fn.delete(file_path)
         end)
     end)
 end)


### PR DESCRIPTION
- forced delete closed the user's other windows
- swap every window off the buffer first
- each window keeps its own alternate buffer
- skip windows that die mid-loop
- covers a window in another tabpage

`clear_diff` resolved one window via `vim.fn.bufwinid`, swapped it, then called
`nvim_buf_delete(bufnr, { force = true })`. That delete closes every remaining
window showing the buffer, so a second split on the same new file vanished.
`win_findbuf` is used without a tabpage filter deliberately: the at-risk window
can be in another tabpage and the forced delete would close it regardless.

Each window's alternate is resolved inside `nvim_win_call` so it is that
window's `#`, not the current window's. `win_findbuf` snapshots the list, so an
earlier swap can fire autocmds that close a later window in it; the loop guards
each handle with `BufHelpers.is_win_usable` and continues past a dead one, so
the buffer still gets deleted. The `pcall` around the alternate lookup is
defence in depth for a stale-valid handle, not separate autocmd coverage:
`nvim_win_call` fires no autocmds for its own window switch, so both guards
address the same dead-handle condition and either alone absorbs the tested
scenario.

Verified by mutation: iterating only the first window fails 2 tests, resolving
the alternate outside `nvim_win_call` fails with `Left: 14 / Right: 15`, and
removing both handle guards fails `finishes the rejection when a window dies
mid-loop`.
