### PR TITLE
fix: isolate ACP restore lifecycle

### DIFF
--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -762,7 +762,7 @@ function ACPClient:load_session(
         cwd = cwd,
         mcpServers = mcp_servers or {},
     }, function(_result, err)
-        if err then
+        if err and self.subscribers[session_id] == handlers then
             self.subscribers[session_id] = nil
         end
 

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -337,6 +337,38 @@ describe("ACPClient", function()
             assert.equal("load failed", received_err.message)
         end)
 
+        it(
+            "keeps a replacement subscriber after an older load fails",
+            function()
+                local client = create_ready_client(LOAD_CAPS)
+                local request_ids = {}
+                transport_send_stub:invokes(function(_self, data)
+                    local decoded = vim.json.decode(data)
+                    request_ids[#request_ids + 1] = decoded.id
+                end)
+                --- @type agentic.acp.ClientHandlers
+                local first_handlers = vim.deepcopy(NOOP_HANDLERS)
+                --- @type agentic.acp.ClientHandlers
+                local replacement_handlers = vim.deepcopy(NOOP_HANDLERS)
+
+                client:load_session("sid-1", "/tmp", {}, first_handlers)
+                client:load_session("sid-1", "/tmp", {}, replacement_handlers)
+
+                local on_message = captured_on_message
+                assert.is_not_nil(on_message)
+                --- @cast on_message -nil
+                on_message({
+                    jsonrpc = "2.0",
+                    id = request_ids[1],
+                    error = { code = -32000, message = "load failed" },
+                })
+
+                assert.is_true(
+                    client.subscribers["sid-1"] == replacement_handlers
+                )
+            end
+        )
+
         it("works without on_load_complete (backward compatible)", function()
             local client = create_ready_client(LOAD_CAPS)
 

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -20,6 +20,7 @@ local Hooks = require("agentic.utils.hooks")
 --- @field session_id? string
 --- @field tab_page_id integer
 --- @field _restoring_session_id? string ACP session ID claimed by an in-flight restore
+--- @field _restoring_session_token? table Identity of the in-flight restore attempt
 --- @field _is_first_message boolean
 --- @field is_generating boolean
 --- @field widget agentic.ui.ChatWidget
@@ -75,6 +76,7 @@ function SessionManager:new(tab_page_id)
         session_id = nil,
         tab_page_id = tab_page_id,
         _restoring_session_id = nil,
+        _restoring_session_token = nil,
         _is_first_message = true,
         is_generating = false,
         _is_restoring_session = false,
@@ -942,6 +944,7 @@ function SessionManager:_cancel_session()
 
     self.session_id = nil
     self._restoring_session_id = nil
+    self._restoring_session_token = nil
     self.permission_manager:clear()
     SlashCommands.setCommands(self.widget.buf_nrs.input, {})
 
@@ -1045,6 +1048,8 @@ function SessionManager:load_acp_session(session_id, title, timestamp)
 
     self._is_restoring_session = true
     self._restoring_session_id = session_id
+    local restoring_session_token = {}
+    self._restoring_session_token = restoring_session_token
     self.status_animation:start("busy")
 
     -- Write banner before loading so it appears at top of cleared buffer
@@ -1066,23 +1071,23 @@ function SessionManager:load_acp_session(session_id, title, timestamp)
         -- vim.schedule to run AFTER deferred session update notifications
         -- (user_message_chunk etc. are routed via __with_subscriber → vim.schedule)
         vim.schedule(function()
-            if self._destroyed then
-                if self._restoring_session_id == session_id then
-                    if not err then
-                        self.agent:cancel_session(session_id)
-                    end
-                    self._restoring_session_id = nil
-                end
-
+            if self._restoring_session_token ~= restoring_session_token then
                 return
             end
 
-            if self._restoring_session_id ~= session_id then
+            if self._destroyed then
+                if not err then
+                    self.agent:cancel_session(session_id)
+                end
+                self._restoring_session_id = nil
+                self._restoring_session_token = nil
+
                 return
             end
 
             self._is_restoring_session = false
             self._restoring_session_id = nil
+            self._restoring_session_token = nil
             self.status_animation:stop()
 
             -- Guard: if a new session was created while the load was in flight,

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -19,6 +19,7 @@ local Hooks = require("agentic.utils.hooks")
 --- @class agentic.SessionManager
 --- @field session_id? string
 --- @field tab_page_id integer
+--- @field _restoring_session_id? string ACP session ID claimed by an in-flight restore
 --- @field _is_first_message boolean
 --- @field is_generating boolean
 --- @field widget agentic.ui.ChatWidget
@@ -37,6 +38,7 @@ local Hooks = require("agentic.utils.hooks")
 --- @field history_to_send agentic.ui.ChatHistory.Message[]|nil
 --- @field _is_restoring_session boolean
 --- @field _connection_error boolean
+--- @field _destroyed boolean Async callbacks must re-check this at run time
 --- @field _session_ready_callbacks fun()[]
 local SessionManager = {}
 SessionManager.__index = SessionManager
@@ -72,16 +74,22 @@ function SessionManager:new(tab_page_id)
     self = setmetatable({
         session_id = nil,
         tab_page_id = tab_page_id,
+        _restoring_session_id = nil,
         _is_first_message = true,
         is_generating = false,
         _is_restoring_session = false,
         _connection_error = false,
+        _destroyed = false,
         history_to_send = nil,
         _session_ready_callbacks = {},
     }, self)
 
     local agent = AgentInstance.get_instance(Config.provider, function(_client)
         vim.schedule(function()
+            if self._destroyed then
+                return
+            end
+
             -- Guard: cached client may be dead
             if
                 self.agent.state == "error"
@@ -90,7 +98,7 @@ function SessionManager:new(tab_page_id)
                 self:_handle_connection_error()
                 return
             end
-            self:new_session()
+            self:_bootstrap_session()
         end)
     end)
 
@@ -119,6 +127,10 @@ function SessionManager:new(tab_page_id)
         and (self.agent.state == "error" or self.agent.state == "disconnected")
     then
         vim.schedule(function()
+            if self._destroyed then
+                return
+            end
+
             if not self._connection_error then
                 self:_handle_connection_error()
             end
@@ -222,6 +234,10 @@ end
 --- Handle provider connection failure.
 --- Stops busy animation and writes error to chat buffer.
 function SessionManager:_handle_connection_error()
+    if self._destroyed then
+        return
+    end
+
     self._connection_error = true
     self._session_ready_callbacks = {}
     self.is_generating = false
@@ -247,6 +263,10 @@ function SessionManager:on_session_ready(callback)
             "on_session_ready: session already ready, scheduling callback immediately"
         )
         vim.schedule(function()
+            if self._destroyed then
+                return
+            end
+
             callback(self)
         end)
         return
@@ -646,6 +666,10 @@ function SessionManager:_build_handlers()
     --- @type agentic.acp.ClientHandlers
     local handlers = {
         on_error = function(err)
+            if self._destroyed then
+                return
+            end
+
             Logger.debug("Agent error: ", err)
 
             self.message_writer:write_message(
@@ -658,18 +682,35 @@ function SessionManager:_build_handlers()
         end,
 
         on_session_update = function(update)
+            if self._destroyed then
+                return
+            end
+
             self:_on_session_update(update)
         end,
 
         on_tool_call = function(tool_call)
+            if self._destroyed then
+                return
+            end
+
             self:_on_tool_call(tool_call)
         end,
 
         on_tool_call_update = function(tool_call_update)
+            if self._destroyed then
+                return
+            end
+
             self:_on_tool_call_update(tool_call_update)
         end,
 
         on_request_permission = function(request, callback)
+            if self._destroyed then
+                callback(nil)
+                return
+            end
+
             Hooks.invoke("on_request_permission", {
                 request = request,
                 session_id = self.session_id,
@@ -701,6 +742,14 @@ function SessionManager:_build_handlers()
     return handlers
 end
 
+function SessionManager:_bootstrap_session()
+    if self._destroyed or self._is_restoring_session then
+        return
+    end
+
+    self:new_session()
+end
+
 --- Create a new session, optionally cancelling any existing one
 --- @param opts {restore_mode?: boolean, on_created?: fun(), timestamp?: string|integer}|nil
 function SessionManager:new_session(opts)
@@ -716,6 +765,14 @@ function SessionManager:new_session(opts)
     local handlers = self:_build_handlers()
 
     self.agent:create_session(handlers, function(response, err)
+        if self._destroyed then
+            if response and response.sessionId then
+                self.agent:cancel_session(response.sessionId)
+            end
+
+            return
+        end
+
         self.status_animation:stop()
 
         --- @type agentic.UserConfig.CreateSessionResponseData
@@ -813,6 +870,10 @@ function SessionManager:new_session(opts)
         -- Defer to avoid fast event context issues
         -- For restore: write welcome first, then replay via on_created
         vim.schedule(function()
+            if self._destroyed then
+                return
+            end
+
             local agent_info = self.agent.agent_info
             local welcome_message = self.message_writer:generate_welcome_header(
                 self.agent.provider_config.name,
@@ -854,14 +915,22 @@ function SessionManager:_start_spinner(state)
 end
 
 function SessionManager:_cancel_session()
+    local session_id = self.session_id
+    local restoring_session_id = self._restoring_session_id
+
     self._is_restoring_session = false
     self.is_generating = false
     self.status_animation:stop()
 
-    if self.session_id then
-        -- only cancel and clear content if there was an session
-        -- Otherwise, it clears selections and files when opening for the first time
-        self.agent:cancel_session(self.session_id)
+    if session_id then
+        self.agent:cancel_session(session_id)
+    end
+    if restoring_session_id and restoring_session_id ~= session_id then
+        self.agent:cancel_session(restoring_session_id)
+    end
+
+    if session_id or restoring_session_id then
+        -- Do not clear selections and files before the first ACP session exists.
         self.widget:clear()
         self.todo_list:clear()
         self.file_list:clear()
@@ -872,6 +941,7 @@ function SessionManager:_cancel_session()
     end
 
     self.session_id = nil
+    self._restoring_session_id = nil
     self.permission_manager:clear()
     SlashCommands.setCommands(self.widget.buf_nrs.input, {})
 
@@ -938,6 +1008,12 @@ function SessionManager:_handle_new_config_options(new_config_options)
 end
 
 function SessionManager:destroy()
+    if self._destroyed then
+        return
+    end
+
+    self._destroyed = true
+
     self:_cancel_session()
     self.widget:destroy()
     if self.message_writer then
@@ -968,6 +1044,7 @@ function SessionManager:load_acp_session(session_id, title, timestamp)
     self.config_options:restore_snapshot(saved_config)
 
     self._is_restoring_session = true
+    self._restoring_session_id = session_id
     self.status_animation:start("busy")
 
     -- Write banner before loading so it appears at top of cleared buffer
@@ -989,7 +1066,23 @@ function SessionManager:load_acp_session(session_id, title, timestamp)
         -- vim.schedule to run AFTER deferred session update notifications
         -- (user_message_chunk etc. are routed via __with_subscriber → vim.schedule)
         vim.schedule(function()
+            if self._destroyed then
+                if self._restoring_session_id == session_id then
+                    if not err then
+                        self.agent:cancel_session(session_id)
+                    end
+                    self._restoring_session_id = nil
+                end
+
+                return
+            end
+
+            if self._restoring_session_id ~= session_id then
+                return
+            end
+
             self._is_restoring_session = false
+            self._restoring_session_id = nil
             self.status_animation:stop()
 
             -- Guard: if a new session was created while the load was in flight,

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -329,6 +329,8 @@ describe("agentic.SessionManager", function()
         local schedule_stub
         --- @type TestStub
         local health_check_stub
+        local agent_state
+        local invoke_agent_callback
 
         --- @type fun()[]
         local schedule_queue = {}
@@ -353,11 +355,13 @@ describe("agentic.SessionManager", function()
             end)
             health_check_stub = spy.stub(ACPHealth, "check_configured_provider")
             health_check_stub:returns(true)
+            agent_state = "ready"
+            invoke_agent_callback = true
             get_instance_stub = spy.stub(AgentInstance, "get_instance")
             get_instance_stub:invokes(function(provider_name, callback)
                 --- @type agentic.acp.ACPClient
                 local fake = {}
-                fake.state = "ready"
+                fake.state = agent_state
                 fake.provider_config = {
                     name = provider_name or "Test",
                     initial_model = nil,
@@ -373,7 +377,7 @@ describe("agentic.SessionManager", function()
                     })
                 end
                 function fake:cancel_session() end
-                if callback then
+                if callback and invoke_agent_callback then
                     callback(fake)
                 end
                 return fake
@@ -432,6 +436,47 @@ describe("agentic.SessionManager", function()
             -- Don't flush — callback should be queued, not fired
             assert.is_false(callback_called)
             assert.equal(1, #session._session_ready_callbacks)
+        end)
+
+        it("ignores a cached-client callback after destroy", function()
+            agent_state = "error"
+            local tab_page_id = vim.api.nvim_get_current_tabpage()
+            local session = SessionManager:new(tab_page_id) --[[@as agentic.SessionManager]]
+
+            session:destroy()
+
+            assert.has_no_errors(function()
+                flush_schedule()
+            end)
+            assert.is_false(session._connection_error)
+        end)
+
+        it("ignores a synchronous-failure callback after destroy", function()
+            agent_state = "error"
+            invoke_agent_callback = false
+            local tab_page_id = vim.api.nvim_get_current_tabpage()
+            local session = SessionManager:new(tab_page_id) --[[@as agentic.SessionManager]]
+
+            session:destroy()
+
+            assert.has_no_errors(function()
+                flush_schedule()
+            end)
+            assert.is_false(session._connection_error)
+        end)
+
+        it("ignores an already-ready callback after destroy", function()
+            local tab_page_id = vim.api.nvim_get_current_tabpage()
+            local session = SessionManager:new(tab_page_id) --[[@as agentic.SessionManager]]
+            flush_schedule()
+            session.session_id = "ready-session" --[[@as string]]
+            local ready_spy = spy.new(function() end)
+            session:on_session_ready(ready_spy)
+
+            session:destroy()
+            flush_schedule()
+
+            assert.spy(ready_spy).was.called(0)
         end)
     end)
 
@@ -510,6 +555,30 @@ describe("agentic.SessionManager", function()
 
             assert.equal(0, #session._session_ready_callbacks)
             assert.is_true(session._connection_error)
+        end)
+
+        it("leaves state and UI unchanged after destroy", function()
+            local stop_spy = spy.new(function() end)
+            local write_spy = spy.new(function() end)
+            local callbacks = { function() end }
+            local session = {
+                _destroyed = true,
+                _connection_error = false,
+                _session_ready_callbacks = callbacks,
+                is_generating = true,
+                status_animation = { stop = stop_spy },
+                message_writer = { write_message = write_spy },
+                agent = { provider_config = { name = "TestProvider" } },
+                _handle_connection_error = SessionManager._handle_connection_error,
+            } --[[@as agentic.SessionManager]]
+
+            session:_handle_connection_error()
+
+            assert.is_false(session._connection_error)
+            assert.equal(callbacks, session._session_ready_callbacks)
+            assert.is_true(session.is_generating)
+            assert.spy(stop_spy).was.called(0)
+            assert.spy(write_spy).was.called(0)
         end)
     end)
 
@@ -2055,6 +2124,9 @@ describe("agentic.SessionManager", function()
             session = {
                 session_id = "test-session-123",
                 tab_page_id = 1,
+                message_writer = {
+                    write_message = function() end,
+                },
                 status_animation = {
                     stop = function() end,
                     start = function() end,
@@ -2069,6 +2141,9 @@ describe("agentic.SessionManager", function()
                     show = function() end,
                     clear = function() end,
                 },
+                _on_session_update = function() end,
+                _on_tool_call = function() end,
+                _on_tool_call_update = function() end,
                 _build_handlers = SessionManager._build_handlers,
             } --[[@as agentic.SessionManager]]
         end)
@@ -2123,6 +2198,64 @@ describe("agentic.SessionManager", function()
 
             -- Should not throw an error
             handlers.on_request_permission(mock_request, mock_callback)
+        end)
+
+        it(
+            "drops every handler after destroy and answers permission",
+            function()
+                local write_spy = spy.new(function() end)
+                local update_spy = spy.new(function() end)
+                local tool_spy = spy.new(function() end)
+                local tool_update_spy = spy.new(function() end)
+                local permission_spy = spy.new(function() end)
+                session._destroyed = true
+                session.message_writer.write_message = write_spy
+                session._on_session_update = update_spy
+                session._on_tool_call = tool_spy
+                session._on_tool_call_update = tool_update_spy
+
+                local handlers = session:_build_handlers()
+                handlers.on_error({ message = "late" })
+                handlers.on_session_update({ sessionUpdate = "late" })
+                handlers.on_tool_call({})
+                handlers.on_tool_call_update({})
+                handlers.on_request_permission({
+                    sessionId = "test-session-123",
+                    toolCall = { toolCallId = "tool-1", kind = "edit" },
+                    options = {},
+                }, permission_spy --[[@as function]])
+
+                assert.spy(write_spy).was.called(0)
+                assert.spy(update_spy).was.called(0)
+                assert.spy(tool_spy).was.called(0)
+                assert.spy(tool_update_spy).was.called(0)
+                assert.spy(permission_spy).was.called(1)
+                assert.is_nil(permission_spy.calls[1][1])
+            end
+        )
+    end)
+
+    describe("destroy", function()
+        it("is idempotent and marks destroyed before cancellation", function()
+            local cancel_spy = spy.new(function(session)
+                assert.is_true(session._destroyed)
+            end)
+            local widget_destroy_spy = spy.new(function() end)
+            local writer_destroy_spy = spy.new(function() end)
+            local session = {
+                _destroyed = false,
+                _cancel_session = cancel_spy,
+                widget = { destroy = widget_destroy_spy },
+                message_writer = { destroy = writer_destroy_spy },
+                destroy = SessionManager.destroy,
+            } --[[@as agentic.SessionManager]]
+
+            session:destroy()
+            session:destroy()
+
+            assert.spy(cancel_spy).was.called(1)
+            assert.spy(widget_destroy_spy).was.called(1)
+            assert.spy(writer_destroy_spy).was.called(1)
         end)
     end)
 end)

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -28,11 +28,26 @@ describe("race: stale create_session after load_acp_session", function()
     local slash_stub
     local payload_stub
 
-    before_each(function()
-        original_schedule = vim.schedule
-        -- Run vim.schedule callbacks synchronously so callbacks fire inline
-        vim.schedule = function(fn)
+    --- @type fun()[]
+    local queue = {}
+
+    local function drain()
+        local index = 1
+
+        while index <= #queue do
+            local fn = queue[index]
+            index = index + 1
             fn()
+        end
+
+        queue = {}
+    end
+
+    before_each(function()
+        queue = {}
+        original_schedule = vim.schedule
+        vim.schedule = function(fn)
+            queue[#queue + 1] = fn
         end
 
         slash_stub = spy.stub(SlashCommands, "setCommands")
@@ -57,7 +72,9 @@ describe("race: stale create_session after load_acp_session", function()
 
         local session = {
             session_id = nil,
+            _restoring_session_id = nil,
             _is_restoring_session = false,
+            _destroyed = false,
             is_generating = false,
             _session_ready_callbacks = {},
             _is_first_message = true,
@@ -101,6 +118,7 @@ describe("race: stale create_session after load_acp_session", function()
             file_list = { clear = function() end },
             code_selection = { clear = function() end },
             diagnostics_list = { clear = function() end },
+            session_state = { clear = function() end },
             config_options = {
                 clear = function() end,
                 mode = nil,
@@ -159,6 +177,7 @@ describe("race: stale create_session after load_acp_session", function()
                 return {}
             end,
             _set_mode_to_chat_header = function() end,
+            _bootstrap_session = SessionManager._bootstrap_session,
             _cancel_session = SessionManager._cancel_session,
             new_session = SessionManager.new_session,
             load_acp_session = SessionManager.load_acp_session,
@@ -186,9 +205,11 @@ describe("race: stale create_session after load_acp_session", function()
 
             -- Step 3: create fires first (while _is_restoring_session is still true)
             create_cb_ref.cb({ sessionId = "new-id" }, nil)
+            drain()
 
             -- Step 4: load completes
             load_cb_ref.cb(nil)
+            drain()
 
             assert.equal("restored-id", session.session_id)
             assert.is_true(vim.tbl_contains(session._cancelled, "new-id"))
@@ -209,11 +230,13 @@ describe("race: stale create_session after load_acp_session", function()
 
             -- Step 2: load_acp_session — load fires and completes synchronously
             session:load_acp_session("restored-id", "title", nil)
+            drain()
             assert.equal("restored-id", session.session_id)
             assert.is_false(session._is_restoring_session) -- cleared by load callback
 
             -- Step 3: stale create fires after load already finished
             create_cb_ref.cb({ sessionId = "new-id" }, nil)
+            drain()
 
             assert.equal("restored-id", session.session_id)
             assert.is_true(vim.tbl_contains(session._cancelled, "new-id"))
@@ -248,7 +271,9 @@ describe("race: stale create_session after load_acp_session", function()
                 },
                 models = { currentModelId = "sonnet", availableModels = {} },
             }, nil)
+            drain()
             load_cb_ref.cb(nil)
+            drain()
 
             assert.equal("restored-id", session.session_id)
             assert.is_true(vim.tbl_contains(session._cancelled, "new-id"))
@@ -279,7 +304,9 @@ describe("race: stale create_session after load_acp_session", function()
             sessionId = "new-id",
             configOptions = config_options,
         }, nil)
+        drain()
         load_cb_ref.cb(nil)
+        drain()
 
         assert.equal("restored-id", session.session_id)
         assert.is_true(vim.tbl_contains(session._cancelled, "new-id"))
@@ -306,14 +333,176 @@ describe("race: stale create_session after load_acp_session", function()
 
             -- Step 2: load_acp_session — load fires and completes synchronously
             session:load_acp_session("restored-id", "title", nil)
+            drain()
             assert.equal("restored-id", session.session_id)
             assert.is_false(session._is_restoring_session) -- cleared by load callback
 
             -- Step 3: stale create fails after restore already finished
             create_cb_ref.cb(nil, { message = "boom" })
+            drain()
 
             assert.equal("restored-id", session.session_id)
             assert.equal(0, #session._cancelled)
         end
     )
+
+    it("load before the bootstrap sends no competing create", function()
+        local create_cb_ref = {}
+        local load_cb_ref = {}
+        local session = make_session(create_cb_ref, load_cb_ref)
+
+        vim.schedule(function()
+            session:_bootstrap_session()
+        end)
+
+        session:load_acp_session("restored-id", "title", nil)
+        drain()
+
+        assert.is_nil(create_cb_ref.cb)
+        assert.is_true(session._is_restoring_session)
+
+        load_cb_ref.cb(nil)
+        drain()
+
+        assert.equal("restored-id", session.session_id)
+        assert.equal(0, #session._cancelled)
+    end)
+
+    it("claims the ACP id while restoring and clears it on failure", function()
+        local create_cb_ref = {}
+        local load_cb_ref = {}
+        local session = make_session(create_cb_ref, load_cb_ref)
+
+        session:load_acp_session("restored-id", "title", nil)
+
+        assert.equal("restored-id", session._restoring_session_id)
+
+        load_cb_ref.cb({ message = "boom" })
+        drain()
+
+        assert.is_nil(session._restoring_session_id)
+        assert.is_nil(session.session_id)
+    end)
+
+    it("keeps a newer restore claim when an older load fails", function()
+        local create_cb_ref = {}
+        local load_cb_ref = {}
+        local session = make_session(create_cb_ref, load_cb_ref)
+
+        session:load_acp_session("older-id", "older", nil)
+        local older_callback = load_cb_ref.cb
+        session:load_acp_session("newer-id", "newer", nil)
+
+        older_callback({ message = "older failed" })
+        drain()
+
+        assert.equal("newer-id", session._restoring_session_id)
+        assert.is_true(session._is_restoring_session)
+    end)
+
+    it("cancels an in-flight restore before starting a new session", function()
+        local create_cb_ref = {}
+        local load_cb_ref = {}
+        local session = make_session(create_cb_ref, load_cb_ref)
+
+        session:load_acp_session("restored-id", "title", nil)
+        session:new_session()
+
+        assert.same({ "restored-id" }, session._cancelled)
+        assert.is_nil(session._restoring_session_id)
+    end)
+
+    it("cancels active and restoring ACP ids once each", function()
+        local session = make_session({}, {})
+        session.session_id = "active-id"
+        session._restoring_session_id = "restored-id"
+
+        session:_cancel_session()
+
+        assert.same({ "active-id", "restored-id" }, session._cancelled)
+    end)
+
+    it("cancels one ACP id once when active and restoring ids match", function()
+        local session = make_session({}, {})
+        session.session_id = "same-id"
+        session._restoring_session_id = "same-id"
+
+        session:_cancel_session()
+
+        assert.same({ "same-id" }, session._cancelled)
+    end)
+
+    it("clears every UI state owner for a restore-only cancellation", function()
+        local session = make_session({}, {})
+        local clear_spies = {
+            spy.new(function() end),
+            spy.new(function() end),
+            spy.new(function() end),
+            spy.new(function() end),
+            spy.new(function() end),
+            spy.new(function() end),
+            spy.new(function() end),
+        }
+        session.widget.clear = clear_spies[1]
+        session.todo_list.clear = clear_spies[2]
+        session.file_list.clear = clear_spies[3]
+        session.code_selection.clear = clear_spies[4]
+        session.diagnostics_list.clear = clear_spies[5]
+        session.config_options.clear = clear_spies[6]
+        session.session_state.clear = clear_spies[7]
+        session._restoring_session_id = "restored-id"
+
+        session:_cancel_session()
+
+        for _, clear_spy in ipairs(clear_spies) do
+            assert.spy(clear_spy).was.called(1)
+        end
+    end)
+
+    it("does not cancel a released restore after destroy", function()
+        local create_cb_ref = {}
+        local load_cb_ref = {}
+        local session = make_session(create_cb_ref, load_cb_ref)
+
+        session:load_acp_session("restored-id", "title", nil)
+        session:_cancel_session()
+        session._destroyed = true
+
+        load_cb_ref.cb(nil)
+        drain()
+
+        assert.same({ "restored-id" }, session._cancelled)
+    end)
+
+    it(
+        "cancels a created ACP session whose response arrives after destroy",
+        function()
+            local create_cb_ref = {}
+            local session = make_session(create_cb_ref, {})
+
+            session:new_session()
+            session._destroyed = true
+            create_cb_ref.cb({ sessionId = "late-id" }, nil)
+            drain()
+
+            assert.is_nil(session.session_id)
+            assert.same({ "late-id" }, session._cancelled)
+        end
+    )
+
+    it("skips the deferred welcome write after destroy", function()
+        local create_cb_ref = {}
+        local session = make_session(create_cb_ref, {})
+        local write_spy = spy.new(function() end)
+        local created_spy = spy.new(function() end)
+        session.message_writer.write_structural_message = write_spy
+
+        session:new_session({ on_created = created_spy })
+        create_cb_ref.cb({ sessionId = "new-id" }, nil)
+        session._destroyed = true
+        drain()
+
+        assert.spy(write_spy).was.called(0)
+        assert.spy(created_spy).was.called(0)
+    end)
 end)

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -400,6 +400,25 @@ describe("race: stale create_session after load_acp_session", function()
         assert.is_true(session._is_restoring_session)
     end)
 
+    it(
+        "keeps a newer same-id restore claim when an older load fails",
+        function()
+            local create_cb_ref = {}
+            local load_cb_ref = {}
+            local session = make_session(create_cb_ref, load_cb_ref)
+
+            session:load_acp_session("same-id", "older", nil)
+            local older_callback = load_cb_ref.cb
+            session:load_acp_session("same-id", "newer", nil)
+
+            older_callback({ message = "older failed" })
+            drain()
+
+            assert.equal("same-id", session._restoring_session_id)
+            assert.is_true(session._is_restoring_session)
+        end
+    )
+
     it("cancels an in-flight restore before starting a new session", function()
         local create_cb_ref = {}
         local load_cb_ref = {}


### PR DESCRIPTION
- Protect overlapping restore ownership
- Cancel only manager-owned ACP sessions
- Preserve replacement subscribers after failure
- Verify with `make validate`
