### PR TITLE
refactor: resolve widget ownership by buffer

### DIFF
--- a/lua/agentic/ui/buffer_guard.lua
+++ b/lua/agentic/ui/buffer_guard.lua
@@ -1,5 +1,7 @@
 -- lua/agentic/ui/buffer_guard.lua
+local BufHelpers = require("agentic.utils.buf_helpers")
 local Logger = require("agentic.utils.logger")
+local WidgetRegistry = require("agentic.ui.widget_registry")
 
 --- @class agentic.ui.BufferGuard
 local BufferGuard = {}
@@ -8,18 +10,40 @@ local BufferGuard = {}
 --- @field tab_page_id integer
 --- @field find_target_window fun(): integer|nil
 
+--- @param widget agentic.ui.ChatWidget
+--- @return integer|nil destination
+local function find_destination(widget)
+    local tabpage = widget.tab_page_id
+    if not vim.api.nvim_tabpage_is_valid(tabpage) then
+        return nil
+    end
+
+    local destination = widget:find_first_non_widget_window()
+        or widget:open_editor_window()
+    if
+        not destination
+        or not BufHelpers.is_win_usable(destination)
+        or vim.api.nvim_win_get_tabpage(destination) ~= tabpage
+    then
+        return nil
+    end
+
+    return destination
+end
+
 --- Redirect a foreign buffer out of a widget window.
 --- The cursor follows the buffer to the target window via
 --- vim.schedule — setting current_win inside BufEnter doesn't
 --- stick because Neovim resets the window after the autocmd.
 --- @param foreign_buf integer
---- @param find_target_window fun(): integer|nil
-local function redirect_foreign(foreign_buf, find_target_window)
+--- @param widget agentic.ui.ChatWidget
+--- @param owner_bufnr integer
+local function redirect_foreign(foreign_buf, widget, owner_bufnr)
     if not vim.api.nvim_buf_is_valid(foreign_buf) then
         return
     end
 
-    local target_win = find_target_window()
+    local target_win = find_destination(widget)
     if not target_win then
         Logger.debug("BufferGuard: no target window for redirect")
         return
@@ -31,10 +55,36 @@ local function redirect_foreign(foreign_buf, find_target_window)
     -- vim.schedule because Neovim resets current_win after
     -- BufEnter autocmd handlers complete.
     vim.schedule(function()
-        if vim.api.nvim_win_is_valid(target_win) then
-            pcall(vim.api.nvim_set_current_win, target_win)
+        if not vim.api.nvim_buf_is_valid(foreign_buf) then
+            return
         end
+
+        local live_widget = WidgetRegistry.get(owner_bufnr)
+        if not live_widget then
+            return
+        end
+
+        local destination = find_destination(live_widget)
+        if not destination then
+            return
+        end
+
+        pcall(vim.api.nvim_win_set_buf, destination, foreign_buf)
+        pcall(vim.api.nvim_set_current_win, destination)
     end)
+end
+
+--- @param widget agentic.ui.ChatWidget
+--- @param old_bufnr integer
+--- @param new_bufnr integer
+local function transfer_ownership(widget, old_bufnr, new_bufnr)
+    for panel, bufnr in pairs(widget.buf_nrs) do
+        if bufnr == old_bufnr then
+            widget.buf_nrs[panel] = new_bufnr
+        end
+    end
+
+    WidgetRegistry.register(widget)
 end
 
 --- Core handler: called on BufEnter for every buffer.
@@ -56,6 +106,11 @@ local function on_buf_enter(cb)
         return
     end
 
+    local widget = WidgetRegistry.get(expected)
+    if not widget then
+        return
+    end
+
     local cur_buf = vim.api.nvim_get_current_buf()
 
     if cur_buf ~= expected then
@@ -63,7 +118,7 @@ local function on_buf_enter(cb)
             return
         end
         pcall(vim.api.nvim_win_set_buf, cur_win, expected)
-        redirect_foreign(cur_buf, cb.find_target_window)
+        redirect_foreign(cur_buf, widget, expected)
         return
     end
 
@@ -80,10 +135,13 @@ local function on_buf_enter(cb)
         -- scratch buffer to keep the widget window intact.
         local new_buf = vim.api.nvim_create_buf(false, true)
         vim.bo[new_buf].buftype = "nofile"
-        vim.api.nvim_win_set_buf(cur_win, new_buf)
+
+        transfer_ownership(widget, cur_buf, new_buf)
         vim.w[cur_win].agentic_bufnr = new_buf
+        vim.api.nvim_win_set_buf(cur_win, new_buf)
+
         -- Redirect the (now-named) repurposed buffer to the editor
-        redirect_foreign(cur_buf, cb.find_target_window)
+        redirect_foreign(cur_buf, widget, new_buf)
     end
 end
 

--- a/lua/agentic/ui/buffer_guard.lua
+++ b/lua/agentic/ui/buffer_guard.lua
@@ -60,7 +60,7 @@ local function redirect_foreign(foreign_buf, widget, owner_bufnr)
         end
 
         local live_widget = WidgetRegistry.get(owner_bufnr)
-        if not live_widget then
+        if not live_widget or live_widget ~= widget then
             return
         end
 

--- a/lua/agentic/ui/buffer_guard.lua
+++ b/lua/agentic/ui/buffer_guard.lua
@@ -8,7 +8,6 @@ local BufferGuard = {}
 
 --- @class agentic.ui.BufferGuard.Callbacks
 --- @field tab_page_id integer
---- @field find_target_window fun(): integer|nil
 
 --- @param widget agentic.ui.ChatWidget
 --- @return integer|nil destination

--- a/lua/agentic/ui/buffer_guard.lua
+++ b/lua/agentic/ui/buffer_guard.lua
@@ -106,7 +106,7 @@ local function on_buf_enter(cb)
     end
 
     local widget = WidgetRegistry.get(expected)
-    if not widget then
+    if not widget or widget.tab_page_id ~= cb.tab_page_id then
         return
     end
 

--- a/lua/agentic/ui/buffer_guard.test.lua
+++ b/lua/agentic/ui/buffer_guard.test.lua
@@ -60,7 +60,7 @@ local function create_widget_setup()
         buf_nrs = buf_nrs,
         win_nrs = win_nrs,
         find_first_non_widget_window = function()
-            if target_win and vim.api.nvim_win_is_valid(target_win) then
+            if target_win and BufHelpers.is_win_usable(target_win) then
                 return target_win
             end
             return nil

