### PR TITLE
fix: restore user hunk-nav keymaps and skip Agentic's own

### DIFF
--- a/lua/agentic/ui/hunk_navigation.lua
+++ b/lua/agentic/ui/hunk_navigation.lua
@@ -234,7 +234,13 @@ local function navigate_hunk(bufnr, direction)
     end)
 end
 
---- Save existing keymap for restoration
+local KEYMAP_DESC_SUFFIX = "Agentic DiffPreview"
+
+--- Buffer-local keymaps only; `maparg`'s `buffer` field is a 0/1 flag, not a buffer number.
+---
+--- Agentic's own mapping is never saved: two sessions diffing one file both run
+--- `setup_keymaps` on it, so the second call would capture the first's `]c` as the
+--- "user's" and reinstall it on teardown.
 --- @param bufnr number
 --- @param key string
 --- @return table|nil map_info
@@ -244,14 +250,16 @@ local function save_keymap(bufnr, key)
         map_info = vim.fn.maparg(key, "n", false, true)
     end)
 
-    if map_info and map_info.lhs then
-        -- vim.fn.maparg() returns buffer=1 as a flag indicating buffer-local mapping
-        -- (not the actual buffer number). We only save buffer-local keymaps.
-        if map_info.buffer == 1 then
-            return map_info
-        end
+    if not map_info or not map_info.lhs or map_info.buffer ~= 1 then
+        return nil
     end
-    return nil
+
+    local desc = map_info.desc
+    if type(desc) == "string" and desc:find(KEYMAP_DESC_SUFFIX, 1, true) then
+        return nil
+    end
+
+    return map_info
 end
 
 --- Navigate to next hunk
@@ -276,11 +284,11 @@ function M.setup_keymaps(bufnr)
 
     BufHelpers.keymap_set(bufnr, "n", keymaps.next_hunk, function()
         M.navigate_next(bufnr)
-    end, { desc = "Go to next hunk - Agentic DiffPreview" })
+    end, { desc = "Go to next hunk - " .. KEYMAP_DESC_SUFFIX })
 
     BufHelpers.keymap_set(bufnr, "n", keymaps.prev_hunk, function()
         M.navigate_prev(bufnr)
-    end, { desc = "Go to previous hunk - Agentic DiffPreview" })
+    end, { desc = "Go to previous hunk - " .. KEYMAP_DESC_SUFFIX })
 end
 
 --- Restore saved keymaps for buffer
@@ -294,7 +302,10 @@ function M.restore_keymaps(bufnr)
     if state and state.saved_keymaps then
         for _, saved_map in pairs(state.saved_keymaps) do
             if saved_map and saved_map.lhs then
-                local opts = { buffer = bufnr }
+                -- No `buffer` key: `BufHelpers.keymap_set` sets the scope itself,
+                -- and on 0.12.1+ both keys together raise "Conflict: 'buf' not
+                -- allowed with 'buffer'", silently swallowed by the pcall below.
+                local opts = {}
                 if saved_map.noremap == 1 then
                     opts.noremap = true
                 end

--- a/lua/agentic/ui/hunk_navigation.test.lua
+++ b/lua/agentic/ui/hunk_navigation.test.lua
@@ -502,9 +502,9 @@ describe("hunk_navigation", function()
             HunkNavigation.setup_keymaps(test_bufnr)
             HunkNavigation.restore_keymaps(test_bufnr)
 
-            assert.is_false(
-                is_buffer_local(get_keymap_in_buf(test_bufnr, "<leader>hn"))
-            )
+            local restored = get_keymap_in_buf(test_bufnr, "<leader>hn")
+            assert.is_false(is_buffer_local(restored))
+            assert.equal(":echo 'global'<CR>", restored.rhs)
         end)
     end)
 end)

--- a/lua/agentic/ui/hunk_navigation.test.lua
+++ b/lua/agentic/ui/hunk_navigation.test.lua
@@ -1,4 +1,5 @@
 local assert = require("tests.helpers.assert")
+local BufHelpers = require("agentic.utils.buf_helpers")
 local HunkNavigation = require("agentic.ui.hunk_navigation")
 local Theme = require("agentic.theme")
 
