### PR TITLE
feat: truncate chat history title

### DIFF
--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -41,6 +41,20 @@ local Hooks = require("agentic.utils.hooks")
 local SessionManager = {}
 SessionManager.__index = SessionManager
 
+local TITLE_MAX_CHARS = 60
+
+--- @param prompt string
+--- @return string title
+local function title_from_prompt(prompt)
+    local title = vim.trim((prompt:gsub("%s+", " ")))
+
+    if vim.fn.strchars(title) > TITLE_MAX_CHARS then
+        title = vim.fn.strcharpart(title, 0, TITLE_MAX_CHARS - 1) .. "…"
+    end
+
+    return title
+end
+
 --- @param tab_page_id integer
 function SessionManager:new(tab_page_id)
     local AgentInstance = require("agentic.acp.agent_instance")
@@ -517,13 +531,13 @@ function SessionManager:_handle_input_submit(input_text)
     --- @type agentic.acp.Content[]
     local prompt = {}
 
-    -- If restored/switched session, prepend history on first submit
     if self.history_to_send then
-        self.chat_history.title = input_text -- Update title for restored session
         ChatHistory.prepend_restored_messages(self.history_to_send, prompt)
         self.history_to_send = nil
-    elseif self.chat_history.title == "" then
-        self.chat_history.title = input_text -- Set title for new session
+    end
+
+    if self.chat_history.title == "" then
+        self.chat_history.title = title_from_prompt(input_text)
     end
 
     table.insert(prompt, {

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -591,6 +591,35 @@ describe("agentic.SessionManager", function()
             end
         end)
 
+        --- @return agentic.SessionManager
+        local function make_session()
+            local tab_page_id = vim.api.nvim_get_current_tabpage()
+            local session = SessionManager:new(tab_page_id) --[[@as agentic.SessionManager]]
+            flush_schedule()
+            session.session_id = "test-session"
+
+            local SessionRegistry = require("agentic.session_registry")
+            SessionRegistry.sessions[tab_page_id] = session
+
+            session.agent.send_prompt = function(
+                _self,
+                _session_id,
+                _prompt,
+                callback
+            )
+                callback(nil, nil)
+            end
+
+            return session
+        end
+
+        --- @param session agentic.SessionManager
+        --- @param prompt string
+        local function submit(session, prompt)
+            assert.is_true(session:_handle_input_submit(prompt))
+            flush_schedule()
+        end
+
         it("prepends history on first submit and clears it", function()
             local tab_page_id = vim.api.nvim_get_current_tabpage()
             local session = SessionManager:new(tab_page_id) --[[@as agentic.SessionManager]]
@@ -626,6 +655,76 @@ describe("agentic.SessionManager", function()
             -- Prompt should contain the restored history
             assert.is_not_nil(submitted_prompt)
             assert.truthy(#submitted_prompt >= 2)
+        end)
+
+        it("uses a short first prompt as the title", function()
+            local session = make_session()
+
+            submit(session, "short prompt")
+
+            assert.equal("short prompt", session.chat_history.title)
+        end)
+
+        it("collapses whitespace in the title", function()
+            local session = make_session()
+
+            submit(session, "  fix  the\n  parser  ")
+
+            assert.equal("fix the parser", session.chat_history.title)
+        end)
+
+        it("truncates a long ASCII title to 60 codepoints", function()
+            local session = make_session()
+
+            submit(session, ("x"):rep(200))
+
+            assert.equal(("x"):rep(59) .. "…", session.chat_history.title)
+            assert.equal(60, vim.fn.strchars(session.chat_history.title))
+        end)
+
+        it("truncates a long CJK title on a codepoint boundary", function()
+            local session = make_session()
+
+            submit(session, ("日"):rep(120))
+
+            assert.equal(("日"):rep(59) .. "…", session.chat_history.title)
+            assert.equal(60, vim.fn.strchars(session.chat_history.title))
+        end)
+
+        it("keeps a title at exactly 60 codepoints", function()
+            local session = make_session()
+            local prompt = ("x"):rep(60)
+
+            submit(session, prompt)
+
+            assert.equal(prompt, session.chat_history.title)
+        end)
+
+        it("keeps the first title on later submits", function()
+            local session = make_session()
+
+            submit(session, "first prompt")
+            submit(session, "second prompt")
+
+            assert.equal("first prompt", session.chat_history.title)
+        end)
+
+        it("keeps a restored title while consuming history", function()
+            local session = make_session()
+            session.chat_history.title = "restored title"
+            session.history_to_send = {
+                {
+                    type = "user",
+                    text = "old msg",
+                    timestamp = os.time(),
+                    provider_name = "P",
+                },
+            }
+
+            submit(session, "new question")
+
+            assert.equal("restored title", session.chat_history.title)
+            assert.is_nil(session.history_to_send)
         end)
     end)
 

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -711,6 +711,8 @@ describe("agentic.SessionManager", function()
 
         it("keeps a restored title while consuming history", function()
             local session = make_session()
+            --- @type agentic.acp.Content[]|nil
+            local submitted_prompt
             session.chat_history.title = "restored title"
             session.history_to_send = {
                 {
@@ -720,11 +722,25 @@ describe("agentic.SessionManager", function()
                     provider_name = "P",
                 },
             }
+            session.agent.send_prompt = function(
+                _self,
+                _session_id,
+                prompt,
+                callback
+            )
+                submitted_prompt = prompt
+                callback(nil, nil)
+            end
 
             submit(session, "new question")
 
             assert.equal("restored title", session.chat_history.title)
             assert.is_nil(session.history_to_send)
+            assert.is_not_nil(submitted_prompt)
+            --- @type agentic.acp.Content[]
+            local prompt = submitted_prompt or {}
+            assert.equal("User: old msg", prompt[1].text)
+            assert.equal("new question", prompt[2].text)
         end)
     end)
 

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -742,6 +742,42 @@ describe("agentic.SessionManager", function()
             assert.equal("User: old msg", prompt[1].text)
             assert.equal("new question", prompt[2].text)
         end)
+
+        it(
+            "derives a normalized title for restored history without one",
+            function()
+                local session = make_session()
+                --- @type agentic.acp.Content[]|nil
+                local submitted_prompt
+                session.history_to_send = {
+                    {
+                        type = "user",
+                        text = "old msg",
+                        timestamp = os.time(),
+                        provider_name = "P",
+                    },
+                }
+                session.agent.send_prompt = function(
+                    _self,
+                    _session_id,
+                    prompt,
+                    callback
+                )
+                    submitted_prompt = prompt
+                    callback(nil, nil)
+                end
+
+                submit(session, "  new   question  ")
+
+                assert.equal("new question", session.chat_history.title)
+                assert.is_nil(session.history_to_send)
+                assert.is_not_nil(submitted_prompt)
+                --- @type agentic.acp.Content[]
+                local prompt = submitted_prompt or {}
+                assert.equal("User: old msg", prompt[1].text)
+                assert.equal("  new   question  ", prompt[2].text)
+            end
+        )
     end)
 
     describe("_on_session_update: on_session_update hook", function()


### PR DESCRIPTION
- 60-codepoint bound
- whitespace normalization
- first-title stability for new and restored sessions