--- a/lua/agentic/ui/buffer_guard.test.lua
+++ b/lua/agentic/ui/buffer_guard.test.lua
@@ -121,9 +121,18 @@ describe("BufferGuard", function()
     local usable_stub
     --- @type TestSpy|nil
     local focus_spy
+    --- @type table<integer, true>
+    local baseline_tabs
+    --- @type agentic.ui.ChatWidget[]
+    local extra_widgets
 
     before_each(function()
         active_setups = {}
+        baseline_tabs = {}
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            baseline_tabs[tabpage] = true
+        end
+        extra_widgets = {}
         schedule_stub = nil
         usable_stub = nil
         focus_spy = nil
@@ -141,6 +150,17 @@ describe("BufferGuard", function()
         end
         for _, setup in ipairs(active_setups) do
             setup.cleanup()
+        end
+        for _, widget in ipairs(extra_widgets) do
+            WidgetRegistry.unregister(widget)
+        end
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            if not baseline_tabs[tabpage] then
+                pcall(function()
+                    vim.api.nvim_set_current_tabpage(tabpage)
+                    vim.cmd("tabclose!")
+                end)
+            end
         end
     end)
 
@@ -259,6 +279,41 @@ describe("BufferGuard", function()
         s.cleanup()
     end)
 
+    it("rejects a different widget that claims the owner buffer", function()
+        local s = create_widget_setup()
+        vim.api.nvim_set_current_win(s.wins.chat)
+
+        local scheduled
+        schedule_stub = spy.stub(vim, "schedule")
+        schedule_stub:invokes(function(callback)
+            scheduled = callback
+        end)
+
+        local foreign = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_win_set_buf(s.wins.chat, foreign)
+        assert.is_not_nil(scheduled)
+
+        --- @type any
+        local replacement = {
+            tab_page_id = s.tab,
+            buf_nrs = { chat = s.widget.buf_nrs.chat },
+            win_nrs = {},
+            find_first_non_widget_window = function()
+                return s.editor_win
+            end,
+            open_editor_window = function()
+                return nil
+            end,
+        }
+        extra_widgets[#extra_widgets + 1] = replacement
+        WidgetRegistry.register(replacement)
+        focus_spy = spy.on(vim.api, "nvim_set_current_win")
+
+        scheduled()
+
+        assert.spy(focus_spy).was.called(0)
+    end)
+
     it("rejects a destination outside the owner's stored tabpage", function()
         local s = create_widget_setup()
 
@@ -283,9 +338,6 @@ describe("BufferGuard", function()
         )
         assert.equal(foreign_tab, vim.api.nvim_win_get_tabpage(foreign_win))
 
-        vim.api.nvim_set_current_tabpage(foreign_tab)
-        vim.cmd("tabclose!")
-        vim.api.nvim_set_current_tabpage(s.tab)
         s.cleanup()
     end)
 

--- a/lua/agentic/ui/buffer_guard.test.lua
+++ b/lua/agentic/ui/buffer_guard.test.lua
@@ -1,7 +1,12 @@
 -- lua/agentic/ui/buffer_guard.test.lua
 local assert = require("tests.helpers.assert")
+local spy = require("tests.helpers.spy")
 local BufferGuard = require("agentic.ui.buffer_guard")
 local WidgetLayout = require("agentic.ui.widget_layout")
+local BufHelpers = require("agentic.utils.buf_helpers")
+local WidgetRegistry = require("agentic.ui.widget_registry")
+
+local active_setups = {}
 
 --- Helper: create a minimal widget-like setup in a fresh tab
 --- @return table state { tab, bufs, wins, augroup, cleanup }
@@ -48,12 +53,30 @@ local function create_widget_setup()
     vim.w[chat_win].agentic_bufnr = chat_buf
     vim.w[input_win].agentic_bufnr = input_buf
 
+    local target_win = editor_win
+    --- @type any
+    local widget = {
+        tab_page_id = tab,
+        buf_nrs = buf_nrs,
+        win_nrs = win_nrs,
+        find_first_non_widget_window = function()
+            if target_win and vim.api.nvim_win_is_valid(target_win) then
+                return target_win
+            end
+            return nil
+        end,
+        open_editor_window = function()
+            return nil
+        end,
+    }
+    WidgetRegistry.register(widget)
+
     --- @type agentic.ui.BufferGuard.Callbacks
     local callbacks = {
         tab_page_id = tab,
         find_target_window = function()
-            if editor_win and vim.api.nvim_win_is_valid(editor_win) then
-                return editor_win
+            if target_win and vim.api.nvim_win_is_valid(target_win) then
+                return target_win
             end
             return nil
         end,
@@ -61,22 +84,66 @@ local function create_widget_setup()
 
     local augroup = BufferGuard.attach(callbacks)
 
-    return {
+    local cleaned = false
+    local setup = {
         tab = tab,
         bufs = buf_nrs,
         wins = win_nrs,
         editor_win = editor_win,
+        widget = widget,
         augroup = augroup,
+        set_target = function(winid)
+            target_win = winid
+        end,
         cleanup = function()
+            if cleaned then
+                return
+            end
+            cleaned = true
             BufferGuard.detach(augroup)
+            WidgetRegistry.unregister(widget)
             pcall(function()
-                vim.cmd("tabclose!")
+                if vim.api.nvim_tabpage_is_valid(tab) then
+                    vim.api.nvim_set_current_tabpage(tab)
+                    vim.cmd("tabclose!")
+                end
             end)
         end,
     }
+    active_setups[#active_setups + 1] = setup
+    return setup
 end
 
 describe("BufferGuard", function()
+    --- @type TestStub|nil
+    local schedule_stub
+    --- @type TestStub|nil
+    local usable_stub
+    --- @type TestSpy|nil
+    local focus_spy
+
+    before_each(function()
+        active_setups = {}
+        schedule_stub = nil
+        usable_stub = nil
+        focus_spy = nil
+    end)
+
+    after_each(function()
+        if focus_spy then
+            focus_spy:revert()
+        end
+        if usable_stub then
+            usable_stub:revert()
+        end
+        if schedule_stub then
+            schedule_stub:revert()
+        end
+        for _, setup in ipairs(active_setups) do
+            setup.cleanup()
+        end
+    end)
+
     it(
         "restores widget buffer when foreign buffer enters " .. "widget window",
         function()
@@ -101,6 +168,7 @@ describe("BufferGuard", function()
 
     it("redirects the foreign buffer to the editor window", function()
         local s = create_widget_setup()
+        local old_chat_buf = s.bufs.chat
 
         vim.api.nvim_set_current_win(s.wins.chat)
 
@@ -120,10 +188,104 @@ describe("BufferGuard", function()
 
         -- Widget window should now hold a fresh replacement buffer
         local buf_in_chat = vim.api.nvim_win_get_buf(s.wins.chat)
-        assert.are_not.equal(s.bufs.chat, buf_in_chat)
+        assert.are_not.equal(old_chat_buf, buf_in_chat)
+        assert.equal(buf_in_chat, s.widget.buf_nrs.chat)
         assert.equal(buf_in_chat, vim.w[s.wins.chat].agentic_bufnr)
+        assert.is_nil(WidgetRegistry.get(old_chat_buf))
+        assert.equal(s.widget, WidgetRegistry.get(buf_in_chat))
 
         os.remove(tmpfile)
+        s.cleanup()
+    end)
+
+    it("re-resolves the deferred destination", function()
+        local s = create_widget_setup()
+        vim.api.nvim_set_current_win(s.wins.chat)
+
+        local scheduled
+        schedule_stub = spy.stub(vim, "schedule")
+        schedule_stub:invokes(function(callback)
+            scheduled = callback
+        end)
+
+        local foreign = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_win_set_buf(s.wins.chat, foreign)
+
+        local later_win = vim.api.nvim_open_win(
+            vim.api.nvim_create_buf(false, true),
+            false,
+            { split = "left", win = s.editor_win }
+        )
+        s.set_target(later_win)
+        assert.is_not_nil(scheduled)
+        scheduled()
+
+        assert.equal(foreign, vim.api.nvim_win_get_buf(later_win))
+        assert.equal(later_win, vim.api.nvim_get_current_win())
+
+        schedule_stub:revert()
+        schedule_stub = nil
+        s.cleanup()
+    end)
+
+    it("rejects a deferred destination that is no longer usable", function()
+        local s = create_widget_setup()
+        vim.api.nvim_set_current_win(s.wins.chat)
+
+        local scheduled
+        schedule_stub = spy.stub(vim, "schedule")
+        schedule_stub:invokes(function(callback)
+            scheduled = callback
+        end)
+
+        local foreign = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_win_set_buf(s.wins.chat, foreign)
+        assert.is_not_nil(scheduled)
+
+        usable_stub = spy.stub(BufHelpers, "is_win_usable")
+        usable_stub:returns(false)
+        focus_spy = spy.on(vim.api, "nvim_set_current_win")
+
+        scheduled()
+
+        assert.spy(focus_spy).was.called(0)
+
+        focus_spy:revert()
+        focus_spy = nil
+        usable_stub:revert()
+        usable_stub = nil
+        schedule_stub:revert()
+        schedule_stub = nil
+        s.cleanup()
+    end)
+
+    it("rejects a destination outside the owner's stored tabpage", function()
+        local s = create_widget_setup()
+
+        vim.cmd("tabnew")
+        local foreign_tab = vim.api.nvim_get_current_tabpage()
+        local foreign_win = vim.api.nvim_get_current_win()
+        local original_foreign_buf = vim.api.nvim_win_get_buf(foreign_win)
+        s.set_target(foreign_win)
+
+        vim.api.nvim_set_current_tabpage(s.tab)
+        vim.api.nvim_set_current_win(s.wins.chat)
+        local foreign = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_win_set_buf(s.wins.chat, foreign)
+
+        assert.equal(
+            s.widget.buf_nrs.chat,
+            vim.api.nvim_win_get_buf(s.wins.chat)
+        )
+        assert.equal(
+            original_foreign_buf,
+            vim.api.nvim_win_get_buf(foreign_win)
+        )
+        assert.equal(foreign_tab, vim.api.nvim_win_get_tabpage(foreign_win))
+
+        vim.api.nvim_set_current_tabpage(foreign_tab)
+        vim.cmd("tabclose!")
+        vim.api.nvim_set_current_tabpage(s.tab)
         s.cleanup()
     end)
 
@@ -174,6 +336,30 @@ describe("BufferGuard", function()
             end,
         })
 
+        --- @type any
+        local widget = {
+            tab_page_id = tab,
+            buf_nrs = { chat = chat_buf },
+            win_nrs = { chat = chat_win },
+            find_first_non_widget_window = function()
+                return nil
+            end,
+            open_editor_window = function()
+                local new_buf = vim.api.nvim_create_buf(false, true)
+                local ok, winid = pcall(
+                    vim.api.nvim_open_win,
+                    new_buf,
+                    true,
+                    { split = "left", win = -1 }
+                )
+                if ok then
+                    return winid
+                end
+                return nil
+            end,
+        }
+        WidgetRegistry.register(widget)
+
         -- Force a foreign buffer in
         local foreign = vim.api.nvim_create_buf(true, false)
         vim.api.nvim_win_set_buf(chat_win, foreign)
@@ -187,6 +373,7 @@ describe("BufferGuard", function()
         assert.is_true(#all_wins > 1)
 
         BufferGuard.detach(augroup)
+        WidgetRegistry.unregister(widget)
         pcall(function()
             vim.cmd("tabclose!")
         end)
@@ -206,6 +393,8 @@ describe("BufferGuard", function()
         -- The foreign buffer should stay (no guard active)
         local buf_in_chat = vim.api.nvim_win_get_buf(s.wins.chat)
         assert.equal(foreign, buf_in_chat)
+
+        WidgetRegistry.unregister(s.widget)
 
         pcall(function()
             vim.cmd("tabclose!")
@@ -281,6 +470,20 @@ describe("BufferGuard", function()
                 end,
             })
 
+            --- @type any
+            local widget = {
+                tab_page_id = tab_page_id,
+                buf_nrs = buf_nrs,
+                win_nrs = win_nrs,
+                find_first_non_widget_window = function()
+                    return editor_win
+                end,
+                open_editor_window = function()
+                    return nil
+                end,
+            }
+            WidgetRegistry.register(widget)
+
             -- Force a foreign buffer into the chat widget window. This
             -- triggers BufEnter inside the widget and, in turn, a
             -- redirect to the editor window via BufferGuard.
@@ -318,6 +521,7 @@ describe("BufferGuard", function()
             )
 
             BufferGuard.detach(augroup)
+            WidgetRegistry.unregister(widget)
             WidgetLayout.close(win_nrs)
             pcall(function()
                 vim.cmd("tabclose!")
@@ -361,9 +565,23 @@ describe("BufferGuard cursor follow (child)", function()
         child.lua(
             [[
             local BG = require("agentic.ui.buffer_guard")
+            local WidgetRegistry = require("agentic.ui.widget_registry")
             local editor_win, chat_win, chat_buf = ...
 
             vim.w[chat_win].agentic_bufnr = chat_buf
+
+            local widget = {
+                tab_page_id = vim.api.nvim_get_current_tabpage(),
+                buf_nrs = { chat = chat_buf },
+                win_nrs = { chat = chat_win },
+                find_first_non_widget_window = function()
+                    return editor_win
+                end,
+                open_editor_window = function()
+                    return nil
+                end,
+            }
+            WidgetRegistry.register(widget)
 
             BG.attach({
                 tab_page_id = vim.api.nvim_get_current_tabpage(),

--- a/lua/agentic/ui/buffer_guard.test.lua
+++ b/lua/agentic/ui/buffer_guard.test.lua
@@ -125,6 +125,8 @@ describe("BufferGuard", function()
     local baseline_tabs
     --- @type agentic.ui.ChatWidget[]
     local extra_widgets
+    --- @type string[]
+    local tempfiles
 
     before_each(function()
         active_setups = {}
@@ -133,6 +135,7 @@ describe("BufferGuard", function()
             baseline_tabs[tabpage] = true
         end
         extra_widgets = {}
+        tempfiles = {}
         schedule_stub = nil
         usable_stub = nil
         focus_spy = nil
@@ -153,6 +156,9 @@ describe("BufferGuard", function()
         end
         for _, widget in ipairs(extra_widgets) do
             WidgetRegistry.unregister(widget)
+        end
+        for _, path in ipairs(tempfiles) do
+            os.remove(path)
         end
         for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
             if not baseline_tabs[tabpage] then
@@ -195,6 +201,7 @@ describe("BufferGuard", function()
         -- Write a temp file so the foreign buffer has a name
         local tmpfile = vim.fn.tempname() .. ".lua"
         vim.fn.writefile({ "-- test" }, tmpfile)
+        tempfiles[#tempfiles + 1] = tmpfile
 
         vim.cmd("edit " .. vim.fn.fnameescape(tmpfile))
 
@@ -214,8 +221,29 @@ describe("BufferGuard", function()
         assert.is_nil(WidgetRegistry.get(old_chat_buf))
         assert.equal(s.widget, WidgetRegistry.get(buf_in_chat))
 
-        os.remove(tmpfile)
         s.cleanup()
+    end)
+
+    it("redirects a later foreign buffer after ownership transfer", function()
+        local s = create_widget_setup()
+        local old_chat_buf = s.bufs.chat
+        vim.api.nvim_set_current_win(s.wins.chat)
+
+        local tmpfile = vim.fn.tempname() .. ".lua"
+        vim.fn.writefile({ "-- test" }, tmpfile)
+        tempfiles[#tempfiles + 1] = tmpfile
+        vim.cmd("edit " .. vim.fn.fnameescape(tmpfile))
+
+        local replacement = s.widget.buf_nrs.chat
+        assert.are_not.equal(old_chat_buf, replacement)
+        assert.equal(s.widget, WidgetRegistry.get(replacement))
+
+        vim.api.nvim_set_current_win(s.wins.chat)
+        local later_foreign = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_win_set_buf(s.wins.chat, later_foreign)
+
+        assert.equal(replacement, vim.api.nvim_win_get_buf(s.wins.chat))
+        assert.equal(later_foreign, vim.api.nvim_win_get_buf(s.editor_win))
     end)
 
     it("re-resolves the deferred destination", function()

--- a/lua/agentic/ui/buffer_guard.test.lua
+++ b/lua/agentic/ui/buffer_guard.test.lua
@@ -366,6 +366,69 @@ describe("BufferGuard", function()
         assert.spy(focus_spy).was.called(0)
     end)
 
+    it("ignores a foreign-buffer event claimed by another tab", function()
+        local s = create_widget_setup()
+        local expected = s.widget.buf_nrs.chat
+
+        vim.cmd("tabnew")
+        local foreign_tab = vim.api.nvim_get_current_tabpage()
+        local foreign_win = vim.api.nvim_get_current_win()
+        --- @type any
+        local foreign_widget = {
+            tab_page_id = foreign_tab,
+            buf_nrs = { chat = expected },
+            win_nrs = { chat = foreign_win },
+            find_first_non_widget_window = function()
+                return foreign_win
+            end,
+            open_editor_window = function()
+                return nil
+            end,
+        }
+        extra_widgets[#extra_widgets + 1] = foreign_widget
+        WidgetRegistry.register(foreign_widget)
+
+        vim.api.nvim_set_current_tabpage(s.tab)
+        vim.api.nvim_set_current_win(s.wins.chat)
+        local foreign_buf = vim.api.nvim_create_buf(true, false)
+        vim.api.nvim_win_set_buf(s.wins.chat, foreign_buf)
+
+        assert.equal(foreign_buf, vim.api.nvim_win_get_buf(s.wins.chat))
+        assert.equal(expected, foreign_widget.buf_nrs.chat)
+    end)
+
+    it("ignores a repurposed-buffer event claimed by another tab", function()
+        local s = create_widget_setup()
+        local expected = s.widget.buf_nrs.chat
+
+        vim.cmd("tabnew")
+        local foreign_tab = vim.api.nvim_get_current_tabpage()
+        local foreign_win = vim.api.nvim_get_current_win()
+        --- @type any
+        local foreign_widget = {
+            tab_page_id = foreign_tab,
+            buf_nrs = { chat = expected },
+            win_nrs = { chat = foreign_win },
+            find_first_non_widget_window = function()
+                return foreign_win
+            end,
+            open_editor_window = function()
+                return nil
+            end,
+        }
+        extra_widgets[#extra_widgets + 1] = foreign_widget
+        WidgetRegistry.register(foreign_widget)
+
+        vim.api.nvim_set_current_tabpage(s.tab)
+        vim.api.nvim_set_current_win(s.wins.chat)
+        vim.api.nvim_buf_set_name(expected, vim.fn.tempname() .. ".lua")
+        vim.bo[expected].buftype = ""
+        vim.api.nvim_exec_autocmds("BufEnter", { buffer = expected })
+
+        assert.equal(expected, vim.api.nvim_win_get_buf(s.wins.chat))
+        assert.equal(expected, foreign_widget.buf_nrs.chat)
+    end)
+
     it("rejects a destination outside the owner's stored tabpage", function()
         local s = create_widget_setup()
 

--- a/lua/agentic/ui/buffer_guard.test.lua
+++ b/lua/agentic/ui/buffer_guard.test.lua
@@ -127,6 +127,28 @@ describe("BufferGuard", function()
     local tempfiles
     local saved_options
 
+    --- @param tabpage integer
+    --- @param bufnr integer
+    --- @param winid integer
+    --- @return agentic.ui.ChatWidget widget
+    local function register_foreign_widget(tabpage, bufnr, winid)
+        --- @type any
+        local widget = {
+            tab_page_id = tabpage,
+            buf_nrs = { chat = bufnr },
+            win_nrs = { chat = winid },
+            find_first_non_widget_window = function()
+                return winid
+            end,
+            open_editor_window = function()
+                return nil
+            end,
+        }
+        extra_widgets[#extra_widgets + 1] = widget
+        WidgetRegistry.register(widget)
+        return widget
+    end
+
     before_each(function()
         active_setups = {}
         baseline_tabs = {}
@@ -373,20 +395,8 @@ describe("BufferGuard", function()
         vim.cmd("tabnew")
         local foreign_tab = vim.api.nvim_get_current_tabpage()
         local foreign_win = vim.api.nvim_get_current_win()
-        --- @type any
-        local foreign_widget = {
-            tab_page_id = foreign_tab,
-            buf_nrs = { chat = expected },
-            win_nrs = { chat = foreign_win },
-            find_first_non_widget_window = function()
-                return foreign_win
-            end,
-            open_editor_window = function()
-                return nil
-            end,
-        }
-        extra_widgets[#extra_widgets + 1] = foreign_widget
-        WidgetRegistry.register(foreign_widget)
+        local foreign_widget =
+            register_foreign_widget(foreign_tab, expected, foreign_win)
 
         vim.api.nvim_set_current_tabpage(s.tab)
         vim.api.nvim_set_current_win(s.wins.chat)
@@ -404,20 +414,8 @@ describe("BufferGuard", function()
         vim.cmd("tabnew")
         local foreign_tab = vim.api.nvim_get_current_tabpage()
         local foreign_win = vim.api.nvim_get_current_win()
-        --- @type any
-        local foreign_widget = {
-            tab_page_id = foreign_tab,
-            buf_nrs = { chat = expected },
-            win_nrs = { chat = foreign_win },
-            find_first_non_widget_window = function()
-                return foreign_win
-            end,
-            open_editor_window = function()
-                return nil
-            end,
-        }
-        extra_widgets[#extra_widgets + 1] = foreign_widget
-        WidgetRegistry.register(foreign_widget)
+        local foreign_widget =
+            register_foreign_widget(foreign_tab, expected, foreign_win)
 
         vim.api.nvim_set_current_tabpage(s.tab)
         vim.api.nvim_set_current_win(s.wins.chat)

--- a/lua/agentic/ui/buffer_guard.test.lua
+++ b/lua/agentic/ui/buffer_guard.test.lua
@@ -123,10 +123,15 @@ describe("BufferGuard", function()
     local focus_spy
     --- @type table<integer, true>
     local baseline_tabs
+    --- @type table<integer, true>
+    local baseline_buffers
     --- @type agentic.ui.ChatWidget[]
     local extra_widgets
+    --- @type integer[]
+    local extra_augroups
     --- @type string[]
     local tempfiles
+    local saved_options
 
     before_each(function()
         active_setups = {}
@@ -134,8 +139,19 @@ describe("BufferGuard", function()
         for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
             baseline_tabs[tabpage] = true
         end
+        baseline_buffers = {}
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            baseline_buffers[bufnr] = true
+        end
         extra_widgets = {}
+        extra_augroups = {}
         tempfiles = {}
+        saved_options = {
+            number = vim.o.number,
+            signcolumn = vim.o.signcolumn,
+            cursorline = vim.o.cursorline,
+            list = vim.o.list,
+        }
         schedule_stub = nil
         usable_stub = nil
         focus_spy = nil
@@ -154,6 +170,9 @@ describe("BufferGuard", function()
         for _, setup in ipairs(active_setups) do
             setup.cleanup()
         end
+        for _, augroup in ipairs(extra_augroups) do
+            BufferGuard.detach(augroup)
+        end
         for _, widget in ipairs(extra_widgets) do
             WidgetRegistry.unregister(widget)
         end
@@ -168,6 +187,17 @@ describe("BufferGuard", function()
                 end)
             end
         end
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            if
+                not baseline_buffers[bufnr] and vim.api.nvim_buf_is_valid(bufnr)
+            then
+                pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            end
+        end
+        vim.o.number = saved_options.number
+        vim.o.signcolumn = saved_options.signcolumn
+        vim.o.cursorline = saved_options.cursorline
+        vim.o.list = saved_options.list
     end)
 
     it(
@@ -415,6 +445,7 @@ describe("BufferGuard", function()
                 return nil
             end,
         })
+        extra_augroups[#extra_augroups + 1] = augroup
 
         --- @type any
         local widget = {
@@ -438,6 +469,7 @@ describe("BufferGuard", function()
                 return nil
             end,
         }
+        extra_widgets[#extra_widgets + 1] = widget
         WidgetRegistry.register(widget)
 
         -- Force a foreign buffer in
@@ -549,6 +581,7 @@ describe("BufferGuard", function()
                     return nil
                 end,
             })
+            extra_augroups[#extra_augroups + 1] = augroup
 
             --- @type any
             local widget = {
@@ -562,6 +595,7 @@ describe("BufferGuard", function()
                     return nil
                 end,
             }
+            extra_widgets[#extra_widgets + 1] = widget
             WidgetRegistry.register(widget)
 
             -- Force a foreign buffer into the chat widget window. This

--- a/lua/agentic/ui/buffer_guard.test.lua
+++ b/lua/agentic/ui/buffer_guard.test.lua
@@ -74,12 +74,6 @@ local function create_widget_setup()
     --- @type agentic.ui.BufferGuard.Callbacks
     local callbacks = {
         tab_page_id = tab,
-        find_target_window = function()
-            if target_win and vim.api.nvim_win_is_valid(target_win) then
-                return target_win
-            end
-            return nil
-        end,
     }
 
     local augroup = BufferGuard.attach(callbacks)
@@ -430,20 +424,6 @@ describe("BufferGuard", function()
 
         local augroup = BufferGuard.attach({
             tab_page_id = tab,
-            find_target_window = function()
-                -- Mimics open_editor_window: create a split
-                local new_buf = vim.api.nvim_create_buf(false, true)
-                local ok, winid = pcall(
-                    vim.api.nvim_open_win,
-                    new_buf,
-                    true,
-                    { split = "left", win = -1 }
-                )
-                if ok then
-                    return winid
-                end
-                return nil
-            end,
         })
         extra_augroups[#extra_augroups + 1] = augroup
 
@@ -574,12 +554,6 @@ describe("BufferGuard", function()
 
             local augroup = BufferGuard.attach({
                 tab_page_id = tab_page_id,
-                find_target_window = function()
-                    if vim.api.nvim_win_is_valid(editor_win) then
-                        return editor_win
-                    end
-                    return nil
-                end,
             })
             extra_augroups[#extra_augroups + 1] = augroup
 
@@ -674,8 +648,7 @@ describe("BufferGuard cursor follow (child)", function()
             win = -1,
         })
 
-        -- vim.w[winid] assignment and BG.attach (which needs a
-        -- callback function) can't cross the RPC boundary.
+        -- vim.w[winid] assignment and BG.attach can't cross the RPC boundary.
         child.lua(
             [[
             local BG = require("agentic.ui.buffer_guard")
@@ -699,11 +672,6 @@ describe("BufferGuard cursor follow (child)", function()
 
             BG.attach({
                 tab_page_id = vim.api.nvim_get_current_tabpage(),
-                find_target_window = function()
-                    if vim.api.nvim_win_is_valid(editor_win) then
-                        return editor_win
-                    end
-                end,
             })
         ]],
             { editor_win, chat_win, chat_buf }

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -5,6 +5,7 @@ local ChatNavigation = require("agentic.ui.chat_navigation")
 local DiffPreview = require("agentic.ui.diff_preview")
 local Logger = require("agentic.utils.logger")
 local WindowDecoration = require("agentic.ui.window_decoration")
+local WidgetRegistry = require("agentic.ui.widget_registry")
 local WidgetLayout = require("agentic.ui.widget_layout")
 
 --- @alias agentic.ui.ChatWidget.PanelNames "chat"|"todos"|"code"|"files"|"input"|"diagnostics"
@@ -240,6 +241,8 @@ function ChatWidget:destroy()
 
     self:_close_hidden_chat_window()
 
+    WidgetRegistry.unregister(self)
+
     for name, bufnr in pairs(self.buf_nrs) do
         self.buf_nrs[name] = nil
         local ok = pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
@@ -320,6 +323,7 @@ end
 
 function ChatWidget:_initialize()
     self.buf_nrs = self:_create_buf_nrs()
+    WidgetRegistry.register(self)
 
     self._hidden_chat_winid =
         WidgetLayout.open_hidden_chat_window(self.buf_nrs.chat)
@@ -679,6 +683,7 @@ local EXCLUDED_FILETYPES = {
 --- @return number|nil winid The first non-widget window ID, or nil if none found
 function ChatWidget:find_first_non_widget_window()
     local all_windows = vim.api.nvim_tabpage_list_wins(self.tab_page_id)
+    local widget_bufnrs = WidgetRegistry.all_bufnrs()
 
     -- Build a set of widget window IDs for fast lookup
     local widget_win_ids = {}
@@ -695,7 +700,7 @@ function ChatWidget:find_first_non_widget_window()
             if win_config.relative == "" then
                 local bufnr = vim.api.nvim_win_get_buf(winid)
                 local ft = vim.bo[bufnr].filetype
-                if not EXCLUDED_FILETYPES[ft] then
+                if not widget_bufnrs[bufnr] and not EXCLUDED_FILETYPES[ft] then
                     return winid
                 end
             end

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -332,10 +332,6 @@ function ChatWidget:_initialize()
 
     self._guard_augroup = BufferGuard.attach({
         tab_page_id = self.tab_page_id,
-        find_target_window = function()
-            return self:find_first_non_widget_window()
-                or self:open_editor_window()
-        end,
     })
 
     -- Track whether we're programmatically closing windows

--- a/lua/agentic/ui/chat_widget.test.lua
+++ b/lua/agentic/ui/chat_widget.test.lua
@@ -3,6 +3,7 @@ local spy = require("tests.helpers.spy")
 local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
 local WindowDecoration = require("agentic.ui.window_decoration")
+local WidgetRegistry = require("agentic.ui.widget_registry")
 
 describe("agentic.ui.ChatWidget", function()
     --- @type agentic.ui.ChatWidget
@@ -953,6 +954,149 @@ describe("agentic.ui.ChatWidget", function()
             assert.is_not_nil(widget._hidden_chat_winid)
             assert.is_true(vim.api.nvim_win_is_valid(widget._hidden_chat_winid))
         end)
+    end)
+
+    describe("widget buffer ownership", function()
+        local widget
+        --- @type any
+        local extra_widget
+        local baseline_tabs
+        local cleanup_buffers
+
+        before_each(function()
+            baseline_tabs = {}
+            for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+                baseline_tabs[tabpage] = true
+            end
+            cleanup_buffers = {}
+
+            vim.cmd("tabnew")
+            widget = ChatWidget:new(
+                vim.api.nvim_get_current_tabpage(),
+                spy.new(function() end) --[[@as function]]
+            )
+        end)
+
+        after_each(function()
+            if extra_widget then
+                WidgetRegistry.unregister(extra_widget)
+                extra_widget = nil
+            end
+            if widget then
+                pcall(function()
+                    widget:destroy()
+                end)
+                widget = nil
+            end
+            for _, bufnr in ipairs(cleanup_buffers) do
+                if vim.api.nvim_buf_is_valid(bufnr) then
+                    pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+                end
+            end
+            for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+                if not baseline_tabs[tabpage] then
+                    pcall(function()
+                        vim.api.nvim_set_current_tabpage(tabpage)
+                        vim.cmd("tabclose!")
+                    end)
+                end
+            end
+        end)
+
+        it("registers every buffer after initialization", function()
+            for _, bufnr in pairs(widget.buf_nrs) do
+                assert.equal(widget, WidgetRegistry.get(bufnr))
+            end
+        end)
+
+        it(
+            "never selects another registered widget window as fallback",
+            function()
+                widget:show({ focus_prompt = false })
+
+                local foreign_buf = vim.api.nvim_create_buf(false, true)
+                cleanup_buffers[#cleanup_buffers + 1] = foreign_buf
+                local foreign_win = vim.api.nvim_open_win(foreign_buf, false, {
+                    split = "left",
+                    win = widget.win_nrs.chat,
+                })
+                extra_widget = {
+                    buf_nrs = { chat = foreign_buf },
+                    win_nrs = { chat = foreign_win },
+                }
+                WidgetRegistry.register(extra_widget)
+
+                local editor_win = widget:find_first_non_widget_window()
+                assert.is_not_nil(editor_win)
+                --- @cast editor_win integer
+                vim.api.nvim_win_close(editor_win, true)
+
+                assert.is_nil(widget:find_first_non_widget_window())
+            end
+        )
+
+        it(
+            "never selects an ordinary window showing a registered widget buffer",
+            function()
+                widget:show({ focus_prompt = false })
+
+                local foreign_buf = vim.api.nvim_create_buf(false, true)
+                cleanup_buffers[#cleanup_buffers + 1] = foreign_buf
+                extra_widget =
+                    { buf_nrs = { chat = foreign_buf }, win_nrs = {} }
+                WidgetRegistry.register(extra_widget)
+                vim.api.nvim_open_win(foreign_buf, false, {
+                    split = "left",
+                    win = widget.win_nrs.chat,
+                })
+
+                local editor_win = widget:find_first_non_widget_window()
+                assert.is_not_nil(editor_win)
+                --- @cast editor_win integer
+                vim.api.nvim_win_close(editor_win, true)
+
+                assert.is_nil(widget:find_first_non_widget_window())
+            end
+        )
+
+        it(
+            "resolves fallback before unregistering and deleting buffers",
+            function()
+                widget:show({ focus_prompt = false })
+
+                local events = {}
+                local original_find = widget.find_first_non_widget_window
+                local original_unregister = WidgetRegistry.unregister
+                local original_delete = vim.api.nvim_buf_delete
+                local find_stub =
+                    spy.stub(widget, "find_first_non_widget_window")
+                find_stub:invokes(function(self)
+                    events[#events + 1] = "fallback"
+                    return original_find(self)
+                end)
+                local unregister_stub = spy.stub(WidgetRegistry, "unregister")
+                unregister_stub:invokes(function(owner)
+                    events[#events + 1] = "unregister"
+                    return original_unregister(owner)
+                end)
+                local delete_stub = spy.stub(vim.api, "nvim_buf_delete")
+                delete_stub:invokes(function(bufnr, opts)
+                    events[#events + 1] = "delete"
+                    return original_delete(bufnr, opts)
+                end)
+
+                widget:destroy()
+                widget = nil
+
+                delete_stub:revert()
+                unregister_stub:revert()
+                find_stub:revert()
+
+                assert.equal("fallback", events[1])
+                assert.equal("unregister", events[2])
+                assert.equal("delete", events[3])
+            end
+        )
     end)
 
     describe("input header suffix", function()

--- a/lua/agentic/ui/chat_widget.test.lua
+++ b/lua/agentic/ui/chat_widget.test.lua
@@ -962,6 +962,12 @@ describe("agentic.ui.ChatWidget", function()
         local extra_widget
         local baseline_tabs
         local cleanup_buffers
+        --- @type TestStub|nil
+        local find_stub
+        --- @type TestStub|nil
+        local unregister_stub
+        --- @type TestStub|nil
+        local delete_stub
 
         before_each(function()
             baseline_tabs = {}
@@ -969,6 +975,9 @@ describe("agentic.ui.ChatWidget", function()
                 baseline_tabs[tabpage] = true
             end
             cleanup_buffers = {}
+            find_stub = nil
+            unregister_stub = nil
+            delete_stub = nil
 
             vim.cmd("tabnew")
             widget = ChatWidget:new(
@@ -978,6 +987,15 @@ describe("agentic.ui.ChatWidget", function()
         end)
 
         after_each(function()
+            if delete_stub then
+                delete_stub:revert()
+            end
+            if unregister_stub then
+                unregister_stub:revert()
+            end
+            if find_stub then
+                find_stub:revert()
+            end
             if extra_widget then
                 WidgetRegistry.unregister(extra_widget)
                 extra_widget = nil
@@ -1068,18 +1086,17 @@ describe("agentic.ui.ChatWidget", function()
                 local original_find = widget.find_first_non_widget_window
                 local original_unregister = WidgetRegistry.unregister
                 local original_delete = vim.api.nvim_buf_delete
-                local find_stub =
-                    spy.stub(widget, "find_first_non_widget_window")
+                find_stub = spy.stub(widget, "find_first_non_widget_window")
                 find_stub:invokes(function(self)
                     events[#events + 1] = "fallback"
                     return original_find(self)
                 end)
-                local unregister_stub = spy.stub(WidgetRegistry, "unregister")
+                unregister_stub = spy.stub(WidgetRegistry, "unregister")
                 unregister_stub:invokes(function(owner)
                     events[#events + 1] = "unregister"
                     return original_unregister(owner)
                 end)
-                local delete_stub = spy.stub(vim.api, "nvim_buf_delete")
+                delete_stub = spy.stub(vim.api, "nvim_buf_delete")
                 delete_stub:invokes(function(bufnr, opts)
                     events[#events + 1] = "delete"
                     return original_delete(bufnr, opts)
@@ -1089,8 +1106,11 @@ describe("agentic.ui.ChatWidget", function()
                 widget = nil
 
                 delete_stub:revert()
+                delete_stub = nil
                 unregister_stub:revert()
+                unregister_stub = nil
                 find_stub:revert()
+                find_stub = nil
 
                 assert.equal("fallback", events[1])
                 assert.equal("unregister", events[2])

--- a/lua/agentic/ui/diagnostics_list.lua
+++ b/lua/agentic/ui/diagnostics_list.lua
@@ -218,11 +218,15 @@ function DiagnosticsList:_render()
     local owner = WidgetRegistry.get(self._bufnr)
     local winid
     if owner then
-        winid = BufHelpers.find_visible_win(
+        local owner_winid = owner.win_nrs.diagnostics
+        local candidate = BufHelpers.find_visible_win(
             self._bufnr,
-            owner.win_nrs.diagnostics,
+            owner_winid,
             owner.tab_page_id
         )
+        if candidate == owner_winid then
+            winid = candidate
+        end
     else
         winid = BufHelpers.find_visible_win(self._bufnr, nil)
     end

--- a/lua/agentic/ui/diagnostics_list.lua
+++ b/lua/agentic/ui/diagnostics_list.lua
@@ -3,6 +3,7 @@ local DiagnosticsContext = require("agentic.ui.diagnostics_context")
 local WidgetLayout = require("agentic.ui.widget_layout")
 local FileSystem = require("agentic.utils.file_system")
 local BufHelpers = require("agentic.utils.buf_helpers")
+local WidgetRegistry = require("agentic.ui.widget_registry")
 
 --- @return table<number, string> icons Keyed by `vim.diagnostic.severity`
 local function get_diagnostic_icons()
@@ -214,7 +215,17 @@ function DiagnosticsList:_render()
     local icons = get_diagnostic_icons()
 
     local buf_width = WidgetLayout.calculate_width(Config.windows.width)
-    local winid = BufHelpers.find_visible_win(self._bufnr, nil)
+    local owner = WidgetRegistry.get(self._bufnr)
+    local winid
+    if owner then
+        winid = BufHelpers.find_visible_win(
+            self._bufnr,
+            owner.win_nrs.diagnostics,
+            owner.tab_page_id
+        )
+    else
+        winid = BufHelpers.find_visible_win(self._bufnr, nil)
+    end
     if winid then
         buf_width = vim.api.nvim_win_get_width(winid)
     end

--- a/lua/agentic/ui/diagnostics_list.test.lua
+++ b/lua/agentic/ui/diagnostics_list.test.lua
@@ -314,13 +314,9 @@ describe("agentic.ui.DiagnosticsList", function()
         end)
 
         it("keeps default width when the registered owner is hidden", function()
-            vim.cmd("tabnew")
-            local owner_tab = vim.api.nvim_get_current_tabpage()
-            vim.cmd("tabprevious")
-
             --- @type any
             local widget = {
-                tab_page_id = owner_tab,
+                tab_page_id = vim.api.nvim_get_current_tabpage(),
                 buf_nrs = { diagnostics = bufnr },
                 win_nrs = {},
             }

--- a/lua/agentic/ui/diagnostics_list.test.lua
+++ b/lua/agentic/ui/diagnostics_list.test.lua
@@ -1,6 +1,9 @@
 local assert = require("tests.helpers.assert")
 local spy = require("tests.helpers.spy")
 local Config = require("agentic.config")
+local BufHelpers = require("agentic.utils.buf_helpers")
+local WidgetLayout = require("agentic.ui.widget_layout")
+local WidgetRegistry = require("agentic.ui.widget_registry")
 
 describe("agentic.ui.DiagnosticsList", function()
     local DiagnosticsList = require("agentic.ui.diagnostics_list")
@@ -13,6 +16,12 @@ describe("agentic.ui.DiagnosticsList", function()
     local diagnostics_list
     --- @type TestSpy
     local on_change_spy
+    --- @type TestStub|nil
+    local find_visible_win_stub
+    --- @type agentic.ui.ChatWidget|nil
+    local registered_widget
+    --- @type table<integer, true>
+    local baseline_tabs
 
     --- @return agentic.ui.DiagnosticsList.Diagnostic
     local function create_diagnostic(overrides)
@@ -30,6 +39,13 @@ describe("agentic.ui.DiagnosticsList", function()
     end
 
     before_each(function()
+        baseline_tabs = {}
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            baseline_tabs[tabpage] = true
+        end
+        find_visible_win_stub = nil
+        registered_widget = nil
+
         bufnr = vim.api.nvim_create_buf(false, true)
         winid = vim.api.nvim_open_win(bufnr, false, {
             relative = "editor",
@@ -45,6 +61,13 @@ describe("agentic.ui.DiagnosticsList", function()
     end)
 
     after_each(function()
+        if find_visible_win_stub then
+            find_visible_win_stub:revert()
+        end
+        if registered_widget then
+            WidgetRegistry.unregister(registered_widget)
+        end
+
         if on_change_spy and on_change_spy.revert then
             on_change_spy:revert()
         end
@@ -55,6 +78,15 @@ describe("agentic.ui.DiagnosticsList", function()
 
         if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
             vim.api.nvim_buf_delete(bufnr, { force = true })
+        end
+
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            if not baseline_tabs[tabpage] then
+                pcall(function()
+                    vim.api.nvim_set_current_tabpage(tabpage)
+                    vim.cmd("tabclose!")
+                end)
+            end
         end
     end)
 
@@ -257,6 +289,56 @@ describe("agentic.ui.DiagnosticsList", function()
     end)
 
     describe("buffer rendering", function()
+        it("scopes lookup to the owning widget's diagnostics window", function()
+            local captured_preferred
+            local captured_tabpage
+            --- @type any
+            local widget = {
+                tab_page_id = 1357,
+                buf_nrs = { diagnostics = bufnr },
+                win_nrs = { diagnostics = 2468 },
+            }
+            registered_widget = widget
+            WidgetRegistry.register(widget)
+            find_visible_win_stub = spy.stub(BufHelpers, "find_visible_win")
+            find_visible_win_stub:invokes(function(_, preferred, tabpage)
+                captured_preferred = preferred
+                captured_tabpage = tabpage
+                return nil
+            end)
+
+            diagnostics_list:add(create_diagnostic())
+
+            assert.equal(2468, captured_preferred)
+            assert.equal(1357, captured_tabpage)
+        end)
+
+        it("keeps default width when the registered owner is hidden", function()
+            vim.cmd("tabnew")
+            local owner_tab = vim.api.nvim_get_current_tabpage()
+            vim.cmd("tabprevious")
+
+            --- @type any
+            local widget = {
+                tab_page_id = owner_tab,
+                buf_nrs = { diagnostics = bufnr },
+                win_nrs = {},
+            }
+            registered_widget = widget
+            WidgetRegistry.register(widget)
+
+            diagnostics_list:add(create_diagnostic({
+                file_path = "/short.lua",
+                message = string.rep("long diagnostic ", 20),
+            }))
+
+            local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+            local default_width =
+                WidgetLayout.calculate_width(Config.windows.width)
+            assert.is_true(vim.fn.strdisplaywidth(lines[1]) <= default_width)
+            assert.equal("...", lines[1]:sub(-3))
+        end)
+
         it("renders diagnostics in buffer", function()
             local diagnostic = create_diagnostic({
                 lnum = 10,

--- a/lua/agentic/ui/permission_manager.lua
+++ b/lua/agentic/ui/permission_manager.lua
@@ -1,6 +1,7 @@
 local BufHelpers = require("agentic.utils.buf_helpers")
 local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
+local WidgetRegistry = require("agentic.ui.widget_registry")
 
 -- See https://agentclientprotocol.com/protocol/tool-calls.md
 local PERMISSION_KIND_PRIORITY = {
@@ -464,12 +465,33 @@ end
 --- @return integer|nil winid
 --- @protected
 function PermissionManager:_find_visible_chat_winid()
-    for _, winid in ipairs(vim.fn.win_findbuf(self.message_writer.bufnr)) do
-        if vim.api.nvim_win_get_config(winid).focusable then
-            return winid
-        end
+    local bufnr = self.message_writer.bufnr
+    local owner = WidgetRegistry.get(bufnr)
+    if not owner then
+        return BufHelpers.find_visible_win(bufnr)
     end
-    return nil
+
+    if not vim.api.nvim_tabpage_is_valid(owner.tab_page_id) then
+        return nil
+    end
+
+    local owner_winid = owner.win_nrs.chat
+    if not owner_winid or not BufHelpers.is_win_usable(owner_winid) then
+        return nil
+    end
+    if vim.api.nvim_win_get_tabpage(owner_winid) ~= owner.tab_page_id then
+        return nil
+    end
+    if vim.api.nvim_win_get_buf(owner_winid) ~= bufnr then
+        return nil
+    end
+
+    local config = vim.api.nvim_win_get_config(owner_winid)
+    if not config.focusable or config.hide then
+        return nil
+    end
+
+    return owner_winid
 end
 
 --- True when the cursor sits on the focused block's status row or on any

--- a/lua/agentic/ui/permission_manager.test.lua
+++ b/lua/agentic/ui/permission_manager.test.lua
@@ -1,4 +1,4 @@
---- @diagnostic disable: invisible
+--- @diagnostic disable: invisible, missing-fields, param-type-mismatch
 local assert = require("tests.helpers.assert")
 local spy = require("tests.helpers.spy")
 local PermissionSection = require("tests.helpers.permission_section")
@@ -20,6 +20,11 @@ describe("agentic.ui.PermissionManager", function()
     local schedule_stub
     --- @type TestSpy|nil
     local cmd_spy
+    local own_win
+    --- @type table<integer, true>
+    local baseline_tabs
+    --- @type agentic.ui.ChatWidget|nil
+    local registered_owner
 
     --- Build a permission request with the given tool_call_id. Defaults to
     --- one allow_once + one reject_once option; pass opts.options to override.
@@ -83,6 +88,13 @@ describe("agentic.ui.PermissionManager", function()
     end
 
     before_each(function()
+        baseline_tabs = {}
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            baseline_tabs[tabpage] = true
+        end
+        own_win = nil
+        registered_owner = nil
+
         schedule_stub = spy.stub(vim, "schedule")
         schedule_stub:invokes(function(fn)
             fn()
@@ -114,12 +126,85 @@ describe("agentic.ui.PermissionManager", function()
 
         schedule_stub:revert()
 
+        if registered_owner then
+            require("agentic.ui.widget_registry").unregister(registered_owner)
+        end
+
+        if own_win and vim.api.nvim_win_is_valid(own_win) then
+            vim.api.nvim_win_close(own_win, true)
+        end
         if winid and vim.api.nvim_win_is_valid(winid) then
             vim.api.nvim_win_close(winid, true)
         end
+
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            if not baseline_tabs[tabpage] then
+                pcall(function()
+                    vim.api.nvim_set_current_tabpage(tabpage)
+                    vim.cmd("tabclose!")
+                end)
+            end
+        end
+
         if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
             vim.api.nvim_buf_delete(bufnr, { force = true })
         end
+    end)
+
+    describe("registered chat owner", function()
+        it("returns the owning widget's visible chat window", function()
+            local WidgetRegistry = require("agentic.ui.widget_registry")
+            vim.cmd("tabnew")
+            local owner_tab = vim.api.nvim_get_current_tabpage()
+            own_win = vim.api.nvim_open_win(bufnr, true, {
+                relative = "editor",
+                width = 80,
+                height = 20,
+                row = 0,
+                col = 0,
+            })
+            registered_owner = {
+                tab_page_id = owner_tab,
+                buf_nrs = { chat = bufnr },
+                win_nrs = { chat = own_win },
+            }
+            WidgetRegistry.register(registered_owner)
+
+            assert.equal(own_win, pm:_find_visible_chat_winid())
+        end)
+
+        it(
+            "returns nil for a hidden owner with a foreign visible copy",
+            function()
+                local WidgetRegistry = require("agentic.ui.widget_registry")
+                registered_owner = {
+                    tab_page_id = vim.api.nvim_get_current_tabpage(),
+                    buf_nrs = { chat = bufnr },
+                    win_nrs = {},
+                }
+                WidgetRegistry.register(registered_owner)
+
+                assert.is_nil(pm:_find_visible_chat_winid())
+            end
+        )
+
+        it(
+            "rejects an owner window outside the owner's stored tabpage",
+            function()
+                local WidgetRegistry = require("agentic.ui.widget_registry")
+                vim.cmd("tabnew")
+                local owner_tab = vim.api.nvim_get_current_tabpage()
+                vim.cmd("tabprevious")
+                registered_owner = {
+                    tab_page_id = owner_tab,
+                    buf_nrs = { chat = bufnr },
+                    win_nrs = { chat = winid },
+                }
+                WidgetRegistry.register(registered_owner)
+
+                assert.is_nil(pm:_find_visible_chat_winid())
+            end
+        )
     end)
 
     describe("concurrent pending map", function()

--- a/lua/agentic/ui/widget_registry.lua
+++ b/lua/agentic/ui/widget_registry.lua
@@ -1,0 +1,44 @@
+--- @class agentic.ui.WidgetRegistry
+local WidgetRegistry = {}
+
+--- Buffer numbers are global in Neovim.
+--- @type table<integer, agentic.ui.ChatWidget>
+local widgets_by_bufnr = {}
+
+--- @param widget agentic.ui.ChatWidget
+function WidgetRegistry.register(widget)
+    WidgetRegistry.unregister(widget)
+
+    for _, bufnr in pairs(widget.buf_nrs) do
+        widgets_by_bufnr[bufnr] = widget
+    end
+end
+
+--- @param widget agentic.ui.ChatWidget
+function WidgetRegistry.unregister(widget)
+    for bufnr, owner in pairs(widgets_by_bufnr) do
+        if owner == widget then
+            widgets_by_bufnr[bufnr] = nil
+        end
+    end
+end
+
+--- @param bufnr integer
+--- @return agentic.ui.ChatWidget|nil
+function WidgetRegistry.get(bufnr)
+    return widgets_by_bufnr[bufnr]
+end
+
+--- @return table<integer, true>
+function WidgetRegistry.all_bufnrs()
+    --- @type table<integer, true>
+    local bufnrs = {}
+
+    for bufnr in pairs(widgets_by_bufnr) do
+        bufnrs[bufnr] = true
+    end
+
+    return bufnrs
+end
+
+return WidgetRegistry

--- a/lua/agentic/ui/widget_registry.test.lua
+++ b/lua/agentic/ui/widget_registry.test.lua
@@ -1,0 +1,101 @@
+--- @diagnostic disable: assign-type-mismatch, missing-fields, return-type-mismatch
+
+local assert = require("tests.helpers.assert")
+local WidgetRegistry = require("agentic.ui.widget_registry")
+
+describe("agentic.ui.WidgetRegistry", function()
+    --- @type agentic.ui.ChatWidget[]
+    local created
+
+    --- @param buf_nrs table<string, integer>
+    --- @return agentic.ui.ChatWidget
+    local function fake_widget(buf_nrs)
+        local widget = { buf_nrs = buf_nrs }
+        created[#created + 1] = widget
+        return widget
+    end
+
+    before_each(function()
+        created = {}
+    end)
+
+    after_each(function()
+        for _, widget in ipairs(created) do
+            WidgetRegistry.unregister(widget)
+        end
+    end)
+
+    it("maps every current buffer to its widget", function()
+        local widget = fake_widget({ chat = 11, input = 12 })
+
+        WidgetRegistry.register(widget)
+
+        assert.equal(widget, WidgetRegistry.get(11))
+        assert.equal(widget, WidgetRegistry.get(12))
+    end)
+
+    it("returns nil for an unregistered buffer", function()
+        assert.is_nil(WidgetRegistry.get(9999))
+    end)
+
+    it("removes stale mappings when a widget re-registers", function()
+        local widget = fake_widget({ chat = 21, input = 22 })
+        WidgetRegistry.register(widget)
+
+        widget.buf_nrs.chat = 23
+        WidgetRegistry.register(widget)
+
+        assert.is_nil(WidgetRegistry.get(21))
+        assert.equal(widget, WidgetRegistry.get(22))
+        assert.equal(widget, WidgetRegistry.get(23))
+    end)
+
+    it("replaces only colliding ownership", function()
+        local first = fake_widget({ chat = 31, input = 32 })
+        local second = fake_widget({ chat = 31, input = 33 })
+        WidgetRegistry.register(first)
+
+        WidgetRegistry.register(second)
+
+        assert.equal(second, WidgetRegistry.get(31))
+        assert.equal(first, WidgetRegistry.get(32))
+        assert.equal(second, WidgetRegistry.get(33))
+    end)
+
+    it("unregisters only mappings still owned by the widget", function()
+        local first = fake_widget({ chat = 41, input = 42 })
+        local second = fake_widget({ chat = 41 })
+        WidgetRegistry.register(first)
+        WidgetRegistry.register(second)
+
+        WidgetRegistry.unregister(first)
+
+        assert.equal(second, WidgetRegistry.get(41))
+        assert.is_nil(WidgetRegistry.get(42))
+    end)
+
+    it("unregisters mappings after buf_nrs changes", function()
+        local widget = fake_widget({ chat = 51, input = 52 })
+        WidgetRegistry.register(widget)
+        widget.buf_nrs = {}
+
+        WidgetRegistry.unregister(widget)
+
+        assert.is_nil(WidgetRegistry.get(51))
+        assert.is_nil(WidgetRegistry.get(52))
+    end)
+
+    it("returns all registered buffer numbers as a set", function()
+        local first = fake_widget({ chat = 61, input = 62 })
+        local second = fake_widget({ chat = 63 })
+        WidgetRegistry.register(first)
+        WidgetRegistry.register(second)
+
+        local registered = WidgetRegistry.all_bufnrs()
+
+        assert.is_true(registered[61])
+        assert.is_true(registered[62])
+        assert.is_true(registered[63])
+        assert.is_nil(registered[64])
+    end)
+end)


### PR DESCRIPTION
- Resolve widget owners by buffer
- Preserve fixed-tab widget placement
- Guard redirects against stale owners
- Verify with `make validate`