@@ -415,6 +416,95 @@ describe("hunk_navigation", function()
 
             local anchors = get_hunk_anchors(test_bufnr)
             assert.equal(#anchors, 1)
+        end)
+    end)
+
+    describe("save_keymap desc filter", function()
+        local Config
+        local original_keymaps
+
+        before_each(function()
+            vim.cmd("buffer " .. test_bufnr)
+            Config = require("agentic.config")
+            original_keymaps = vim.deepcopy(Config.keymaps.diff_preview)
+            Config.keymaps.diff_preview.next_hunk = "<leader>hn"
+            Config.keymaps.diff_preview.prev_hunk = "<leader>hp"
+        end)
+
+        after_each(function()
+            Config.keymaps.diff_preview = original_keymaps
+            BufHelpers.keymap_del(test_bufnr, "n", "<leader>hn")
+            BufHelpers.keymap_del(test_bufnr, "n", "<leader>hp")
+            pcall(vim.keymap.del, "n", "<leader>hn")
+            pcall(vim.keymap.del, "n", "<leader>hp")
+            HunkNavigation.clear_state(test_bufnr)
+        end)
+
+        it(
+            "saves and restores a user mapping with an unrelated desc",
+            function()
+                BufHelpers.keymap_set(
+                    test_bufnr,
+                    "n",
+                    "<leader>hn",
+                    ":echo 'user'<CR>",
+                    { desc = "User next hunk" }
+                )
+
+                HunkNavigation.setup_keymaps(test_bufnr)
+                HunkNavigation.restore_keymaps(test_bufnr)
+
+                local restored = get_keymap_in_buf(test_bufnr, "<leader>hn")
+                assert.is_true(is_buffer_local(restored))
+                assert.equal(restored.rhs, ":echo 'user'<CR>")
+            end
+        )
+
+        it(
+            "does not save a mapping whose desc marks it as Agentic's",
+            function()
+                BufHelpers.keymap_set(
+                    test_bufnr,
+                    "n",
+                    "<leader>hn",
+                    ":echo 'ours'<CR>",
+                    { desc = "Go to next hunk - Agentic DiffPreview" }
+                )
+
+                HunkNavigation.setup_keymaps(test_bufnr)
+                HunkNavigation.restore_keymaps(test_bufnr)
+
+                assert.is_true(
+                    vim.tbl_isempty(get_keymap_in_buf(test_bufnr, "<leader>hn"))
+                )
+            end
+        )
+
+        it("saves a mapping that carries no desc", function()
+            BufHelpers.keymap_set(
+                test_bufnr,
+                "n",
+                "<leader>hn",
+                ":echo 'no desc'<CR>"
+            )
+
+            HunkNavigation.setup_keymaps(test_bufnr)
+            HunkNavigation.restore_keymaps(test_bufnr)
+
+            local restored = get_keymap_in_buf(test_bufnr, "<leader>hn")
+            assert.is_true(is_buffer_local(restored))
+            assert.equal(restored.rhs, ":echo 'no desc'<CR>")
+        end)
+
+        it("does not save a global mapping", function()
+            vim.keymap.set("n", "<leader>hn", ":echo 'global'<CR>")
+
+            HunkNavigation.setup_keymaps(test_bufnr)
+            HunkNavigation.restore_keymaps(test_bufnr)
+
+            assert.is_false(
+                is_buffer_local(get_keymap_in_buf(test_bufnr, "<leader>hn"))
+            )
         end)
     end)
 end)


### PR DESCRIPTION
- user's hunk-nav keymaps were never restored
- buf and buffer keys conflict on 0.12.1+
- pcall swallowed the error silently
- skip Agentic's own mappings when saving
- prep for two sessions diffing one file

`restore_keymaps` passed `{ buffer = bufnr }` to `BufHelpers.keymap_set`, which
injects `opts.buf` on 0.12.1+. Both keys together raise
`Conflict: 'buf' not allowed with 'buffer'`, and the call sits inside a `pcall`,
so the failure was silent: the user's `]c` and `[c` were deleted and never
reinstalled. Reproduced directly on v0.12.4. Fix is `local opts = {}`, matching
what `BufHelpers.keymap_del` already did. Verified on both version branches, with
every other opt (`noremap`, `silent`, `expr`, `nowait`) preserved and no global
leak.

`save_keymap` now returns nil for a mapping whose `desc` contains
`Agentic DiffPreview`, so a double `setup_keymaps` cannot record Agentic's own
`]c` as the user's original. That path is not reachable today, since `main` pairs
one `setup_keymaps` with one `restore_keymaps`; it becomes reachable when two
sessions can diff the same file. That half is prep.

Verified by mutation: removing the desc check fails exactly
`does not save a mapping whose desc marks it as Agentic's`, and reinstating
`{ buffer = bufnr }` fails both restore tests.
