### PR TITLE
refactor: move diff state out of tabpage scope

### DIFF
--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -455,6 +455,21 @@ function SessionManager:_on_tool_call_update(tool_call_update)
         )
     end
 
+    local tracker =
+        self.message_writer.tool_call_blocks[tool_call_update.tool_call_id]
+
+    if
+        tool_call_update.status == "completed"
+        and tracker
+        and tracker.kind
+        and ACPPayloads.FILE_MUTATING_KINDS[tracker.kind]
+    then
+        DiffPreview.cleanup_suggestion_buffer(
+            tracker.file_path,
+            self.diff_coordinator.diff_state
+        )
+    end
+
     -- pre-emptively clear diff preview when tool call update is received, as it's either done or failed
     local is_rejection = tool_call_update.status == "failed"
     self.diff_coordinator:clear(tool_call_update.tool_call_id, is_rejection)
@@ -474,20 +489,12 @@ function SessionManager:_on_tool_call_update(tool_call_update)
 
     -- Reload buffers when file-mutating tool calls complete
     if tool_call_update.status == "completed" then
-        local tracker =
-            self.message_writer.tool_call_blocks[tool_call_update.tool_call_id]
-
         if
             tracker
             and tracker.kind
             and ACPPayloads.FILE_MUTATING_KINDS[tracker.kind]
         then
             vim.cmd.checktime()
-
-            DiffPreview.cleanup_suggestion_buffer(
-                tracker.file_path,
-                self.diff_coordinator.diff_state
-            )
 
             -- Skip the hook during restore replay: the provider replays
             -- historical tool calls as "completed" but no write happened now.

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -458,6 +458,10 @@ function SessionManager:_on_tool_call_update(tool_call_update)
     local tracker =
         self.message_writer.tool_call_blocks[tool_call_update.tool_call_id]
 
+    -- pre-emptively clear diff preview when tool call update is received, as it's either done or failed
+    local is_rejection = tool_call_update.status == "failed"
+    self.diff_coordinator:clear(tool_call_update.tool_call_id, is_rejection)
+
     if
         tool_call_update.status == "completed"
         and tracker
@@ -469,10 +473,6 @@ function SessionManager:_on_tool_call_update(tool_call_update)
             self.diff_coordinator.diff_state
         )
     end
-
-    -- pre-emptively clear diff preview when tool call update is received, as it's either done or failed
-    local is_rejection = tool_call_update.status == "failed"
-    self.diff_coordinator:clear(tool_call_update.tool_call_id, is_rejection)
 
     -- Remove the permission request when the tool call reaches a terminal status.
     -- `failed` covers user rejection or agent-side error;

--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -484,7 +484,10 @@ function SessionManager:_on_tool_call_update(tool_call_update)
         then
             vim.cmd.checktime()
 
-            DiffPreview.cleanup_suggestion_buffer(tracker.file_path)
+            DiffPreview.cleanup_suggestion_buffer(
+                tracker.file_path,
+                self.diff_coordinator.diff_state
+            )
 
             -- Skip the hook during restore replay: the provider replays
             -- historical tool calls as "completed" but no write happened now.

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -1453,6 +1453,81 @@ describe("agentic.SessionManager", function()
         end)
 
         it(
+            "accepts its new-file suggestion before clearing diff ownership",
+            function()
+                cleanup_suggestion_buffer_stub:revert()
+
+                local DiffCoordinator = require("agentic.ui.diff_coordinator")
+                local file_path = "/tmp/agentic-completed-new-file-"
+                    .. tostring(vim.uv.hrtime())
+                    .. ".lua"
+                local tool_call_id = "tc-new-file"
+                local tracker = {
+                    tool_call_id = tool_call_id,
+                    kind = "edit",
+                    status = "in_progress",
+                    file_path = file_path,
+                    diff = { changed_pairs = {} },
+                }
+                local session = make_session({ [tool_call_id] = tracker })
+                local current_winid = vim.api.nvim_get_current_win()
+                local original_bufnr = vim.api.nvim_get_current_buf()
+                local suggestion_bufnr
+
+                session.diff_coordinator = DiffCoordinator:new(
+                    { buf_nrs = {} } --[[@as agentic.ui.ChatWidget]],
+                    session.message_writer --[[@as agentic.ui.MessageWriter]],
+                    function()
+                        return vim.api.nvim_get_current_tabpage()
+                    end
+                )
+                DiffPreview._show_new_file_diff({
+                    file_path = file_path,
+                    diff = { changed_pairs = {} },
+                    state = session.diff_coordinator.diff_state,
+                    get_winid = function(bufnr)
+                        suggestion_bufnr = bufnr
+                        vim.api.nvim_win_set_buf(current_winid, bufnr)
+                        return current_winid
+                    end,
+                }, { "return true" })
+
+                SessionManager._on_tool_call_update(session, {
+                    tool_call_id = tool_call_id,
+                    status = "completed",
+                })
+
+                local suggestion_is_valid = suggestion_bufnr ~= nil
+                    and vim.api.nvim_buf_is_valid(suggestion_bufnr)
+                local displayed_bufnr = vim.api.nvim_win_get_buf(current_winid)
+                local displayed_name =
+                    vim.api.nvim_buf_get_name(displayed_bufnr)
+
+                pcall(vim.api.nvim_win_set_buf, current_winid, original_bufnr)
+                if suggestion_bufnr then
+                    pcall(
+                        vim.api.nvim_buf_delete,
+                        suggestion_bufnr,
+                        { force = true }
+                    )
+                end
+                if displayed_bufnr ~= original_bufnr then
+                    pcall(
+                        vim.api.nvim_buf_delete,
+                        displayed_bufnr,
+                        { force = true }
+                    )
+                end
+
+                assert.is_false(suggestion_is_valid)
+                assert.equal(
+                    vim.fn.fnamemodify(file_path, ":t"),
+                    vim.fn.fnamemodify(displayed_name, ":t")
+                )
+            end
+        )
+
+        it(
             "removes pending permission on failed and completed tool-call updates",
             function()
                 for _, status in ipairs({ "failed", "completed" }) do

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -1520,6 +1520,8 @@ describe("agentic.SessionManager", function()
                 assert.is_not_nil(permission_callback)
                 permission_callback("allow_once")
                 show_suggestion()
+                local real_bufnr = vim.fn.bufadd(file_path)
+                vim.fn.bufload(real_bufnr)
                 restore_keymaps_spy = spy.on(HunkNavigation, "restore_keymaps")
 
                 SessionManager._on_tool_call_update(session, {
@@ -1557,6 +1559,7 @@ describe("agentic.SessionManager", function()
                 assert.is_true(restored_owner)
                 assert.is_nil(session.diff_coordinator.diff_state.preview_bufnr)
                 assert.is_nil(session.diff_coordinator.diff_state.preview_winid)
+                assert.equal(real_bufnr, displayed_bufnr)
                 assert.equal(
                     vim.fn.fnamemodify(file_path, ":t"),
                     vim.fn.fnamemodify(displayed_name, ":t")

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -1380,7 +1380,10 @@ describe("agentic.SessionManager", function()
                 status_animation = { start = function() end },
                 is_generating = true,
                 _start_spinner = SessionManager._start_spinner,
-                diff_coordinator = { clear = function() end },
+                diff_coordinator = {
+                    clear = function() end,
+                    diff_state = {},
+                },
                 _on_tool_call = function() end,
                 chat_history = {
                     update_tool_call = function() end,
@@ -1428,6 +1431,25 @@ describe("agentic.SessionManager", function()
 
                 assert.spy(checktime_stub).was.called(1)
             end
+        end)
+
+        it("cleans up only its coordinator-owned suggestion", function()
+            local session = make_session({
+                ["tc-1"] = {
+                    kind = "edit",
+                    status = "in_progress",
+                    file_path = "/tmp/owned.lua",
+                },
+            })
+
+            SessionManager._on_tool_call_update(
+                session,
+                { tool_call_id = "tc-1", status = "completed" }
+            )
+
+            assert
+                .spy(cleanup_suggestion_buffer_stub).was
+                .called_with("/tmp/owned.lua", session.diff_coordinator.diff_state)
         end)
 
         it(

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -1453,7 +1453,7 @@ describe("agentic.SessionManager", function()
         end)
 
         it(
-            "accepts its new-file suggestion before clearing diff ownership",
+            "accepts a permission-cleared new-file suggestion on completion",
             function()
                 cleanup_suggestion_buffer_stub:revert()
 
@@ -1473,6 +1473,7 @@ describe("agentic.SessionManager", function()
                 local current_winid = vim.api.nvim_get_current_win()
                 local original_bufnr = vim.api.nvim_get_current_buf()
                 local suggestion_bufnr
+                local permission_callback
 
                 session.diff_coordinator = DiffCoordinator:new(
                     { buf_nrs = {} } --[[@as agentic.ui.ChatWidget]],
@@ -1481,6 +1482,15 @@ describe("agentic.SessionManager", function()
                         return vim.api.nvim_get_current_tabpage()
                     end
                 )
+                session.diff_coordinator.show = function() end
+                session.permission_manager.add_request = function(
+                    _self,
+                    _request,
+                    callback
+                )
+                    permission_callback = callback
+                end
+                session.status_animation.stop = function() end
                 DiffPreview._show_new_file_diff({
                     file_path = file_path,
                     diff = { changed_pairs = {} },
@@ -1491,6 +1501,14 @@ describe("agentic.SessionManager", function()
                         return current_winid
                     end,
                 }, { "return true" })
+
+                local handlers = SessionManager._build_handlers(session)
+                handlers.on_request_permission({
+                    toolCall = { toolCallId = tool_call_id },
+                    options = {},
+                }, function() end)
+                assert.is_not_nil(permission_callback)
+                permission_callback("allow_once")
 
                 SessionManager._on_tool_call_update(session, {
                     tool_call_id = tool_call_id,

--- a/lua/agentic/session_manager.test.lua
+++ b/lua/agentic/session_manager.test.lua
@@ -1359,6 +1359,8 @@ describe("agentic.SessionManager", function()
         local schedule_stub
         --- @type TestStub
         local cleanup_suggestion_buffer_stub
+        --- @type TestSpy|nil
+        local restore_keymaps_spy
 
         --- @param tool_call_blocks table<string, table>
         --- @return agentic.SessionManager
@@ -1403,6 +1405,10 @@ describe("agentic.SessionManager", function()
         end)
 
         after_each(function()
+            if restore_keymaps_spy then
+                restore_keymaps_spy:revert()
+                restore_keymaps_spy = nil
+            end
             checktime_stub:revert()
             schedule_stub:revert()
             cleanup_suggestion_buffer_stub:revert()
@@ -1453,11 +1459,12 @@ describe("agentic.SessionManager", function()
         end)
 
         it(
-            "accepts a permission-cleared new-file suggestion on completion",
+            "clears a refreshed permission-cleared preview before acceptance",
             function()
                 cleanup_suggestion_buffer_stub:revert()
 
                 local DiffCoordinator = require("agentic.ui.diff_coordinator")
+                local HunkNavigation = require("agentic.ui.hunk_navigation")
                 local file_path = "/tmp/agentic-completed-new-file-"
                     .. tostring(vim.uv.hrtime())
                     .. ".lua"
@@ -1491,17 +1498,20 @@ describe("agentic.SessionManager", function()
                     permission_callback = callback
                 end
                 session.status_animation.stop = function() end
-                DiffPreview._show_new_file_diff({
-                    file_path = file_path,
-                    diff = { changed_pairs = {} },
-                    state = session.diff_coordinator.diff_state,
-                    get_winid = function(bufnr)
-                        suggestion_bufnr = bufnr
-                        vim.api.nvim_win_set_buf(current_winid, bufnr)
-                        return current_winid
-                    end,
-                }, { "return true" })
+                local function show_suggestion()
+                    DiffPreview._show_new_file_diff({
+                        file_path = file_path,
+                        diff = { changed_pairs = {} },
+                        state = session.diff_coordinator.diff_state,
+                        get_winid = function(bufnr)
+                            suggestion_bufnr = bufnr
+                            vim.api.nvim_win_set_buf(current_winid, bufnr)
+                            return current_winid
+                        end,
+                    }, { "return true" })
+                end
 
+                show_suggestion()
                 local handlers = SessionManager._build_handlers(session)
                 handlers.on_request_permission({
                     toolCall = { toolCallId = tool_call_id },
@@ -1509,6 +1519,8 @@ describe("agentic.SessionManager", function()
                 }, function() end)
                 assert.is_not_nil(permission_callback)
                 permission_callback("allow_once")
+                show_suggestion()
+                restore_keymaps_spy = spy.on(HunkNavigation, "restore_keymaps")
 
                 SessionManager._on_tool_call_update(session, {
                     tool_call_id = tool_call_id,
@@ -1520,6 +1532,10 @@ describe("agentic.SessionManager", function()
                 local displayed_bufnr = vim.api.nvim_win_get_buf(current_winid)
                 local displayed_name =
                     vim.api.nvim_buf_get_name(displayed_bufnr)
+                local restored_owner = restore_keymaps_spy:called_with(
+                    suggestion_bufnr,
+                    session.diff_coordinator.diff_state
+                )
 
                 pcall(vim.api.nvim_win_set_buf, current_winid, original_bufnr)
                 if suggestion_bufnr then
@@ -1538,6 +1554,9 @@ describe("agentic.SessionManager", function()
                 end
 
                 assert.is_false(suggestion_is_valid)
+                assert.is_true(restored_owner)
+                assert.is_nil(session.diff_coordinator.diff_state.preview_bufnr)
+                assert.is_nil(session.diff_coordinator.diff_state.preview_winid)
                 assert.equal(
                     vim.fn.fnamemodify(file_path, ":t"),
                     vim.fn.fnamemodify(displayed_name, ":t")

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -154,6 +154,9 @@ function ChatWidget:rotate_layout(layouts)
         if not vim.api.nvim_tabpage_is_valid(self.tab_page_id) then
             return
         end
+        if not self:is_open() then
+            return
+        end
         local win =
             BufHelpers.find_visible_win(previous_buf, nil, self.tab_page_id)
         if not win or not BufHelpers.is_win_usable(win) then

--- a/lua/agentic/ui/chat_widget.lua
+++ b/lua/agentic/ui/chat_widget.lua
@@ -2,7 +2,6 @@ local Config = require("agentic.config")
 local BufHelpers = require("agentic.utils.buf_helpers")
 local BufferGuard = require("agentic.ui.buffer_guard")
 local ChatNavigation = require("agentic.ui.chat_navigation")
-local DiffPreview = require("agentic.ui.diff_preview")
 local Logger = require("agentic.utils.logger")
 local WindowDecoration = require("agentic.ui.window_decoration")
 local WidgetRegistry = require("agentic.ui.widget_registry")
@@ -152,10 +151,15 @@ function ChatWidget:rotate_layout(layouts)
     })
 
     vim.schedule(function()
-        local win = vim.fn.bufwinid(previous_buf)
-        if win ~= -1 then
-            vim.api.nvim_set_current_win(win)
+        if not vim.api.nvim_tabpage_is_valid(self.tab_page_id) then
+            return
         end
+        local win =
+            BufHelpers.find_visible_win(previous_buf, nil, self.tab_page_id)
+        if not win or not BufHelpers.is_win_usable(win) then
+            return
+        end
+        vim.api.nvim_set_current_win(win)
         if previous_mode == "i" then
             vim.cmd("startinsert")
         end
@@ -301,16 +305,34 @@ end
 --- @param winid integer|nil
 --- @param callback fun()|nil
 function ChatWidget:move_cursor_to(winid, callback)
+    local panel_name
+    for name, panel_winid in pairs(self.win_nrs) do
+        if panel_winid == winid then
+            panel_name = name
+            break
+        end
+    end
+
     vim.schedule(function()
-        if winid and vim.api.nvim_win_is_valid(winid) then
+        local target_winid = panel_name and self.win_nrs[panel_name] or winid
+        if target_winid and BufHelpers.is_win_usable(target_winid) then
+            local target_bufnr = vim.api.nvim_win_get_buf(target_winid)
+            local visible_winid = BufHelpers.find_visible_win(
+                target_bufnr,
+                target_winid,
+                self.tab_page_id
+            )
+            if visible_winid ~= target_winid then
+                return
+            end
             if Config.settings.move_cursor_to_chat_on_submit then
-                vim.api.nvim_set_current_win(winid)
+                vim.api.nvim_set_current_win(target_winid)
             end
 
             -- make sure to scroll to the bottom
             -- 1. user can see the new message
             -- 2. auto-scroll will start again
-            vim.api.nvim_win_call(winid, function()
+            vim.api.nvim_win_call(target_winid, function()
                 vim.cmd("normal! G0zb")
             end)
 
@@ -440,7 +462,6 @@ function ChatWidget:_bind_keymaps()
         end
     end
 
-    DiffPreview.setup_diff_navigation_keymaps(self.buf_nrs)
     ChatNavigation.setup_keymaps(self.buf_nrs.chat)
 end
 

--- a/lua/agentic/ui/chat_widget.test.lua
+++ b/lua/agentic/ui/chat_widget.test.lua
@@ -1,4 +1,5 @@
 local assert = require("tests.helpers.assert")
+local Child = require("tests.helpers.child")
 local spy = require("tests.helpers.spy")
 local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
@@ -1212,6 +1213,68 @@ describe("agentic.ui.ChatWidget", function()
             assert.is_true(panels.files)
         end)
     end)
+end)
+
+describe("agentic.ui.ChatWidget foreign cached windows (child)", function()
+    local child = Child.new()
+
+    before_each(function()
+        child.setup()
+    end)
+
+    after_each(function()
+        child.stop()
+    end)
+
+    it(
+        "keeps replacement windows open after deferred WinClosed callbacks",
+        function()
+            local replacement_windows = child.lua([[
+            local ChatWidget = require("agentic.ui.chat_widget")
+
+            vim.cmd("tabnew")
+            local owner_tab = vim.api.nvim_get_current_tabpage()
+            local widget = ChatWidget:new(owner_tab, function()
+                return true
+            end)
+            widget:show({ focus_prompt = false })
+
+            vim.bo[widget.buf_nrs.code].modifiable = true
+            vim.api.nvim_buf_set_lines(
+                widget.buf_nrs.code,
+                0,
+                -1,
+                false,
+                { "diff" }
+            )
+
+            vim.cmd("tabnew")
+            local foreign_chat = vim.api.nvim_get_current_win()
+            local foreign_code = vim.api.nvim_open_win(
+                vim.api.nvim_create_buf(false, true),
+                false,
+                { split = "right", win = foreign_chat }
+            )
+            vim.api.nvim_open_win(
+                vim.api.nvim_create_buf(false, true),
+                false,
+                { split = "right", win = foreign_code }
+            )
+
+            vim.api.nvim_set_current_tabpage(owner_tab)
+            widget.win_nrs.chat = foreign_chat
+            widget.win_nrs.code = foreign_code
+            widget:show({ focus_prompt = false })
+
+            return { widget.win_nrs.chat, widget.win_nrs.code }
+        ]])
+
+            child.flush()
+
+            assert.is_true(child.api.nvim_win_is_valid(replacement_windows[1]))
+            assert.is_true(child.api.nvim_win_is_valid(replacement_windows[2]))
+        end
+    )
 end)
 
 describe("agentic.ui.ChatWidget deferred window guards", function()

--- a/lua/agentic/ui/chat_widget.test.lua
+++ b/lua/agentic/ui/chat_widget.test.lua
@@ -1297,6 +1297,9 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
         }
 
         ChatWidget.move_cursor_to(widget, old_win)
+        local move_callback = scheduled
+        assert.is_not_nil(move_callback)
+        ---@cast move_callback function
         widget.win_nrs.chat = replacement
         vim.api.nvim_win_close(old_win, true)
         local bystander_buf = vim.api.nvim_create_buf(false, true)
@@ -1305,7 +1308,7 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
             win = replacement,
         })
         assert.equal(bystander, vim.api.nvim_get_current_win())
-        scheduled()
+        move_callback()
 
         assert.equal(replacement, vim.api.nvim_get_current_win())
     end)
@@ -1372,9 +1375,12 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
         }
 
         ChatWidget.rotate_layout(widget, { "right", "left" })
+        local rotate_callback = scheduled
+        assert.is_not_nil(rotate_callback)
+        ---@cast rotate_callback function
         vim.api.nvim_win_close(old_win, true)
         vim.cmd("tabnew")
-        scheduled()
+        rotate_callback()
 
         assert.equal(replacement, vim.api.nvim_get_current_win())
     end)
@@ -1401,11 +1407,14 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
         widget:show({ focus_prompt = false })
 
         widget:rotate_layout({ "right", "bottom" })
+        local rotate_callback = scheduled
+        assert.is_not_nil(rotate_callback)
+        ---@cast rotate_callback function
         widget:hide()
         vim.cmd("tabnew")
         local safe_tab = vim.api.nvim_get_current_tabpage()
         local safe_win = vim.api.nvim_get_current_win()
-        scheduled()
+        rotate_callback()
 
         assert.equal(safe_tab, vim.api.nvim_get_current_tabpage())
         assert.equal(safe_win, vim.api.nvim_get_current_win())
@@ -1431,9 +1440,12 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
         }
 
         ChatWidget.rotate_layout(widget, { "right", "left" })
+        local rotate_callback = scheduled
+        assert.is_not_nil(rotate_callback)
+        ---@cast rotate_callback function
         vim.api.nvim_win_close(old_win, true)
         vim.api.nvim_set_current_win(spare)
-        scheduled()
+        rotate_callback()
 
         assert.spy(startinsert_stub).was.called(0)
         mode_stub:revert()

--- a/lua/agentic/ui/chat_widget.test.lua
+++ b/lua/agentic/ui/chat_widget.test.lua
@@ -4,6 +4,7 @@ local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
 local WindowDecoration = require("agentic.ui.window_decoration")
 local WidgetRegistry = require("agentic.ui.widget_registry")
+local BufHelpers = require("agentic.utils.buf_helpers")
 
 describe("agentic.ui.ChatWidget", function()
     --- @type agentic.ui.ChatWidget
@@ -1210,5 +1211,157 @@ describe("agentic.ui.ChatWidget", function()
             end
             assert.is_true(panels.files)
         end)
+    end)
+end)
+
+describe("agentic.ui.ChatWidget deferred window guards", function()
+    local ChatWidget = require("agentic.ui.chat_widget")
+    local schedule_stub
+    local scheduled
+    local saved_move_cursor
+    local base_tabs
+
+    before_each(function()
+        base_tabs = {}
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            base_tabs[tabpage] = true
+        end
+        saved_move_cursor = Config.settings.move_cursor_to_chat_on_submit
+        Config.settings.move_cursor_to_chat_on_submit = true
+        scheduled = nil
+        schedule_stub = spy.stub(vim, "schedule")
+        schedule_stub:invokes(function(callback)
+            scheduled = callback
+        end)
+    end)
+
+    after_each(function()
+        schedule_stub:revert()
+        Config.settings.move_cursor_to_chat_on_submit = saved_move_cursor
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            if not base_tabs[tabpage] then
+                pcall(function()
+                    vim.api.nvim_set_current_tabpage(tabpage)
+                    vim.cmd("tabclose!")
+                end)
+            end
+        end
+    end)
+
+    it("focuses a rebuilt panel instead of its captured handle", function()
+        vim.cmd("tabnew")
+        local tabpage = vim.api.nvim_get_current_tabpage()
+        local old_win = vim.api.nvim_get_current_win()
+        local replacement_buf = vim.api.nvim_create_buf(false, true)
+        local replacement = vim.api.nvim_open_win(replacement_buf, false, {
+            split = "right",
+            win = old_win,
+        })
+        local widget = {
+            tab_page_id = tabpage,
+            win_nrs = { chat = old_win },
+        }
+
+        ChatWidget.move_cursor_to(widget, old_win)
+        widget.win_nrs.chat = replacement
+        vim.api.nvim_win_close(old_win, true)
+        local bystander_buf = vim.api.nvim_create_buf(false, true)
+        local bystander = vim.api.nvim_open_win(bystander_buf, true, {
+            split = "below",
+            win = replacement,
+        })
+        assert.equal(bystander, vim.api.nvim_get_current_win())
+        scheduled()
+
+        assert.equal(replacement, vim.api.nvim_get_current_win())
+    end)
+
+    it("ignores a hidden destination window", function()
+        local current = vim.api.nvim_get_current_win()
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local hidden = vim.api.nvim_open_win(bufnr, false, {
+            relative = "editor",
+            row = 0,
+            col = 0,
+            width = 10,
+            height = 2,
+            hide = true,
+            focusable = false,
+        })
+        local widget = { win_nrs = { chat = hidden } }
+
+        ChatWidget.move_cursor_to(widget, hidden)
+
+        assert.has_no_errors(scheduled)
+        assert.equal(current, vim.api.nvim_get_current_win())
+        pcall(vim.api.nvim_win_close, hidden, true)
+    end)
+
+    it("ignores a stale-valid handle whose tabpage is gone", function()
+        local target = vim.api.nvim_get_current_win()
+        local widget = { win_nrs = { chat = target } }
+        local usable_stub = spy.stub(BufHelpers, "is_win_usable")
+        usable_stub:returns(false)
+        local focus_stub = spy.stub(vim.api, "nvim_set_current_win")
+
+        ChatWidget.move_cursor_to(widget, target)
+        scheduled()
+
+        local usable_called = usable_stub:called_with(target)
+        local focus_count = focus_stub.call_count
+        focus_stub:revert()
+        usable_stub:revert()
+        assert.is_true(usable_called)
+        assert.equal(0, focus_count)
+    end)
+
+    it("restores rotation focus in the stored tabpage", function()
+        vim.cmd("tabnew")
+        local owner_tab = vim.api.nvim_get_current_tabpage()
+        local previous_buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_win_set_buf(0, previous_buf)
+        local old_win = vim.api.nvim_get_current_win()
+        vim.cmd("split")
+        local replacement = vim.api.nvim_get_current_win()
+        vim.api.nvim_win_set_buf(replacement, previous_buf)
+        vim.api.nvim_set_current_win(old_win)
+        local widget = {
+            tab_page_id = owner_tab,
+            current_position = "right",
+            hide = function() end,
+            show = function() end,
+        }
+
+        ChatWidget.rotate_layout(widget, { "right", "left" })
+        vim.api.nvim_win_close(old_win, true)
+        vim.cmd("tabnew")
+        scheduled()
+
+        assert.equal(replacement, vim.api.nvim_get_current_win())
+    end)
+
+    it("does not restore insert mode when the prior editor is gone", function()
+        local mode_stub = spy.stub(vim.fn, "mode")
+        mode_stub:returns("i")
+        local startinsert_stub = spy.stub(vim.cmd, "startinsert")
+        local old_win = vim.api.nvim_get_current_win()
+        vim.cmd("split")
+        local spare = vim.api.nvim_get_current_win()
+        vim.api.nvim_set_current_win(old_win)
+        local widget = {
+            tab_page_id = vim.api.nvim_get_current_tabpage(),
+            current_position = "right",
+            hide = function() end,
+            show = function() end,
+        }
+
+        ChatWidget.rotate_layout(widget, { "right", "left" })
+        vim.api.nvim_win_close(old_win, true)
+        vim.api.nvim_set_current_win(spare)
+        scheduled()
+
+        assert.spy(startinsert_stub).was.called(0)
+        mode_stub:revert()
+        startinsert_stub:revert()
     end)
 end)

--- a/lua/agentic/ui/chat_widget.test.lua
+++ b/lua/agentic/ui/chat_widget.test.lua
@@ -1220,12 +1220,29 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
     local scheduled
     local saved_move_cursor
     local base_tabs
+    local base_bufs
+    local created_widgets
+
+    --- @return agentic.ui.ChatWidget widget
+    local function create_widget()
+        local widget = ChatWidget:new(
+            vim.api.nvim_get_current_tabpage(),
+            spy.new(function() end) --[[@as function]]
+        )
+        created_widgets[#created_widgets + 1] = widget
+        return widget
+    end
 
     before_each(function()
         base_tabs = {}
         for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
             base_tabs[tabpage] = true
         end
+        base_bufs = {}
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            base_bufs[bufnr] = true
+        end
+        created_widgets = {}
         saved_move_cursor = Config.settings.move_cursor_to_chat_on_submit
         Config.settings.move_cursor_to_chat_on_submit = true
         scheduled = nil
@@ -1236,6 +1253,11 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
     end)
 
     after_each(function()
+        for _, widget in ipairs(created_widgets) do
+            pcall(function()
+                widget:destroy()
+            end)
+        end
         schedule_stub:revert()
         Config.settings.move_cursor_to_chat_on_submit = saved_move_cursor
         for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
@@ -1246,6 +1268,18 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
                 end)
             end
         end
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            if not base_bufs[bufnr] and vim.api.nvim_buf_is_valid(bufnr) then
+                pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            end
+        end
+        local extra_bufs = 0
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            if not base_bufs[bufnr] then
+                extra_bufs = extra_bufs + 1
+            end
+        end
+        assert.equal(0, extra_bufs)
     end)
 
     it("focuses a rebuilt panel instead of its captured handle", function()
@@ -1277,6 +1311,7 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
     end)
 
     it("ignores a hidden destination window", function()
+        vim.cmd("tabnew")
         local current = vim.api.nvim_get_current_win()
         local bufnr = vim.api.nvim_create_buf(false, true)
         local hidden = vim.api.nvim_open_win(bufnr, false, {
@@ -1298,6 +1333,7 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
     end)
 
     it("ignores a stale-valid handle whose tabpage is gone", function()
+        vim.cmd("tabnew")
         local target = vim.api.nvim_get_current_win()
         local widget = { win_nrs = { chat = target } }
         local usable_stub = spy.stub(BufHelpers, "is_win_usable")
@@ -1330,6 +1366,9 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
             current_position = "right",
             hide = function() end,
             show = function() end,
+            is_open = function()
+                return true
+            end,
         }
 
         ChatWidget.rotate_layout(widget, { "right", "left" })
@@ -1340,7 +1379,40 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
         assert.equal(replacement, vim.api.nvim_get_current_win())
     end)
 
+    it("never restores rotation focus into the hidden chat float", function()
+        vim.cmd("tabnew")
+        local widget = create_widget()
+        widget:show({ focus_prompt = false })
+        vim.api.nvim_set_current_win(widget.win_nrs.chat)
+
+        widget:rotate_layout({ "right", "bottom" })
+        scheduled()
+
+        assert.equal(widget.win_nrs.chat, vim.api.nvim_get_current_win())
+        local config =
+            vim.api.nvim_win_get_config(vim.api.nvim_get_current_win())
+        assert.is_true(config.focusable)
+        assert.is_falsy(config.hide)
+    end)
+
+    it("drops rotation focus restoration after the widget hides", function()
+        vim.cmd("tabnew")
+        local widget = create_widget()
+        widget:show({ focus_prompt = false })
+
+        widget:rotate_layout({ "right", "bottom" })
+        widget:hide()
+        vim.cmd("tabnew")
+        local safe_tab = vim.api.nvim_get_current_tabpage()
+        local safe_win = vim.api.nvim_get_current_win()
+        scheduled()
+
+        assert.equal(safe_tab, vim.api.nvim_get_current_tabpage())
+        assert.equal(safe_win, vim.api.nvim_get_current_win())
+    end)
+
     it("does not restore insert mode when the prior editor is gone", function()
+        vim.cmd("tabnew")
         local mode_stub = spy.stub(vim.fn, "mode")
         mode_stub:returns("i")
         local startinsert_stub = spy.stub(vim.cmd, "startinsert")
@@ -1353,6 +1425,9 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
             current_position = "right",
             hide = function() end,
             show = function() end,
+            is_open = function()
+                return true
+            end,
         }
 
         ChatWidget.rotate_layout(widget, { "right", "left" })

--- a/lua/agentic/ui/chat_widget.test.lua
+++ b/lua/agentic/ui/chat_widget.test.lua
@@ -1255,7 +1255,7 @@ describe("agentic.ui.ChatWidget foreign cached windows (child)", function()
                 false,
                 { split = "right", win = foreign_chat }
             )
-            vim.api.nvim_open_win(
+            local bystander = vim.api.nvim_open_win(
                 vim.api.nvim_create_buf(false, true),
                 false,
                 { split = "right", win = foreign_code }
@@ -1266,13 +1266,31 @@ describe("agentic.ui.ChatWidget foreign cached windows (child)", function()
             widget.win_nrs.code = foreign_code
             widget:show({ focus_prompt = false })
 
-            return { widget.win_nrs.chat, widget.win_nrs.code }
+            return {
+                widget.win_nrs.chat,
+                widget.win_nrs.code,
+                foreign_chat,
+                foreign_code,
+                bystander,
+                owner_tab,
+            }
         ]])
 
             child.flush()
 
             assert.is_true(child.api.nvim_win_is_valid(replacement_windows[1]))
             assert.is_true(child.api.nvim_win_is_valid(replacement_windows[2]))
+            assert.is_not.equal(replacement_windows[3], replacement_windows[1])
+            assert.is_not.equal(replacement_windows[4], replacement_windows[2])
+            assert.is_true(child.api.nvim_win_is_valid(replacement_windows[5]))
+            assert.equal(
+                replacement_windows[6],
+                child.api.nvim_win_get_tabpage(replacement_windows[1])
+            )
+            assert.equal(
+                replacement_windows[6],
+                child.api.nvim_win_get_tabpage(replacement_windows[2])
+            )
         end
     )
 end)
@@ -1285,6 +1303,8 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
     local base_tabs
     local base_bufs
     local created_widgets
+    local mode_stub
+    local cmd_stub
 
     --- @return agentic.ui.ChatWidget widget
     local function create_widget()
@@ -1306,6 +1326,8 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
             base_bufs[bufnr] = true
         end
         created_widgets = {}
+        mode_stub = nil
+        cmd_stub = nil
         saved_move_cursor = Config.settings.move_cursor_to_chat_on_submit
         Config.settings.move_cursor_to_chat_on_submit = true
         scheduled = nil
@@ -1316,6 +1338,14 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
     end)
 
     after_each(function()
+        if cmd_stub then
+            cmd_stub:revert()
+            cmd_stub = nil
+        end
+        if mode_stub then
+            mode_stub:revert()
+            mode_stub = nil
+        end
         for _, widget in ipairs(created_widgets) do
             pcall(function()
                 widget:destroy()
@@ -1389,7 +1419,11 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
             hide = true,
             focusable = false,
         })
-        local widget = { win_nrs = { chat = hidden } }
+        local widget = {
+            tab_page_id = vim.api.nvim_get_current_tabpage(),
+            win_nrs = { chat = hidden },
+        }
+        assert.is_true(BufHelpers.is_win_usable(hidden))
 
         ChatWidget.move_cursor_to(widget, hidden)
 
@@ -1485,13 +1519,15 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
 
     it("does not restore insert mode when the prior editor is gone", function()
         vim.cmd("tabnew")
-        local mode_stub = spy.stub(vim.fn, "mode")
+        mode_stub = spy.stub(vim.fn, "mode")
         mode_stub:returns("i")
-        local startinsert_stub = spy.stub(vim.cmd, "startinsert")
         local old_win = vim.api.nvim_get_current_win()
         vim.cmd("split")
         local spare = vim.api.nvim_get_current_win()
+        local spare_bufnr = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_win_set_buf(spare, spare_bufnr)
         vim.api.nvim_set_current_win(old_win)
+        cmd_stub = spy.stub(vim, "cmd")
         local widget = {
             tab_page_id = vim.api.nvim_get_current_tabpage(),
             current_position = "right",
@@ -1510,8 +1546,11 @@ describe("agentic.ui.ChatWidget deferred window guards", function()
         vim.api.nvim_set_current_win(spare)
         rotate_callback()
 
-        assert.spy(startinsert_stub).was.called(0)
+        local cmd_call_count = cmd_stub.call_count
+        cmd_stub:revert()
+        cmd_stub = nil
         mode_stub:revert()
-        startinsert_stub:revert()
+        mode_stub = nil
+        assert.equal(0, cmd_call_count)
     end)
 end)

--- a/lua/agentic/ui/diff_coordinator.lua
+++ b/lua/agentic/ui/diff_coordinator.lua
@@ -2,14 +2,17 @@ local Config = require("agentic.config")
 local DiffPreview = require("agentic.ui.diff_preview")
 local Logger = require("agentic.utils.logger")
 
---- Coordinates inline edit-diff previews for a session: reads the edit
---- tool-call tracker, resolves a target editor window from the widget, and
---- dispatches to DiffPreview. Owns tool-call introspection + window placement
---- so SessionManager only forwards a tool_call_id.
+--- @class agentic.ui.DiffState
+--- @field preview_bufnr? integer
+--- @field preview_winid? integer
+--- @field split_state? table<string, agentic.ui.DiffSplitView.State>
+
+--- Coordinates edit-diff previews for one session.
 --- @class agentic.ui.DiffCoordinator
 --- @field _widget agentic.ui.ChatWidget
 --- @field _message_writer agentic.ui.MessageWriter
 --- @field _get_tab_page_id fun(): integer|nil
+--- @field diff_state agentic.ui.DiffState
 local DiffCoordinator = {}
 DiffCoordinator.__index = DiffCoordinator
 
@@ -18,11 +21,16 @@ DiffCoordinator.__index = DiffCoordinator
 --- @param get_tab_page_id fun(): integer|nil Resolves the session's tabpage live
 --- @return agentic.ui.DiffCoordinator
 function DiffCoordinator:new(widget, message_writer, get_tab_page_id)
+    --- @type agentic.ui.DiffState
+    local diff_state = {}
     local instance = setmetatable({
         _widget = widget,
         _message_writer = message_writer,
         _get_tab_page_id = get_tab_page_id,
+        diff_state = diff_state,
     }, self)
+
+    DiffPreview.setup_diff_navigation_keymaps(widget.buf_nrs, diff_state)
     return instance
 end
 
@@ -47,11 +55,12 @@ end
 
 --- @param tool_call_id string
 function DiffCoordinator:show(tool_call_id)
+    local tabpage = self._get_tab_page_id()
     -- Only show diff if enabled by user config,
     -- and cursor is in the same tabpage as this session to avoid disruption
     if
         not Config.diff_preview.enabled
-        or vim.api.nvim_get_current_tabpage() ~= self._get_tab_page_id()
+        or vim.api.nvim_get_current_tabpage() ~= tabpage
     then
         return
     end
@@ -64,6 +73,8 @@ function DiffCoordinator:show(tool_call_id)
     DiffPreview.show_diff({
         file_path = tracker.file_path,
         diff = tracker.diff,
+        state = self.diff_state,
+        tabpage = tabpage,
         get_winid = function(bufnr)
             local winid = self._widget:find_first_non_widget_window()
             if not winid then
@@ -91,7 +102,7 @@ function DiffCoordinator:clear(tool_call_id, is_rejection)
         return
     end
 
-    DiffPreview.clear_diff(tracker.file_path, is_rejection)
+    DiffPreview.clear_diff(tracker.file_path, is_rejection, self.diff_state)
 end
 
 return DiffCoordinator

--- a/lua/agentic/ui/diff_coordinator.test.lua
+++ b/lua/agentic/ui/diff_coordinator.test.lua
@@ -38,6 +38,7 @@ describe("agentic.ui.DiffCoordinator", function()
     --- @param blocks table<string, any>
     local function make_coordinator(blocks)
         local widget = {
+            buf_nrs = {},
             find_first_non_widget_window = function()
                 return 1
             end,
@@ -75,6 +76,20 @@ describe("agentic.ui.DiffCoordinator", function()
             local opts = show_diff_stub.calls[1][1]
             assert.equal("/tmp/a.lua", opts.file_path)
             assert.equal("function", type(opts.get_winid))
+        end)
+
+        it("owns state independently per coordinator", function()
+            local first = make_coordinator({ t1 = edit_block() })
+            local second = make_coordinator({ t1 = edit_block() })
+
+            first:show("t1")
+            second:show("t1")
+
+            local first_opts = show_diff_stub.calls[1][1]
+            local second_opts = show_diff_stub.calls[2][1]
+            assert.equal("table", type(first_opts.state))
+            assert.is_true(first_opts.state ~= second_opts.state)
+            assert.equal(OWNED_TAB, first_opts.tabpage)
         end)
 
         it("does nothing when diff_preview is disabled", function()
@@ -136,6 +151,19 @@ describe("agentic.ui.DiffCoordinator", function()
             assert.spy(clear_diff_stub).was.called(1)
             assert.equal("/tmp/a.lua", clear_diff_stub.calls[1][1])
             assert.equal(true, clear_diff_stub.calls[1][2])
+            assert.equal(c.diff_state, clear_diff_stub.calls[1][3])
+        end)
+
+        it("clears only its own state", function()
+            local first = make_coordinator({ t1 = edit_block() })
+            local second = make_coordinator({ t1 = edit_block() })
+            first.diff_state.preview_bufnr = 11
+            second.diff_state.preview_bufnr = 22
+
+            first:clear("t1")
+
+            assert.equal(first.diff_state, clear_diff_stub.calls[1][3])
+            assert.equal(22, second.diff_state.preview_bufnr)
         end)
 
         it("does nothing for an invalid tracker", function()

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -675,7 +675,15 @@ function M._show_new_file_diff(opts, new_lines)
     local winid = opts.get_winid(bufnr)
     if not winid then
         if not owned_refresh then
-            pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            local deleted =
+                pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            if deleted then
+                HunkNavigation.clear_state(bufnr)
+                if opts.state and opts.state.preview_bufnr == bufnr then
+                    opts.state.preview_bufnr = nil
+                    opts.state.preview_winid = nil
+                end
+            end
         end
         return
     end

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -27,6 +27,66 @@ local function state_identity(state)
     return state and tostring(state):gsub("^table: ", "") or LEGACY_OWNER
 end
 
+--- @param bufnr integer
+local function delete_buffer_without_closing_windows(bufnr)
+    -- EVERY window, not just the painted one: `nvim_buf_delete(force)` closes
+    -- each window still holding the buffer.
+    for _, buf_winid in ipairs(vim.fn.win_findbuf(bufnr)) do
+        if BufHelpers.is_win_usable(buf_winid) then
+            local ok, alt = pcall(vim.api.nvim_win_call, buf_winid, function()
+                return vim.fn.bufnr("#")
+            end)
+            local target_buf = (ok and alt ~= -1 and alt ~= bufnr) and alt
+                or vim.api.nvim_create_buf(true, true)
+            pcall(vim.api.nvim_win_set_buf, buf_winid, target_buf)
+        end
+    end
+    pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+end
+
+--- @param state agentic.ui.DiffState|nil
+--- @param next_bufnr integer
+local function retire_previous_inline_preview(state, next_bufnr)
+    if not state then
+        return
+    end
+
+    local previous_bufnr = state.preview_bufnr
+    if not previous_bufnr or previous_bufnr == next_bufnr then
+        return
+    end
+
+    if not vim.api.nvim_buf_is_valid(previous_bufnr) then
+        state.preview_bufnr = nil
+        state.preview_winid = nil
+        return
+    end
+
+    if vim.b[previous_bufnr]._agentic_inline_diff_owner ~= owner_for(state) then
+        state.preview_bufnr = nil
+        state.preview_winid = nil
+        return
+    end
+
+    local is_suggestion = vim.b[previous_bufnr]._agentic_suggestion_for ~= nil
+    HunkNavigation.restore_keymaps(previous_bufnr, state)
+    pcall(vim.api.nvim_buf_clear_namespace, previous_bufnr, NS_DIFF, 0, -1)
+    vim.b[previous_bufnr]._agentic_inline_diff_owner = nil
+
+    if is_suggestion then
+        delete_buffer_without_closing_windows(previous_bufnr)
+    else
+        local prev_modifiable = vim.b[previous_bufnr]._agentic_prev_modifiable
+        if prev_modifiable ~= nil then
+            vim.bo[previous_bufnr].modifiable = prev_modifiable
+            vim.b[previous_bufnr]._agentic_prev_modifiable = nil
+        end
+    end
+
+    state.preview_bufnr = nil
+    state.preview_winid = nil
+end
+
 --- @param file_path string
 --- @param state agentic.ui.DiffState|nil
 --- @return integer bufnr
@@ -313,6 +373,7 @@ function M.show_diff(opts)
         return
     end
 
+    retire_previous_inline_preview(opts.state, bufnr)
     M.clear_diff(bufnr, nil, opts.state)
 
     for _, block in ipairs(diff_blocks) do
@@ -469,30 +530,7 @@ function M.clear_diff(buf, is_rejection, state)
         local stat = file_path ~= "" and vim.uv.fs_stat(file_path)
 
         if not stat then
-            -- EVERY window, not just the painted one: `nvim_buf_delete(force)`
-            -- closes each window still holding the buffer. `win_findbuf` is
-            -- tab-agnostic on purpose — that window may be in another tabpage.
-            for _, buf_winid in ipairs(vim.fn.win_findbuf(bufnr)) do
-                -- An earlier swap fires autocmds that can close a later window
-                -- in this snapshot; a dead window needs no swap.
-                if BufHelpers.is_win_usable(buf_winid) then
-                    -- The TARGET window's alternate buffer, not the current one's.
-                    local ok, alt = pcall(
-                        vim.api.nvim_win_call,
-                        buf_winid,
-                        function()
-                            return vim.fn.bufnr("#")
-                        end
-                    )
-
-                    local target_buf = (ok and alt ~= -1 and alt ~= bufnr)
-                            and alt
-                        or vim.api.nvim_create_buf(true, true)
-
-                    pcall(vim.api.nvim_win_set_buf, buf_winid, target_buf)
-                end
-            end
-            pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            delete_buffer_without_closing_windows(bufnr)
         end
     end
 end
@@ -634,6 +672,7 @@ function M._show_new_file_diff(opts, new_lines)
         pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
         return
     end
+    retire_previous_inline_preview(opts.state, bufnr)
     if opts.state then
         opts.state.preview_bufnr = bufnr
         opts.state.preview_winid = winid

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -643,6 +643,8 @@ function M._show_new_file_diff(opts, new_lines)
     end
     local owned_refresh = opts.state ~= nil
         and opts.state.preview_bufnr == bufnr
+        and vim.b[bufnr]._agentic_inline_diff_owner == owner_for(opts.state)
+        and vim.b[bufnr]._agentic_suggestion_for == opts.file_path
 
     -- Set buffer properties
     vim.bo[bufnr].buflisted = false

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -425,16 +425,18 @@ function M.clear_diff(buf, is_rejection, state)
         return
     end
 
+    local is_suggestion = vim.b[bufnr]._agentic_suggestion_for ~= nil
+
     HunkNavigation.restore_keymaps(bufnr, state)
     if state and state.preview_bufnr == bufnr then
         state.preview_bufnr = nil
         state.preview_winid = nil
     end
-    vim.b[bufnr]._agentic_inline_diff_owner = nil
+    if not is_suggestion or is_rejection then
+        vim.b[bufnr]._agentic_inline_diff_owner = nil
+    end
 
     pcall(vim.api.nvim_buf_clear_namespace, bufnr, NS_DIFF, 0, -1)
-
-    local is_suggestion = vim.b[bufnr]._agentic_suggestion_for ~= nil
 
     -- Restore modifiable state if it was saved
     -- (skip for suggestion buffers on acceptance —

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -641,6 +641,8 @@ function M._show_new_file_diff(opts, new_lines)
         bufnr = vim.api.nvim_create_buf(false, true)
         vim.api.nvim_buf_set_name(bufnr, suggestion_name)
     end
+    local owned_refresh = opts.state ~= nil
+        and opts.state.preview_bufnr == bufnr
 
     -- Set buffer properties
     vim.bo[bufnr].buflisted = false
@@ -670,7 +672,7 @@ function M._show_new_file_diff(opts, new_lines)
     -- Display in window; delete orphaned buffer if no window available
     local winid = opts.get_winid(bufnr)
     if not winid then
-        if created then
+        if not owned_refresh then
             pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
         end
         return

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -13,33 +13,28 @@ local ToolCallDiff = require("agentic.ui.tool_call_diff")
 local M = {}
 
 local NS_DIFF = HunkNavigation.NS_DIFF
+local LEGACY_OWNER = "legacy"
 
---- Get diff preview buffer from tabpage
---- @param tabpage number Tabpage ID
+--- @param state agentic.ui.DiffState|nil
+--- @return string owner
+local function owner_for(state)
+    return state and tostring(state) or LEGACY_OWNER
+end
+
+--- @param state agentic.ui.DiffState|nil
+--- @return string identity
+local function state_identity(state)
+    return state and tostring(state):gsub("^table: ", "") or LEGACY_OWNER
+end
+
+--- @param state agentic.ui.DiffState
 --- @return number|nil bufnr
-local function get_diff_bufnr(tabpage)
-    return vim.t[tabpage]._agentic_diff_preview_bufnr
-end
-
---- Set diff preview buffer for tabpage
---- @param tabpage number Tabpage ID
---- @param bufnr number|nil Buffer number (nil to clear)
-local function set_diff_bufnr(tabpage, bufnr)
-    vim.t[tabpage]._agentic_diff_preview_bufnr = bufnr
-end
-
---- Get the buffer number with active diff preview for the current or specified tabpage
---- @param tabpage number|nil Tabpage ID (defaults to current tabpage)
---- @return number|nil bufnr Buffer number with active diff, or nil if none
-function M.get_active_diff_buffer(tabpage)
-    local tab = tabpage or vim.api.nvim_get_current_tabpage()
-
-    local split_state = DiffSplitView.get_split_state(tab)
+function M.get_active_diff_buffer(state)
+    local split_state = DiffSplitView.find_split_state(state)
     if split_state then
         return split_state.original_bufnr
     end
-
-    return get_diff_bufnr(tab)
+    return state.preview_bufnr
 end
 
 --- Builds a highlight map for all lines parsed as a block
@@ -223,6 +218,8 @@ end
 --- @field file_path string
 --- @field diff agentic.ui.MessageWriter.ToolCallDiff
 --- @field get_winid fun(bufnr: number): number|nil Called when buffer is not already visible, should return a winid
+--- @field state? agentic.ui.DiffState
+--- @field tabpage? integer
 
 --- @param opts agentic.ui.DiffPreview.ShowOpts
 function M.show_diff(opts)
@@ -233,7 +230,7 @@ function M.show_diff(opts)
         return
     end
 
-    if Config.diff_preview.layout == "split" then
+    if Config.diff_preview.layout == "split" and opts.state then
         local success = DiffSplitView.show_split_diff(opts)
         if success then
             return
@@ -285,13 +282,19 @@ function M.show_diff(opts)
     end
 
     -- Check if buffer is already visible, otherwise request a window
-    local winid = vim.fn.bufwinid(bufnr)
-    local target_winid = winid ~= -1 and winid or opts.get_winid(bufnr)
+    local owner = owner_for(opts.state)
+    local inline_owner = vim.b[bufnr]._agentic_inline_diff_owner
+    if inline_owner and inline_owner ~= owner then
+        return
+    end
+
+    local winid = BufHelpers.find_visible_win(bufnr, nil, opts.tabpage)
+    local target_winid = winid or opts.get_winid(bufnr)
     if not target_winid then
         return
     end
 
-    M.clear_diff(bufnr)
+    M.clear_diff(bufnr, nil, opts.state)
 
     for _, block in ipairs(diff_blocks) do
         local old_count = #block.old_lines
@@ -353,20 +356,20 @@ function M.show_diff(opts)
 
     -- Scroll target window to first diff block without moving cursor
     if #diff_blocks > 0 then
-        local ok, tabpage = pcall(vim.api.nvim_win_get_tabpage, target_winid)
-        if not ok then
-            return
+        vim.b[bufnr]._agentic_inline_diff_owner = owner
+        if opts.state then
+            opts.state.preview_bufnr = bufnr
+            opts.state.preview_winid = target_winid
         end
-        set_diff_bufnr(tabpage, bufnr)
 
         -- Make buffer read-only to prevent edits while diff is visible
         vim.b[bufnr]._agentic_prev_modifiable = vim.bo[bufnr].modifiable
         vim.bo[bufnr].modifiable = false
 
-        HunkNavigation.setup_keymaps(bufnr)
+        HunkNavigation.setup_keymaps(bufnr, opts.state)
 
         vim.schedule(function()
-            HunkNavigation.navigate_next(bufnr)
+            HunkNavigation.navigate_next(bufnr, opts.state)
         end)
     end
 end
@@ -374,13 +377,41 @@ end
 --- Clears the diff highlights from the given buffer
 --- @param buf number|string Buffer number or file path
 --- @param is_rejection boolean|nil If true and file doesn't exist, cleanup buffer
-function M.clear_diff(buf, is_rejection)
+--- @param state agentic.ui.DiffState|nil
+function M.clear_diff(buf, is_rejection, state)
+    if state then
+        local split_file_path = type(buf) == "string" and buf or nil
+        if not split_file_path and state.split_state then
+            for _, split_state in pairs(state.split_state) do
+                if
+                    split_state.original_bufnr == buf
+                    or split_state.new_bufnr == buf
+                then
+                    split_file_path = split_state.file_path
+                    break
+                end
+            end
+        end
+        if
+            split_file_path
+            and DiffSplitView.clear_split_diff(state, split_file_path)
+        then
+            return
+        end
+    end
     local bufnr = type(buf) == "string" and vim.fn.bufnr(buf) or buf --[[@as integer]]
 
     -- Fallback: check for suggestion buffer by smart path
     if bufnr == -1 and type(buf) == "string" then
         local smart = FileSystem.to_smart_path(buf)
-        local smart_bufnr = vim.fn.bufnr(smart)
+        local suggestion_name = state
+                and string.format(
+                    "%s (suggestion %s)",
+                    smart,
+                    state_identity(state)
+                )
+            or smart
+        local smart_bufnr = vim.fn.bufnr(suggestion_name)
         if smart_bufnr ~= -1 and vim.b[smart_bufnr]._agentic_suggestion_for then
             bufnr = smart_bufnr
         end
@@ -390,19 +421,16 @@ function M.clear_diff(buf, is_rejection)
         return
     end
 
-    local winid = vim.fn.bufwinid(bufnr)
-    if winid ~= -1 then
-        local ok, tabpage = pcall(vim.api.nvim_win_get_tabpage, winid)
-        if ok then
-            if DiffSplitView.get_split_state(tabpage) then
-                DiffSplitView.clear_split_diff(tabpage)
-                return
-            end
-            set_diff_bufnr(tabpage, nil)
-        end
+    if vim.b[bufnr]._agentic_inline_diff_owner ~= owner_for(state) then
+        return
     end
 
-    HunkNavigation.restore_keymaps(bufnr)
+    HunkNavigation.restore_keymaps(bufnr, state)
+    if state and state.preview_bufnr == bufnr then
+        state.preview_bufnr = nil
+        state.preview_winid = nil
+    end
+    vim.b[bufnr]._agentic_inline_diff_owner = nil
 
     pcall(vim.api.nvim_buf_clear_namespace, bufnr, NS_DIFF, 0, -1)
 
@@ -510,28 +538,29 @@ end
 --- Setup hunk navigation keymaps for widget buffers
 --- Allows navigating hunks in the active diff buffer from widget buffers
 --- @param buf_nrs table<string, number>
-function M.setup_diff_navigation_keymaps(buf_nrs)
+--- @param state agentic.ui.DiffState
+function M.setup_diff_navigation_keymaps(buf_nrs, state)
     local diff_keymaps = Config.keymaps.diff_preview
 
     for _, bufnr in pairs(buf_nrs) do
         BufHelpers.keymap_set(bufnr, "n", diff_keymaps.next_hunk, function()
-            local diff_bufnr = M.get_active_diff_buffer()
+            local diff_bufnr = M.get_active_diff_buffer(state)
             if not diff_bufnr then
                 Logger.notify("No active diff preview", vim.log.levels.INFO)
                 return
             end
-            HunkNavigation.navigate_next(diff_bufnr)
+            HunkNavigation.navigate_next(diff_bufnr, state)
         end, {
             desc = "Go to next hunk - " .. HunkNavigation.KEYMAP_DESC_SUFFIX,
         })
 
         BufHelpers.keymap_set(bufnr, "n", diff_keymaps.prev_hunk, function()
-            local diff_bufnr = M.get_active_diff_buffer()
+            local diff_bufnr = M.get_active_diff_buffer(state)
             if not diff_bufnr then
                 Logger.notify("No active diff preview", vim.log.levels.INFO)
                 return
             end
-            HunkNavigation.navigate_prev(diff_bufnr)
+            HunkNavigation.navigate_prev(diff_bufnr, state)
         end, {
             desc = "Go to previous hunk - "
                 .. HunkNavigation.KEYMAP_DESC_SUFFIX,
@@ -544,7 +573,14 @@ end
 --- @param opts agentic.ui.DiffPreview.ShowOpts
 --- @param new_lines string[]
 function M._show_new_file_diff(opts, new_lines)
-    local suggestion_name = FileSystem.to_smart_path(opts.file_path)
+    local smart_path = FileSystem.to_smart_path(opts.file_path)
+    local suggestion_name = opts.state
+            and string.format(
+                "%s (suggestion %s)",
+                smart_path,
+                state_identity(opts.state)
+            )
+        or smart_path
     local bufnr = vim.fn.bufnr(suggestion_name)
     if bufnr == -1 then
         bufnr = vim.api.nvim_create_buf(false, true)
@@ -554,6 +590,7 @@ function M._show_new_file_diff(opts, new_lines)
     -- Set buffer properties
     vim.bo[bufnr].buflisted = false
     vim.b[bufnr]._agentic_suggestion_for = opts.file_path
+    vim.b[bufnr]._agentic_inline_diff_owner = owner_for(opts.state)
 
     -- Set filetype from real path
     local ft = vim.filetype.match({ filename = opts.file_path })
@@ -579,18 +616,35 @@ function M._show_new_file_diff(opts, new_lines)
     local winid = opts.get_winid(bufnr)
     if not winid then
         pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+        return
     end
+    if opts.state then
+        opts.state.preview_bufnr = bufnr
+        opts.state.preview_winid = winid
+    end
+    HunkNavigation.setup_keymaps(bufnr, opts.state)
+    vim.schedule(function()
+        HunkNavigation.navigate_next(bufnr, opts.state)
+    end)
 end
 
 --- Replace suggestion buffer with the real file in the same window.
 --- Called when a file-mutating tool call completes.
 --- @param file_path string|nil
-function M.cleanup_suggestion_buffer(file_path)
+--- @param state agentic.ui.DiffState|nil
+function M.cleanup_suggestion_buffer(file_path, state)
     if not file_path then
         return
     end
 
-    local suggestion_name = FileSystem.to_smart_path(file_path)
+    local smart_path = FileSystem.to_smart_path(file_path)
+    local suggestion_name = state
+            and string.format(
+                "%s (suggestion %s)",
+                smart_path,
+                state_identity(state)
+            )
+        or smart_path
     local suggestion_bufnr = vim.fn.bufnr(suggestion_name)
     if
         suggestion_bufnr == -1
@@ -599,12 +653,19 @@ function M.cleanup_suggestion_buffer(file_path)
         return
     end
 
-    local winid = vim.fn.bufwinid(suggestion_bufnr)
+    if
+        vim.b[suggestion_bufnr]._agentic_inline_diff_owner ~= owner_for(state)
+    then
+        return
+    end
+
+    local winid = state and state.preview_winid
+        or BufHelpers.find_visible_win(suggestion_bufnr)
 
     -- Must delete suggestion buffer before bufadd because Neovim path
     -- resolution can match the smart-path name to the absolute path.
     -- A temporary buffer keeps the window alive during the swap.
-    if winid ~= -1 then
+    if winid and BufHelpers.is_win_usable(winid) then
         local tmp_bufnr = vim.api.nvim_create_buf(false, true)
         pcall(vim.api.nvim_win_set_buf, winid, tmp_bufnr)
         pcall(vim.api.nvim_buf_delete, suggestion_bufnr, { force = true })
@@ -615,6 +676,11 @@ function M.cleanup_suggestion_buffer(file_path)
         pcall(vim.api.nvim_buf_delete, tmp_bufnr, { force = true })
     else
         pcall(vim.api.nvim_buf_delete, suggestion_bufnr, { force = true })
+    end
+
+    if state and state.preview_bufnr == suggestion_bufnr then
+        state.preview_bufnr = nil
+        state.preview_winid = nil
     end
 end
 

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -636,7 +636,8 @@ function M._show_new_file_diff(opts, new_lines)
             )
         or smart_path
     local bufnr = vim.fn.bufnr(suggestion_name)
-    if bufnr == -1 then
+    local created = bufnr == -1
+    if created then
         bufnr = vim.api.nvim_create_buf(false, true)
         vim.api.nvim_buf_set_name(bufnr, suggestion_name)
     end
@@ -669,7 +670,9 @@ function M._show_new_file_diff(opts, new_lines)
     -- Display in window; delete orphaned buffer if no window available
     local winid = opts.get_winid(bufnr)
     if not winid then
-        pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+        if created then
+            pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+        end
         return
     end
     retire_previous_inline_preview(opts.state, bufnr)

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -659,8 +659,8 @@ function M.cleanup_suggestion_buffer(file_path, state)
         return
     end
 
-    local winid = state and state.preview_winid
-        or BufHelpers.find_visible_win(suggestion_bufnr)
+    local preferred_winid = state and state.preview_winid or nil
+    local winid = BufHelpers.find_visible_win(suggestion_bufnr, preferred_winid)
 
     -- Must delete suggestion buffer before bufadd because Neovim path
     -- resolution can match the smart-path name to the absolute path.

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -27,6 +27,25 @@ local function state_identity(state)
     return state and tostring(state):gsub("^table: ", "") or LEGACY_OWNER
 end
 
+--- @param file_path string
+--- @param state agentic.ui.DiffState|nil
+--- @return integer bufnr
+local function find_suggestion_buffer(file_path, state)
+    local smart_path = FileSystem.to_smart_path(file_path)
+    local suggestion_name = state
+            and string.format(
+                "%s (suggestion %s)",
+                smart_path,
+                state_identity(state)
+            )
+        or smart_path
+    local bufnr = vim.fn.bufnr(suggestion_name)
+    if bufnr ~= -1 and vim.b[bufnr]._agentic_suggestion_for then
+        return bufnr
+    end
+    return -1
+end
+
 --- @param state agentic.ui.DiffState
 --- @return number|nil bufnr
 function M.get_active_diff_buffer(state)
@@ -399,21 +418,16 @@ function M.clear_diff(buf, is_rejection, state)
             return
         end
     end
-    local bufnr = type(buf) == "string" and vim.fn.bufnr(buf) or buf --[[@as integer]]
-
-    -- Fallback: check for suggestion buffer by smart path
-    if bufnr == -1 and type(buf) == "string" then
-        local smart = FileSystem.to_smart_path(buf)
-        local suggestion_name = state
-                and string.format(
-                    "%s (suggestion %s)",
-                    smart,
-                    state_identity(state)
-                )
-            or smart
-        local smart_bufnr = vim.fn.bufnr(suggestion_name)
-        if smart_bufnr ~= -1 and vim.b[smart_bufnr]._agentic_suggestion_for then
-            bufnr = smart_bufnr
+    local bufnr = buf --[[@as integer]]
+    if type(buf) == "string" then
+        local suggestion_bufnr = find_suggestion_buffer(buf, state)
+        if state and suggestion_bufnr ~= -1 then
+            bufnr = suggestion_bufnr
+        else
+            bufnr = vim.fn.bufnr(buf)
+            if bufnr == -1 then
+                bufnr = suggestion_bufnr
+            end
         end
     end
 

--- a/lua/agentic/ui/diff_preview.lua
+++ b/lua/agentic/ui/diff_preview.lua
@@ -37,7 +37,7 @@ local function delete_buffer_without_closing_windows(bufnr)
                 return vim.fn.bufnr("#")
             end)
             local target_buf = (ok and alt ~= -1 and alt ~= bufnr) and alt
-                or vim.api.nvim_create_buf(true, true)
+                or vim.api.nvim_create_buf(false, true)
             pcall(vim.api.nvim_win_set_buf, buf_winid, target_buf)
         end
     end

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -744,6 +744,38 @@ describe("diff_preview owner isolation", function()
         assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
     end)
 
+    it("deletes a wrong-owner suggestion when refresh cannot open", function()
+        local path = vim.fn.tempname() .. ".lua"
+        --- @type agentic.ui.DiffState
+        local state = {}
+
+        show_new(path, state, "first")
+        local bufnr = state.preview_bufnr
+        assert.is_not_nil(bufnr)
+        ---@cast bufnr integer
+        vim.b[bufnr]._agentic_inline_diff_owner = "foreign"
+
+        show_new(path, state, "second", false)
+
+        assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
+    end)
+
+    it("deletes a wrong-source suggestion when refresh cannot open", function()
+        local path = vim.fn.tempname() .. ".lua"
+        --- @type agentic.ui.DiffState
+        local state = {}
+
+        show_new(path, state, "first")
+        local bufnr = state.preview_bufnr
+        assert.is_not_nil(bufnr)
+        ---@cast bufnr integer
+        vim.b[bufnr]._agentic_suggestion_for = path .. ".foreign"
+
+        show_new(path, state, "second", false)
+
+        assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
+    end)
+
     it(
         "replaces a different new-file suggestion only after its target opens",
         function()

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -769,6 +769,34 @@ describe("diff_preview owner isolation", function()
         assert.equal(bufnr, state.preview_bufnr)
     end)
 
+    it(
+        "does not replace a window repurposed after showing a suggestion",
+        function()
+            local path = vim.fn.tempname() .. ".lua"
+            --- @type agentic.ui.DiffState
+            local state = {}
+            show_new(path, state, "content")
+            local suggestion_bufnr = state.preview_bufnr
+            local preview_winid = state.preview_winid
+            assert.is_not_nil(suggestion_bufnr)
+            assert.is_not_nil(preview_winid)
+            ---@cast suggestion_bufnr integer
+            ---@cast preview_winid integer
+            local replacement_bufnr = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_win_set_buf(preview_winid, replacement_bufnr)
+
+            DiffPreview.cleanup_suggestion_buffer(path, state)
+
+            assert.equal(
+                replacement_bufnr,
+                vim.api.nvim_win_get_buf(preview_winid)
+            )
+            assert.is_false(vim.api.nvim_buf_is_valid(suggestion_bufnr))
+            assert.is_nil(state.preview_bufnr)
+            assert.is_nil(state.preview_winid)
+        end
+    )
+
     it("restricts existing-buffer lookup to the explicit tabpage", function()
         local path = vim.fn.tempname() .. ".lua"
         local bufnr = vim.fn.bufadd(path)

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -708,6 +708,30 @@ describe("diff_preview owner isolation", function()
         )
     end)
 
+    it("preserves a same-owner suggestion when refresh cannot open", function()
+        local path = vim.fn.tempname() .. ".lua"
+        --- @type agentic.ui.DiffState
+        local state = {}
+
+        show_new(path, state, "first")
+        local bufnr = state.preview_bufnr
+        local winid = state.preview_winid
+        assert.is_not_nil(bufnr)
+        assert.is_not_nil(winid)
+        ---@cast bufnr integer
+
+        show_new(path, state, "second", false)
+
+        assert.is_true(vim.api.nvim_buf_is_valid(bufnr))
+        assert.equal(bufnr, state.preview_bufnr)
+        assert.equal(winid, state.preview_winid)
+        assert.equal(tostring(state), vim.b[bufnr]._agentic_inline_diff_owner)
+        assert.equal(
+            "second",
+            vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+        )
+    end)
+
     it(
         "replaces a different new-file suggestion only after its target opens",
         function()

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -4,6 +4,7 @@ local DiffPreview = require("agentic.ui.diff_preview")
 local Config = require("agentic.config")
 local FileSystem = require("agentic.utils.file_system")
 local Logger = require("agentic.utils.logger")
+local DiffSplitView = require("agentic.ui.diff_split_view")
 
 --- Closes every tabpage absent from the baseline set. Counting tabpages and
 --- closing the *current* one can shut a baseline tab while a created one lives.
@@ -25,6 +26,7 @@ describe("diff_preview", function()
         local get_winid_spy
         local notify_spy
         local fs_stat_stub
+        local schedule_stub
         local orig_layout
 
         --- @type integer|nil
@@ -42,6 +44,7 @@ describe("diff_preview", function()
             notify_spy = spy_module.on(Logger, "notify")
             fs_stat_stub = spy_module.stub(vim.uv, "fs_stat")
             fs_stat_stub:returns(nil)
+            schedule_stub = spy_module.stub(vim, "schedule")
             orig_layout = Config.diff_preview.layout
             Config.diff_preview.layout = "inline"
         end)
@@ -51,6 +54,7 @@ describe("diff_preview", function()
             get_winid_spy:revert()
             notify_spy:revert()
             fs_stat_stub:revert()
+            schedule_stub:revert()
             Config.diff_preview.layout = orig_layout
 
             -- Clean up any buffers created during test
@@ -197,6 +201,30 @@ describe("diff_preview", function()
                 assert.spy(notify_spy).was.called(0)
             end
         )
+
+        it("skips split layout for the reserved nil-state owner", function()
+            Config.diff_preview.layout = "split"
+            local split_stub = spy_module.stub(DiffSplitView, "show_split_diff")
+            local path = "/tmp/test_nil_state_split.lua"
+
+            DiffPreview.show_diff({
+                file_path = path,
+                diff = { old = {}, new = { "return true" } },
+                get_winid = get_winid_spy --[[@as function]],
+            })
+
+            local split_calls = split_stub.call_count
+            local bufnr = vim.fn.bufnr(path)
+            local found_navigation = false
+            for _, keymap in ipairs(vim.api.nvim_buf_get_keymap(bufnr, "n")) do
+                if keymap.lhs == Config.keymaps.diff_preview.next_hunk then
+                    found_navigation = true
+                end
+            end
+            split_stub:revert()
+            assert.equal(0, split_calls)
+            assert.is_true(found_navigation)
+        end)
     end)
 
     describe("clear_diff", function()
@@ -256,8 +284,14 @@ describe("diff_preview", function()
             return winid
         end
 
+        --- @param bufnr integer
+        local function mark_legacy_owner(bufnr)
+            vim.b[bufnr]._agentic_inline_diff_owner = "legacy"
+        end
+
         it("clears the diff without any error", function()
             local bufnr = vim.api.nvim_create_buf(false, true)
+            mark_legacy_owner(bufnr)
 
             assert.has_no_errors(function()
                 DiffPreview.clear_diff(bufnr)
@@ -279,6 +313,7 @@ describe("diff_preview", function()
                 assert.equal(current_bufnr, new_bufnr)
 
                 vim.cmd("file tests/my_new_test.lua")
+                mark_legacy_owner(new_bufnr)
 
                 DiffPreview.clear_diff(new_bufnr, true)
 
@@ -301,6 +336,7 @@ describe("diff_preview", function()
 
                 -- Simulate what show_diff does: save state and set read-only
                 vim.b[bufnr]._agentic_prev_modifiable = true
+                mark_legacy_owner(bufnr)
                 vim.bo[bufnr].modifiable = false
 
                 assert.is_false(vim.bo[bufnr].modifiable)
@@ -321,6 +357,7 @@ describe("diff_preview", function()
 
                     -- Simulate show_diff on already non-modifiable buffer
                     vim.b[bufnr]._agentic_prev_modifiable = false
+                    mark_legacy_owner(bufnr)
                     vim.bo[bufnr].modifiable = false
 
                     DiffPreview.clear_diff(bufnr)
@@ -337,6 +374,7 @@ describe("diff_preview", function()
             local bufnr = vim.api.nvim_create_buf(false, true)
             vim.api.nvim_buf_set_name(bufnr, "/tmp/new.lua")
             vim.b[bufnr]._agentic_suggestion_for = "/tmp/new.lua"
+            mark_legacy_owner(bufnr)
 
             -- Write content
             vim.api.nvim_buf_set_lines(
@@ -382,6 +420,7 @@ describe("diff_preview", function()
             local bufnr = vim.api.nvim_create_buf(false, true)
             vim.api.nvim_buf_set_name(bufnr, "/tmp/rejected.lua")
             vim.b[bufnr]._agentic_suggestion_for = "/tmp/rejected.lua"
+            mark_legacy_owner(bufnr)
             vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "content" })
 
             -- Display suggestion buffer in current window
@@ -404,6 +443,7 @@ describe("diff_preview", function()
 
         it("keeps the user's other window open on rejection", function()
             local bufnr = new_named_buf("/tmp/rejected_two_windows.lua")
+            mark_legacy_owner(bufnr)
             local first_alt = new_named_buf("/tmp/first_alternate.lua")
             local second_alt = new_named_buf("/tmp/second_alternate.lua")
 
@@ -427,6 +467,7 @@ describe("diff_preview", function()
 
         it("finishes the rejection when a window dies mid-loop", function()
             local bufnr = new_named_buf("/tmp/rejected_dying_window.lua")
+            mark_legacy_owner(bufnr)
             local alt = new_named_buf("/tmp/dying_alternate.lua")
 
             local first_win = vim.api.nvim_get_current_win()
@@ -462,6 +503,7 @@ describe("diff_preview", function()
 
         it("keeps a window on the rejected file in another tabpage", function()
             local bufnr = new_named_buf("/tmp/rejected_other_tab.lua")
+            mark_legacy_owner(bufnr)
 
             local first_win = vim.api.nvim_get_current_win()
             vim.api.nvim_win_set_buf(first_win, bufnr)
@@ -485,6 +527,7 @@ describe("diff_preview", function()
             local bufnr = vim.fn.bufadd(file_path)
             created_bufs[#created_bufs + 1] = bufnr
             vim.fn.bufload(bufnr)
+            mark_legacy_owner(bufnr)
 
             local winid = vim.api.nvim_get_current_win()
             vim.api.nvim_win_set_buf(winid, bufnr)
@@ -496,5 +539,266 @@ describe("diff_preview", function()
 
             vim.fn.delete(file_path)
         end)
+    end)
+end)
+
+describe("diff_preview owner isolation", function()
+    local read_stub
+    local fs_stat_stub
+    local schedule_stub
+    local saved_layout
+    local base_tabs
+    local base_bufs
+
+    before_each(function()
+        base_tabs = {}
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            base_tabs[tabpage] = true
+        end
+        base_bufs = {}
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            base_bufs[bufnr] = true
+        end
+        saved_layout = Config.diff_preview.layout
+        Config.diff_preview.layout = "inline"
+        read_stub = spy_module.stub(FileSystem, "read_from_buffer_or_disk")
+        read_stub:invokes(function()
+            return { "local x = 1", "" }, nil
+        end)
+        fs_stat_stub = spy_module.stub(vim.uv, "fs_stat")
+        fs_stat_stub:returns(nil)
+        schedule_stub = spy_module.stub(vim, "schedule")
+    end)
+
+    after_each(function()
+        read_stub:revert()
+        fs_stat_stub:revert()
+        schedule_stub:revert()
+        Config.diff_preview.layout = saved_layout
+        close_extra_tabs(base_tabs)
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            if not base_bufs[bufnr] and vim.api.nvim_buf_is_valid(bufnr) then
+                pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            end
+        end
+    end)
+
+    --- @param path string
+    --- @param state agentic.ui.DiffState|nil
+    --- @param line string
+    local function show_new(path, state, line)
+        DiffPreview.show_diff({
+            file_path = path,
+            diff = { old = {}, new = { line } },
+            state = state,
+            get_winid = function(bufnr)
+                local winid = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(winid, bufnr)
+                return winid
+            end,
+        })
+    end
+
+    --- @param path string
+    --- @param state agentic.ui.DiffState
+    --- @param line string
+    --- @param tabpage integer|nil
+    --- @return integer bufnr
+    local function show_existing(path, state, line, tabpage)
+        fs_stat_stub:returns({ type = "file" })
+        local bufnr = vim.fn.bufadd(path)
+        vim.fn.bufload(bufnr)
+        if not vim.b[bufnr]._agentic_inline_diff_owner then
+            vim.bo[bufnr].modifiable = true
+            vim.api.nvim_buf_set_lines(
+                bufnr,
+                0,
+                -1,
+                false,
+                { "local x = 1", "" }
+            )
+        end
+        DiffPreview.show_diff({
+            file_path = path,
+            diff = { old = { "local x = 1" }, new = { line } },
+            state = state,
+            tabpage = tabpage,
+            get_winid = function(target)
+                local winid = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(winid, target)
+                return winid
+            end,
+        })
+        return bufnr
+    end
+
+    it(
+        "gives same-path new-file suggestions distinct owner identities",
+        function()
+            local path = vim.fn.tempname() .. ".lua"
+            --- @type agentic.ui.DiffState
+            local first = {}
+            --- @type agentic.ui.DiffState
+            local second = {}
+
+            show_new(path, first, "first")
+            show_new(path, second, "second")
+
+            assert.is_not_nil(first.preview_bufnr)
+            assert.is_not_nil(second.preview_bufnr)
+            assert.is_not.equal(first.preview_bufnr, second.preview_bufnr)
+            assert.is_not.equal(
+                vim.api.nvim_buf_get_name(first.preview_bufnr),
+                vim.api.nvim_buf_get_name(second.preview_bufnr)
+            )
+        end
+    )
+
+    it("refreshes a new-file suggestion for the same owner", function()
+        local path = vim.fn.tempname() .. ".lua"
+        --- @type agentic.ui.DiffState
+        local state = {}
+
+        show_new(path, state, "first")
+        local bufnr = state.preview_bufnr
+        assert.is_not_nil(bufnr)
+        ---@cast bufnr integer
+        show_new(path, state, "second")
+
+        assert.equal(bufnr, state.preview_bufnr)
+        assert.equal(
+            "second",
+            vim.api.nvim_buf_get_lines(bufnr, 0, 1, false)[1]
+        )
+    end)
+
+    it("rejects a second owner for an existing-file inline preview", function()
+        local path = vim.fn.tempname() .. ".lua"
+        --- @type agentic.ui.DiffState
+        local first = {}
+        --- @type agentic.ui.DiffState
+        local second = {}
+        local bufnr = show_existing(path, first, "local x = 2")
+        local marks = vim.api.nvim_buf_get_extmarks(bufnr, -1, 0, -1, {})
+
+        show_existing(path, second, "local x = 3")
+
+        assert.equal(tostring(first), vim.b[bufnr]._agentic_inline_diff_owner)
+        assert.is_nil(second.preview_bufnr)
+        assert.same(marks, vim.api.nvim_buf_get_extmarks(bufnr, -1, 0, -1, {}))
+    end)
+
+    it(
+        "refreshes an existing-file inline preview for the same owner",
+        function()
+            local path = vim.fn.tempname() .. ".lua"
+            --- @type agentic.ui.DiffState
+            local state = {}
+            local bufnr = show_existing(path, state, "local x = 2")
+            local before = vim.api.nvim_buf_get_extmarks(
+                bufnr,
+                -1,
+                0,
+                -1,
+                { details = true }
+            )
+
+            show_existing(path, state, "local x = 3")
+
+            local after = vim.api.nvim_buf_get_extmarks(
+                bufnr,
+                -1,
+                0,
+                -1,
+                { details = true }
+            )
+            assert.equal(bufnr, state.preview_bufnr)
+            assert.equal(
+                tostring(state),
+                vim.b[bufnr]._agentic_inline_diff_owner
+            )
+            assert.is_not.same(before, after)
+        end
+    )
+
+    it("leaves another owner intact during out-of-order clear", function()
+        local path = vim.fn.tempname() .. ".lua"
+        --- @type agentic.ui.DiffState
+        local first = {}
+        --- @type agentic.ui.DiffState
+        local second = {}
+        local bufnr = show_existing(path, first, "local x = 2")
+
+        DiffPreview.clear_diff(bufnr, false, second)
+
+        assert.equal(bufnr, first.preview_bufnr)
+        assert.equal(tostring(first), vim.b[bufnr]._agentic_inline_diff_owner)
+        assert.is_false(vim.bo[bufnr].modifiable)
+    end)
+
+    it(
+        "nil-state clear leaves a state-owned inline preview unchanged",
+        function()
+            local path = vim.fn.tempname() .. ".lua"
+            --- @type agentic.ui.DiffState
+            local state = {}
+            local bufnr = show_existing(path, state, "local x = 2")
+
+            DiffPreview.clear_diff(bufnr, false, nil)
+
+            assert.equal(bufnr, state.preview_bufnr)
+            assert.equal(
+                tostring(state),
+                vim.b[bufnr]._agentic_inline_diff_owner
+            )
+        end
+    )
+
+    it("nil-state cleanup ignores state-qualified suggestions", function()
+        local path = vim.fn.tempname() .. ".lua"
+        --- @type agentic.ui.DiffState
+        local state = {}
+        show_new(path, state, "content")
+        local bufnr = state.preview_bufnr
+        assert.is_not_nil(bufnr)
+        ---@cast bufnr integer
+
+        DiffPreview.cleanup_suggestion_buffer(path, nil)
+
+        assert.is_true(vim.api.nvim_buf_is_valid(bufnr))
+        assert.equal(bufnr, state.preview_bufnr)
+    end)
+
+    it("restricts existing-buffer lookup to the explicit tabpage", function()
+        local path = vim.fn.tempname() .. ".lua"
+        local bufnr = vim.fn.bufadd(path)
+        vim.fn.bufload(bufnr)
+        vim.bo[bufnr].modifiable = true
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, { "local x = 1", "" })
+
+        vim.cmd("tabnew")
+        local owner_tab = vim.api.nvim_get_current_tabpage()
+        local owner_win = vim.api.nvim_get_current_win()
+        vim.api.nvim_win_set_buf(owner_win, bufnr)
+        vim.cmd("tabnew")
+        local foreign_win = vim.api.nvim_get_current_win()
+        vim.api.nvim_win_set_buf(foreign_win, bufnr)
+
+        --- @type agentic.ui.DiffState
+        local state = {}
+        show_existing(path, state, "local x = 2", owner_tab)
+
+        assert.equal(owner_win, state.preview_winid)
+        assert.is_not.equal(foreign_win, state.preview_winid)
+    end)
+
+    it("keeps unscoped visible-window lookup when tabpage is nil", function()
+        local path = vim.fn.tempname() .. ".lua"
+        --- @type agentic.ui.DiffState
+        local state = {}
+        local bufnr = show_existing(path, state, "local x = 2", nil)
+
+        assert.equal(bufnr, state.preview_bufnr)
+        assert.is_not_nil(state.preview_winid)
     end)
 end)

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -732,6 +732,18 @@ describe("diff_preview owner isolation", function()
         )
     end)
 
+    it("deletes a legacy suggestion when refresh cannot open", function()
+        local path = vim.fn.tempname() .. ".lua"
+
+        show_new(path, nil, "first")
+        local bufnr = vim.fn.bufnr(FileSystem.to_smart_path(path))
+        assert.is_not.equal(-1, bufnr)
+
+        show_new(path, nil, "second", false)
+
+        assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
+    end)
+
     it(
         "replaces a different new-file suggestion only after its target opens",
         function()

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -5,6 +5,7 @@ local Config = require("agentic.config")
 local FileSystem = require("agentic.utils.file_system")
 local Logger = require("agentic.utils.logger")
 local DiffSplitView = require("agentic.ui.diff_split_view")
+local HunkNavigation = require("agentic.ui.hunk_navigation")
 
 --- Closes every tabpage absent from the baseline set. Counting tabpages and
 --- closing the *current* one can shut a baseline tab while a created one lives.
@@ -577,6 +578,7 @@ describe("diff_preview owner isolation", function()
     local saved_layout
     local base_tabs
     local base_bufs
+    local clear_state_spy
 
     before_each(function()
         base_tabs = {}
@@ -584,6 +586,7 @@ describe("diff_preview owner isolation", function()
             base_tabs[tabpage] = true
         end
         base_bufs = {}
+        clear_state_spy = nil
         for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
             base_bufs[bufnr] = true
         end
@@ -599,6 +602,10 @@ describe("diff_preview owner isolation", function()
     end)
 
     after_each(function()
+        if clear_state_spy then
+            clear_state_spy:revert()
+            clear_state_spy = nil
+        end
         read_stub:revert()
         fs_stat_stub:revert()
         schedule_stub:revert()
@@ -754,10 +761,17 @@ describe("diff_preview owner isolation", function()
         assert.is_not_nil(bufnr)
         ---@cast bufnr integer
         vim.b[bufnr]._agentic_inline_diff_owner = "foreign"
+        clear_state_spy = spy_module.on(HunkNavigation, "clear_state")
 
         show_new(path, state, "second", false)
 
+        local navigation_cleared = clear_state_spy:called_with(bufnr)
+        clear_state_spy:revert()
+        clear_state_spy = nil
         assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
+        assert.is_nil(state.preview_bufnr)
+        assert.is_nil(state.preview_winid)
+        assert.is_true(navigation_cleared)
     end)
 
     it("deletes a wrong-source suggestion when refresh cannot open", function()
@@ -770,10 +784,17 @@ describe("diff_preview owner isolation", function()
         assert.is_not_nil(bufnr)
         ---@cast bufnr integer
         vim.b[bufnr]._agentic_suggestion_for = path .. ".foreign"
+        clear_state_spy = spy_module.on(HunkNavigation, "clear_state")
 
         show_new(path, state, "second", false)
 
+        local navigation_cleared = clear_state_spy:called_with(bufnr)
+        clear_state_spy:revert()
+        clear_state_spy = nil
         assert.is_false(vim.api.nvim_buf_is_valid(bufnr))
+        assert.is_nil(state.preview_bufnr)
+        assert.is_nil(state.preview_winid)
+        assert.is_true(navigation_cleared)
     end)
 
     it(

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -236,10 +236,12 @@ describe("diff_preview", function()
         local base_tabs
         --- @type integer
         local augroup
+        local bufnr_stub
 
         before_each(function()
             created_wins = {}
             created_bufs = {}
+            bufnr_stub = nil
             base_tabs = {}
             for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
                 base_tabs[tab] = true
@@ -251,6 +253,10 @@ describe("diff_preview", function()
         end)
 
         after_each(function()
+            if bufnr_stub then
+                bufnr_stub:revert()
+                bufnr_stub = nil
+            end
             -- A leaked autocmd corrupts every later test file.
             pcall(vim.api.nvim_del_augroup_by_id, augroup)
             for _, winid in ipairs(created_wins) do
@@ -440,6 +446,28 @@ describe("diff_preview", function()
                 pcall(vim.api.nvim_buf_delete, alt_bufnr, { force = true })
             end
         end)
+
+        it(
+            "uses an unlisted placeholder without an alternate buffer",
+            function()
+                local bufnr =
+                    new_named_buf("/tmp/rejected_without_alternate.lua")
+                mark_legacy_owner(bufnr)
+                local winid = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(winid, bufnr)
+                bufnr_stub = spy_module.stub(vim.fn, "bufnr")
+                bufnr_stub:returns(-1)
+
+                DiffPreview.clear_diff(bufnr, true)
+
+                local replacement_bufnr = vim.api.nvim_win_get_buf(winid)
+                local replacement_listed = vim.bo[replacement_bufnr].buflisted
+                bufnr_stub:revert()
+                bufnr_stub = nil
+                created_bufs[#created_bufs + 1] = replacement_bufnr
+                assert.is_false(replacement_listed)
+            end
+        )
 
         it("keeps the user's other window open on rejection", function()
             local bufnr = new_named_buf("/tmp/rejected_two_windows.lua")

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -586,12 +586,16 @@ describe("diff_preview owner isolation", function()
     --- @param path string
     --- @param state agentic.ui.DiffState|nil
     --- @param line string
-    local function show_new(path, state, line)
+    --- @param can_open boolean|nil
+    local function show_new(path, state, line, can_open)
         DiffPreview.show_diff({
             file_path = path,
             diff = { old = {}, new = { line } },
             state = state,
             get_winid = function(bufnr)
+                if can_open == false then
+                    return nil
+                end
                 local winid = vim.api.nvim_get_current_win()
                 vim.api.nvim_win_set_buf(winid, bufnr)
                 return winid
@@ -603,8 +607,9 @@ describe("diff_preview owner isolation", function()
     --- @param state agentic.ui.DiffState
     --- @param line string
     --- @param tabpage integer|nil
+    --- @param can_open boolean|nil
     --- @return integer bufnr
-    local function show_existing(path, state, line, tabpage)
+    local function show_existing(path, state, line, tabpage, can_open)
         fs_stat_stub:returns({ type = "file" })
         local bufnr = vim.fn.bufadd(path)
         vim.fn.bufload(bufnr)
@@ -624,6 +629,9 @@ describe("diff_preview owner isolation", function()
             state = state,
             tabpage = tabpage,
             get_winid = function(target)
+                if can_open == false then
+                    return nil
+                end
                 local winid = vim.api.nvim_get_current_win()
                 vim.api.nvim_win_set_buf(winid, target)
                 return winid
@@ -672,6 +680,46 @@ describe("diff_preview owner isolation", function()
         )
     end)
 
+    it(
+        "replaces a different new-file suggestion only after its target opens",
+        function()
+            local first_path = vim.fn.tempname() .. ".lua"
+            local second_path = vim.fn.tempname() .. ".lua"
+            --- @type agentic.ui.DiffState
+            local state = {}
+
+            show_new(first_path, state, "first")
+            local first_bufnr = state.preview_bufnr
+            assert.is_not_nil(first_bufnr)
+            ---@cast first_bufnr integer
+
+            show_new(second_path, state, "second", false)
+
+            assert.equal(first_bufnr, state.preview_bufnr)
+            assert.is_true(vim.api.nvim_buf_is_valid(first_bufnr))
+            assert.equal(
+                tostring(state),
+                vim.b[first_bufnr]._agentic_inline_diff_owner
+            )
+
+            show_new(second_path, state, "second")
+
+            local second_bufnr = state.preview_bufnr
+            assert.is_not_nil(second_bufnr)
+            ---@cast second_bufnr integer
+            assert.is_not.equal(first_bufnr, second_bufnr)
+            assert.is_false(vim.api.nvim_buf_is_valid(first_bufnr))
+            assert.equal(
+                tostring(state),
+                vim.b[second_bufnr]._agentic_inline_diff_owner
+            )
+            assert.equal(
+                second_path,
+                vim.b[second_bufnr]._agentic_suggestion_for
+            )
+        end
+    )
+
     it("rejects a second owner for an existing-file inline preview", function()
         local path = vim.fn.tempname() .. ".lua"
         --- @type agentic.ui.DiffState
@@ -718,6 +766,53 @@ describe("diff_preview owner isolation", function()
                 vim.b[bufnr]._agentic_inline_diff_owner
             )
             assert.is_not.same(before, after)
+        end
+    )
+
+    it(
+        "retires a different existing-file preview only after its target opens",
+        function()
+            local first_path = vim.fn.tempname() .. ".lua"
+            local second_path = vim.fn.tempname() .. ".lua"
+            --- @type agentic.ui.DiffState
+            local state = {}
+            local first_bufnr = show_existing(first_path, state, "local x = 2")
+            local namespace =
+                vim.api.nvim_create_namespace("agentic_diff_preview")
+            local first_marks =
+                vim.api.nvim_buf_get_extmarks(first_bufnr, namespace, 0, -1, {})
+            assert.is_true(#first_marks > 0)
+
+            show_existing(second_path, state, "local x = 3", nil, false)
+
+            assert.equal(first_bufnr, state.preview_bufnr)
+            assert.equal(
+                tostring(state),
+                vim.b[first_bufnr]._agentic_inline_diff_owner
+            )
+            assert.is_false(vim.bo[first_bufnr].modifiable)
+
+            local second_bufnr =
+                show_existing(second_path, state, "local x = 3")
+
+            assert.equal(second_bufnr, state.preview_bufnr)
+            assert.is_nil(vim.b[first_bufnr]._agentic_inline_diff_owner)
+            assert.is_nil(vim.b[first_bufnr]._agentic_prev_modifiable)
+            assert.is_true(vim.bo[first_bufnr].modifiable)
+            assert.same(
+                {},
+                vim.api.nvim_buf_get_extmarks(first_bufnr, namespace, 0, -1, {})
+            )
+
+            local found_navigation = false
+            for _, keymap in
+                ipairs(vim.api.nvim_buf_get_keymap(first_bufnr, "n"))
+            do
+                if keymap.lhs == Config.keymaps.diff_preview.next_hunk then
+                    found_navigation = true
+                end
+            end
+            assert.is_false(found_navigation)
         end
     )
 

--- a/lua/agentic/ui/diff_preview.test.lua
+++ b/lua/agentic/ui/diff_preview.test.lua
@@ -754,20 +754,28 @@ describe("diff_preview owner isolation", function()
         end
     )
 
-    it("nil-state cleanup ignores state-qualified suggestions", function()
-        local path = vim.fn.tempname() .. ".lua"
-        --- @type agentic.ui.DiffState
-        local state = {}
-        show_new(path, state, "content")
-        local bufnr = state.preview_bufnr
-        assert.is_not_nil(bufnr)
-        ---@cast bufnr integer
+    it(
+        "nil-state clear and cleanup ignore state-qualified suggestions",
+        function()
+            local path = vim.fn.tempname() .. ".lua"
+            --- @type agentic.ui.DiffState
+            local state = {}
+            show_new(path, state, "content")
+            local bufnr = state.preview_bufnr
+            assert.is_not_nil(bufnr)
+            ---@cast bufnr integer
 
-        DiffPreview.cleanup_suggestion_buffer(path, nil)
+            DiffPreview.clear_diff(path, false, nil)
 
-        assert.is_true(vim.api.nvim_buf_is_valid(bufnr))
-        assert.equal(bufnr, state.preview_bufnr)
-    end)
+            assert.is_true(vim.api.nvim_buf_is_valid(bufnr))
+            assert.equal(bufnr, state.preview_bufnr)
+
+            DiffPreview.cleanup_suggestion_buffer(path, nil)
+
+            assert.is_true(vim.api.nvim_buf_is_valid(bufnr))
+            assert.equal(bufnr, state.preview_bufnr)
+        end
+    )
 
     it(
         "does not replace a window repurposed after showing a suggestion",

--- a/lua/agentic/ui/diff_split_view.lua
+++ b/lua/agentic/ui/diff_split_view.lua
@@ -142,12 +142,22 @@ local function open_split_view(
     vim.bo[scratch_bufnr].modifiable = false
 
     vim.schedule(function()
-        if not BufHelpers.is_win_usable(target_winid) then
+        local current_split = diff_state.split_state
+            and diff_state.split_state[abs_path]
+        if not current_split then
+            return
+        end
+        local current_winid = current_split.original_winid
+        if
+            not BufHelpers.is_win_usable(current_winid)
+            or vim.api.nvim_win_get_buf(current_winid)
+                ~= current_split.original_bufnr
+        then
             return
         end
         local center_cmd = Config.diff_preview.center_on_navigate_hunks and "zz"
             or ""
-        pcall(vim.api.nvim_win_call, target_winid, function()
+        pcall(vim.api.nvim_win_call, current_winid, function()
             vim.cmd("normal! gg]c" .. center_cmd)
         end)
     end)

--- a/lua/agentic/ui/diff_split_view.lua
+++ b/lua/agentic/ui/diff_split_view.lua
@@ -197,6 +197,18 @@ local function resolve_buf_and_win(abs_path, get_winid, tabpage, diff_state)
         bufnr = vim.fn.bufadd(abs_path)
     end
 
+    local existing_split = diff_state.split_state
+        and diff_state.split_state[abs_path]
+    if
+        existing_split
+        and BufHelpers.is_win_usable(existing_split.original_winid)
+        and vim.api.nvim_win_get_buf(existing_split.original_winid) == bufnr
+    then
+        return bufnr,
+            existing_split.original_winid,
+            existing_split.close_original_win
+    end
+
     local winid = BufHelpers.find_visible_win(bufnr, nil, tabpage)
     local target_winid = winid or get_winid(bufnr)
     if not target_winid then
@@ -249,6 +261,19 @@ local function resolve_buf_and_win(abs_path, get_winid, tabpage, diff_state)
             Logger.debug("resolve_buf_and_win: failed to set buffer:", err)
             return nil, nil, nil
         end
+    end
+
+    local owner_count = vim.b[bufnr]._agentic_diff_split_owner_count or 0
+    if owner_count > 0 then
+        local opened, isolated_winid =
+            pcall(vim.api.nvim_open_win, bufnr, false, {
+                split = "right",
+                win = target_winid,
+            })
+        if not opened then
+            return nil, nil, nil
+        end
+        return bufnr, isolated_winid, true
     end
 
     return bufnr, target_winid, false

--- a/lua/agentic/ui/diff_split_view.lua
+++ b/lua/agentic/ui/diff_split_view.lua
@@ -1,3 +1,4 @@
+local BufHelpers = require("agentic.utils.buf_helpers")
 local Config = require("agentic.config")
 local FileSystem = require("agentic.utils.file_system")
 local Logger = require("agentic.utils.logger")
@@ -7,27 +8,13 @@ local ToolCallDiff = require("agentic.ui.tool_call_diff")
 --- @class agentic.ui.DiffSplitView
 local M = {}
 
---- State for split diff view per tabpage
+--- State for one owned split diff.
 --- @class agentic.ui.DiffSplitView.State
 --- @field original_winid number Window ID of original file buffer
 --- @field original_bufnr number Buffer number of original file
 --- @field new_winid number Window ID of scratch buffer window
 --- @field new_bufnr number Buffer number of scratch buffer
 --- @field file_path string Path to file being diffed
-
---- Get split state from tabpage
---- @param tabpage number Tabpage ID
---- @return agentic.ui.DiffSplitView.State|nil state
-local function get_state(tabpage)
-    return vim.t[tabpage]._agentic_diff_split_state
-end
-
---- Set split state for tabpage
---- @param tabpage number Tabpage ID
---- @param state agentic.ui.DiffSplitView.State|nil State to set (nil to clear)
-local function set_state(tabpage, state)
-    vim.t[tabpage]._agentic_diff_split_state = state
-end
 
 --- Reconstruct full modified file from agent's partial diffs
 --- Uses ToolCallDiff.match_or_substring_fallback for matching, which includes
@@ -88,7 +75,9 @@ local function cleanup_stale_suggestion_buf(suggestion_name)
 
     -- Close any windows displaying the stale buffer
     for _, winid in ipairs(vim.fn.win_findbuf(existing)) do
-        pcall(vim.api.nvim_win_close, winid, true)
+        if BufHelpers.is_win_usable(winid) then
+            pcall(vim.api.nvim_win_close, winid, true)
+        end
     end
 
     pcall(vim.api.nvim_buf_delete, existing, { force = true })
@@ -99,9 +88,21 @@ end
 --- @param bufnr number
 --- @param target_winid number
 --- @param modified_lines string[]
+--- @param diff_state agentic.ui.DiffState
 --- @return boolean success
-local function open_split_view(abs_path, bufnr, target_winid, modified_lines)
-    local suggestion_name = abs_path .. " (suggestion)"
+local function open_split_view(
+    abs_path,
+    bufnr,
+    target_winid,
+    modified_lines,
+    diff_state
+)
+    local existing_split = diff_state.split_state
+        and diff_state.split_state[abs_path]
+    local is_new_owner = existing_split == nil
+    local identity = tostring(diff_state):gsub("^table: ", "")
+    local suggestion_name =
+        string.format("%s (suggestion %s)", abs_path, identity)
     cleanup_stale_suggestion_buf(suggestion_name)
 
     local scratch_bufnr = vim.api.nvim_create_buf(false, true)
@@ -131,13 +132,17 @@ local function open_split_view(abs_path, bufnr, target_winid, modified_lines)
     if vim.b[bufnr]._agentic_prev_modified == nil then
         vim.b[bufnr]._agentic_prev_modified = vim.bo[bufnr].modified
     end
+    if is_new_owner then
+        local owner_count = vim.b[bufnr]._agentic_diff_split_owner_count or 0
+        vim.b[bufnr]._agentic_diff_split_owner_count = owner_count + 1
+    end
     vim.bo[bufnr].modifiable = false
     vim.bo[bufnr].modified = true
 
     vim.bo[scratch_bufnr].modifiable = false
 
     vim.schedule(function()
-        if not vim.api.nvim_win_is_valid(target_winid) then
+        if not BufHelpers.is_win_usable(target_winid) then
             return
         end
         local center_cmd = Config.diff_preview.center_on_navigate_hunks and "zz"
@@ -147,18 +152,14 @@ local function open_split_view(abs_path, bufnr, target_winid, modified_lines)
         end)
     end)
 
-    local ok, tabpage = pcall(vim.api.nvim_win_get_tabpage, target_winid)
-    if not ok then
-        return false
-    end
-
-    set_state(tabpage, {
+    diff_state.split_state = diff_state.split_state or {}
+    diff_state.split_state[abs_path] = {
         original_winid = target_winid,
         original_bufnr = bufnr,
         new_winid = new_winid,
         new_bufnr = scratch_bufnr,
         file_path = abs_path,
-    })
+    }
 
     return true
 end
@@ -170,16 +171,17 @@ end
 --- on the returned window. See session_manager.lua get_winid for reference.
 --- @param abs_path string
 --- @param get_winid fun(bufnr: number): number|nil
+--- @param tabpage integer|nil
 --- @return number|nil bufnr
 --- @return number|nil target_winid
-local function resolve_buf_and_win(abs_path, get_winid)
+local function resolve_buf_and_win(abs_path, get_winid, tabpage)
     local bufnr = vim.fn.bufnr(abs_path)
     if bufnr == -1 then
         bufnr = vim.fn.bufadd(abs_path)
     end
 
-    local winid = vim.fn.bufwinid(bufnr)
-    local target_winid = winid ~= -1 and winid or get_winid(bufnr)
+    local winid = BufHelpers.find_visible_win(bufnr, nil, tabpage)
+    local target_winid = winid or get_winid(bufnr)
     if not target_winid then
         Logger.debug("show_split_diff: no valid window found")
         return nil, nil
@@ -200,6 +202,9 @@ end
 
 --- @param opts agentic.ui.DiffPreview.ShowOpts
 function M.show_split_diff(opts)
+    if not opts.state then
+        return false
+    end
     local old_lines = ToolCallDiff.normalize_to_lines(opts.diff.old)
     local new_lines = ToolCallDiff.normalize_to_lines(opts.diff.new)
 
@@ -226,12 +231,18 @@ function M.show_split_diff(opts)
         end
 
         local bufnr, target_winid =
-            resolve_buf_and_win(abs_path, opts.get_winid)
+            resolve_buf_and_win(abs_path, opts.get_winid, opts.tabpage)
         if not bufnr or not target_winid then
             return false
         end
 
-        return open_split_view(abs_path, bufnr, target_winid, new_lines)
+        return open_split_view(
+            abs_path,
+            bufnr,
+            target_winid,
+            new_lines,
+            opts.state
+        )
     end
 
     local original_lines, err = FileSystem.read_from_buffer_or_disk(abs_path)
@@ -253,37 +264,56 @@ function M.show_split_diff(opts)
         return false
     end
 
-    local bufnr, target_winid = resolve_buf_and_win(abs_path, opts.get_winid)
+    local bufnr, target_winid =
+        resolve_buf_and_win(abs_path, opts.get_winid, opts.tabpage)
     if not bufnr or not target_winid then
         return false
     end
 
-    return open_split_view(abs_path, bufnr, target_winid, modified_lines)
+    return open_split_view(
+        abs_path,
+        bufnr,
+        target_winid,
+        modified_lines,
+        opts.state
+    )
 end
 
---- @param tabpage number|nil Tabpage ID (defaults to current tabpage)
+--- @param diff_state agentic.ui.DiffState
 --- @return agentic.ui.DiffSplitView.State|nil state
-function M.get_split_state(tabpage)
-    local tab = tabpage or vim.api.nvim_get_current_tabpage()
-    return get_state(tab)
+function M.find_split_state(diff_state)
+    local split_states = diff_state.split_state
+    if not split_states then
+        return nil
+    end
+    local current_bufnr = vim.api.nvim_get_current_buf()
+    --- @type agentic.ui.DiffSplitView.State|nil
+    local fallback
+    for _, state in pairs(split_states) do
+        if
+            state.original_bufnr == current_bufnr
+            or state.new_bufnr == current_bufnr
+        then
+            return state
+        end
+        fallback = fallback or state
+    end
+    return fallback
 end
 
---- @param tabpage number|nil Tabpage ID (defaults to current tabpage)
-function M.clear_split_diff(tabpage)
-    local tab = tabpage or vim.api.nvim_get_current_tabpage()
-    local state = get_state(tab)
-
+--- @param state agentic.ui.DiffSplitView.State
+local function teardown_split(state)
     if not state then
         return
     end
 
-    if vim.api.nvim_win_is_valid(state.original_winid) then
+    if BufHelpers.is_win_usable(state.original_winid) then
         vim.api.nvim_win_call(state.original_winid, function()
             vim.cmd("diffoff")
         end)
     end
 
-    if vim.api.nvim_win_is_valid(state.new_winid) then
+    if BufHelpers.is_win_usable(state.new_winid) then
         vim.api.nvim_win_call(state.new_winid, function()
             vim.cmd("diffoff")
         end)
@@ -295,6 +325,14 @@ function M.clear_split_diff(tabpage)
     end
 
     if vim.api.nvim_buf_is_valid(state.original_bufnr) then
+        local owner_count =
+            vim.b[state.original_bufnr]._agentic_diff_split_owner_count
+        if owner_count and owner_count > 1 then
+            vim.b[state.original_bufnr]._agentic_diff_split_owner_count = owner_count
+                - 1
+            return
+        end
+        vim.b[state.original_bufnr]._agentic_diff_split_owner_count = nil
         local prev_modifiable =
             vim.b[state.original_bufnr]._agentic_prev_modifiable
         local prev_modified = vim.b[state.original_bufnr]._agentic_prev_modified
@@ -309,8 +347,36 @@ function M.clear_split_diff(tabpage)
             vim.b[state.original_bufnr]._agentic_prev_modified = nil
         end
     end
+end
 
-    set_state(tab, nil)
+--- @param diff_state agentic.ui.DiffState
+--- @param file_path string|nil
+--- @return boolean cleared
+function M.clear_split_diff(diff_state, file_path)
+    local split_states = diff_state.split_state
+    if not split_states then
+        return false
+    end
+    local cleared = false
+    if file_path then
+        local abs_path = FileSystem.to_absolute_path(file_path)
+        local state = split_states[abs_path]
+        if state then
+            teardown_split(state)
+            split_states[abs_path] = nil
+            cleared = true
+        end
+    else
+        for path, state in pairs(split_states) do
+            teardown_split(state)
+            split_states[path] = nil
+            cleared = true
+        end
+    end
+    if next(split_states) == nil then
+        diff_state.split_state = nil
+    end
+    return cleared
 end
 
 return M

--- a/lua/agentic/ui/diff_split_view.lua
+++ b/lua/agentic/ui/diff_split_view.lua
@@ -15,6 +15,7 @@ local M = {}
 --- @field new_winid number Window ID of scratch buffer window
 --- @field new_bufnr number Buffer number of scratch buffer
 --- @field file_path string Path to file being diffed
+--- @field close_original_win? boolean Close an isolation split during teardown
 
 --- Reconstruct full modified file from agent's partial diffs
 --- Uses ToolCallDiff.match_or_substring_fallback for matching, which includes
@@ -95,11 +96,14 @@ local function open_split_view(
     bufnr,
     target_winid,
     modified_lines,
-    diff_state
+    diff_state,
+    close_original_win
 )
     local existing_split = diff_state.split_state
         and diff_state.split_state[abs_path]
     local is_new_owner = existing_split == nil
+    local should_close_original_win = close_original_win
+        or (existing_split and existing_split.close_original_win)
     local identity = tostring(diff_state):gsub("^table: ", "")
     local suggestion_name =
         string.format("%s (suggestion %s)", abs_path, identity)
@@ -169,6 +173,7 @@ local function open_split_view(
         new_winid = new_winid,
         new_bufnr = scratch_bufnr,
         file_path = abs_path,
+        close_original_win = should_close_original_win,
     }
 
     return true
@@ -182,9 +187,11 @@ end
 --- @param abs_path string
 --- @param get_winid fun(bufnr: number): number|nil
 --- @param tabpage integer|nil
+--- @param diff_state agentic.ui.DiffState
 --- @return number|nil bufnr
 --- @return number|nil target_winid
-local function resolve_buf_and_win(abs_path, get_winid, tabpage)
+--- @return boolean|nil close_original_win
+local function resolve_buf_and_win(abs_path, get_winid, tabpage, diff_state)
     local bufnr = vim.fn.bufnr(abs_path)
     if bufnr == -1 then
         bufnr = vim.fn.bufadd(abs_path)
@@ -194,7 +201,44 @@ local function resolve_buf_and_win(abs_path, get_winid, tabpage)
     local target_winid = winid or get_winid(bufnr)
     if not target_winid then
         Logger.debug("show_split_diff: no valid window found")
-        return nil, nil
+        return nil, nil, nil
+    end
+
+    local claimed_bufnr
+    for path, split_state in pairs(diff_state.split_state or {}) do
+        if path ~= abs_path then
+            if split_state.original_winid == target_winid then
+                claimed_bufnr = split_state.original_bufnr
+                break
+            end
+            if split_state.new_winid == target_winid then
+                claimed_bufnr = split_state.new_bufnr
+                break
+            end
+        end
+    end
+
+    if claimed_bufnr then
+        if
+            not BufHelpers.is_win_usable(target_winid)
+            or not vim.api.nvim_buf_is_valid(claimed_bufnr)
+        then
+            return nil, nil, nil
+        end
+        local restored =
+            pcall(vim.api.nvim_win_set_buf, target_winid, claimed_bufnr)
+        if not restored then
+            return nil, nil, nil
+        end
+        local opened, isolated_winid =
+            pcall(vim.api.nvim_open_win, bufnr, false, {
+                split = "right",
+                win = target_winid,
+            })
+        if not opened then
+            return nil, nil, nil
+        end
+        return bufnr, isolated_winid, true
     end
 
     -- Ensure the target window actually displays the buffer (get_winid
@@ -203,11 +247,11 @@ local function resolve_buf_and_win(abs_path, get_winid, tabpage)
         local ok, err = pcall(vim.api.nvim_win_set_buf, target_winid, bufnr)
         if not ok then
             Logger.debug("resolve_buf_and_win: failed to set buffer:", err)
-            return nil, nil
+            return nil, nil, nil
         end
     end
 
-    return bufnr, target_winid
+    return bufnr, target_winid, false
 end
 
 --- @param opts agentic.ui.DiffPreview.ShowOpts
@@ -240,8 +284,12 @@ function M.show_split_diff(opts)
             return false
         end
 
-        local bufnr, target_winid =
-            resolve_buf_and_win(abs_path, opts.get_winid, opts.tabpage)
+        local bufnr, target_winid, close_original_win = resolve_buf_and_win(
+            abs_path,
+            opts.get_winid,
+            opts.tabpage,
+            opts.state
+        )
         if not bufnr or not target_winid then
             return false
         end
@@ -251,7 +299,8 @@ function M.show_split_diff(opts)
             bufnr,
             target_winid,
             new_lines,
-            opts.state
+            opts.state,
+            close_original_win
         )
     end
 
@@ -274,8 +323,8 @@ function M.show_split_diff(opts)
         return false
     end
 
-    local bufnr, target_winid =
-        resolve_buf_and_win(abs_path, opts.get_winid, opts.tabpage)
+    local bufnr, target_winid, close_original_win =
+        resolve_buf_and_win(abs_path, opts.get_winid, opts.tabpage, opts.state)
     if not bufnr or not target_winid then
         return false
     end
@@ -285,7 +334,8 @@ function M.show_split_diff(opts)
         bufnr,
         target_winid,
         modified_lines,
-        opts.state
+        opts.state,
+        close_original_win
     )
 end
 
@@ -317,17 +367,36 @@ local function teardown_split(state)
         return
     end
 
-    if BufHelpers.is_win_usable(state.original_winid) then
+    local original_owned = BufHelpers.is_win_usable(state.original_winid)
+        and vim.api.nvim_win_get_buf(state.original_winid)
+            == state.original_bufnr
+    if original_owned then
         vim.api.nvim_win_call(state.original_winid, function()
             vim.cmd("diffoff")
         end)
     end
 
-    if BufHelpers.is_win_usable(state.new_winid) then
+    local new_owned = BufHelpers.is_win_usable(state.new_winid)
+        and vim.api.nvim_win_get_buf(state.new_winid) == state.new_bufnr
+    if new_owned then
         vim.api.nvim_win_call(state.new_winid, function()
             vim.cmd("diffoff")
         end)
-        pcall(vim.api.nvim_win_close, state.new_winid, true)
+        if
+            BufHelpers.is_win_usable(state.new_winid)
+            and vim.api.nvim_win_get_buf(state.new_winid) == state.new_bufnr
+        then
+            pcall(vim.api.nvim_win_close, state.new_winid, true)
+        end
+    end
+
+    if
+        state.close_original_win
+        and BufHelpers.is_win_usable(state.original_winid)
+        and vim.api.nvim_win_get_buf(state.original_winid)
+            == state.original_bufnr
+    then
+        pcall(vim.api.nvim_win_close, state.original_winid, true)
     end
 
     if vim.api.nvim_buf_is_valid(state.new_bufnr) then

--- a/lua/agentic/ui/diff_split_view.test.lua
+++ b/lua/agentic/ui/diff_split_view.test.lua
@@ -590,7 +590,7 @@ describe("DiffSplitView", function()
             assert.is_not_nil(diff_state.split_state[second_path])
         end)
 
-        it("isolates same-path scratch buffers for two owners", function()
+        it("keeps a same-path owner active when the other clears", function()
             --- @type agentic.ui.DiffState
             local first_state = new_diff_state()
             --- @type agentic.ui.DiffState
@@ -617,9 +617,25 @@ describe("DiffSplitView", function()
             assert.is_not_nil(second)
             ---@cast first agentic.ui.DiffSplitView.State
             ---@cast second agentic.ui.DiffSplitView.State
+            assert.is_not.equal(first.original_winid, second.original_winid)
             assert.is_not.equal(first.new_bufnr, second.new_bufnr)
             assert.is_true(vim.api.nvim_buf_is_valid(first.new_bufnr))
             assert.is_true(vim.api.nvim_buf_is_valid(second.new_bufnr))
+
+            assert.is_true(DiffSplitView.clear_split_diff(first_state))
+
+            assert.is_true(BufHelpers.is_win_usable(second.original_winid))
+            assert.is_true(BufHelpers.is_win_usable(second.new_winid))
+            assert.equal(
+                second.original_bufnr,
+                vim.api.nvim_win_get_buf(second.original_winid)
+            )
+            assert.equal(
+                second.new_bufnr,
+                vim.api.nvim_win_get_buf(second.new_winid)
+            )
+            assert.is_true(vim.wo[second.original_winid].diff)
+            assert.is_true(vim.wo[second.new_winid].diff)
         end)
 
         it(

--- a/lua/agentic/ui/diff_split_view.test.lua
+++ b/lua/agentic/ui/diff_split_view.test.lua
@@ -432,6 +432,98 @@ describe("DiffSplitView", function()
             assert.is_not_nil(owner_state.split_state[second_path])
         end)
 
+        it(
+            "keeps two live paths isolated when get_winid reuses a window",
+            function()
+                local first_path = test_file_path .. ".first"
+                local second_path = test_file_path .. ".second"
+                local get_winid = function(bufnr)
+                    local winid = vim.api.nvim_get_current_win()
+                    vim.api.nvim_win_set_buf(winid, bufnr)
+                    return winid
+                end
+
+                assert.is_true(show_split({
+                    file_path = first_path,
+                    diff = {
+                        old = { "local x = 1" },
+                        new = { "local x = 2" },
+                    },
+                    get_winid = get_winid,
+                }))
+                assert.is_true(show_split({
+                    file_path = second_path,
+                    diff = {
+                        old = { "local x = 1" },
+                        new = { "local x = 3" },
+                    },
+                    get_winid = get_winid,
+                }))
+
+                local first = diff_state.split_state[first_path]
+                local second = diff_state.split_state[second_path]
+                assert.is_not.equal(first.original_winid, second.original_winid)
+                assert.is_not.equal(first.new_winid, second.new_winid)
+                assert.equal(
+                    first.original_bufnr,
+                    vim.api.nvim_win_get_buf(first.original_winid)
+                )
+                assert.equal(
+                    second.original_bufnr,
+                    vim.api.nvim_win_get_buf(second.original_winid)
+                )
+
+                assert.is_true(
+                    DiffSplitView.clear_split_diff(diff_state, first_path)
+                )
+
+                assert.is_true(BufHelpers.is_win_usable(second.original_winid))
+                assert.is_true(BufHelpers.is_win_usable(second.new_winid))
+                assert.equal(
+                    second.original_bufnr,
+                    vim.api.nvim_win_get_buf(second.original_winid)
+                )
+                assert.equal(
+                    second.new_bufnr,
+                    vim.api.nvim_win_get_buf(second.new_winid)
+                )
+                assert.is_true(vim.wo[second.original_winid].diff)
+                assert.is_true(vim.wo[second.new_winid].diff)
+            end
+        )
+
+        it("closes an isolation window after same-path refresh", function()
+            local first_path = test_file_path .. ".first"
+            local second_path = test_file_path .. ".second"
+            local get_winid = function(bufnr)
+                local winid = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(winid, bufnr)
+                return winid
+            end
+            local function show_path(path, replacement)
+                return show_split({
+                    file_path = path,
+                    diff = {
+                        old = { "local x = 1" },
+                        new = { replacement },
+                    },
+                    get_winid = get_winid,
+                })
+            end
+
+            assert.is_true(show_path(first_path, "local x = 2"))
+            assert.is_true(show_path(second_path, "local x = 3"))
+            local isolation_winid =
+                diff_state.split_state[second_path].original_winid
+
+            assert.is_true(show_path(second_path, "local x = 4"))
+            assert.is_true(
+                DiffSplitView.clear_split_diff(diff_state, second_path)
+            )
+
+            assert.is_false(BufHelpers.is_win_usable(isolation_winid))
+        end)
+
         it("selects the owned split containing the current buffer", function()
             local current = vim.api.nvim_get_current_buf()
             local other = vim.api.nvim_create_buf(false, true)
@@ -746,6 +838,30 @@ describe("DiffSplitView", function()
             assert.is_true(usable_count > 0)
             assert.equal(0, win_call_count)
             assert.equal(0, close_count)
+        end)
+
+        it("does not tear down repurposed split windows", function()
+            setup_and_show_split()
+            local state = DiffSplitView.find_split_state(diff_state)
+            assert.is_not_nil(state)
+            ---@cast state agentic.ui.DiffSplitView.State
+            local original_replacement = vim.api.nvim_create_buf(false, true)
+            local new_replacement = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_win_set_buf(state.original_winid, original_replacement)
+            vim.api.nvim_win_set_buf(state.new_winid, new_replacement)
+
+            DiffSplitView.clear_split_diff(diff_state)
+
+            assert.is_true(BufHelpers.is_win_usable(state.original_winid))
+            assert.is_true(BufHelpers.is_win_usable(state.new_winid))
+            assert.equal(
+                original_replacement,
+                vim.api.nvim_win_get_buf(state.original_winid)
+            )
+            assert.equal(
+                new_replacement,
+                vim.api.nvim_win_get_buf(state.new_winid)
+            )
         end)
     end)
 end)

--- a/lua/agentic/ui/diff_split_view.test.lua
+++ b/lua/agentic/ui/diff_split_view.test.lua
@@ -10,8 +10,19 @@ describe("DiffSplitView", function()
     local test_file_path = "/tmp/test_diff_split_view_fake.lua"
     local test_tabpage
     local read_stub
+    local base_tabs
+    local base_bufs
+    local owner_states
     --- @type agentic.ui.DiffState
     local diff_state
+
+    --- @return agentic.ui.DiffState state
+    local function new_diff_state()
+        --- @type agentic.ui.DiffState
+        local state = {}
+        owner_states[#owner_states + 1] = state
+        return state
+    end
 
     --- @param opts agentic.ui.DiffPreview.ShowOpts
     --- @return boolean success
@@ -26,29 +37,47 @@ describe("DiffSplitView", function()
     end
 
     before_each(function()
+        base_tabs = {}
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            base_tabs[tabpage] = true
+        end
+        base_bufs = {}
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            base_bufs[bufnr] = true
+        end
+        owner_states = {}
         read_stub = spy_module.stub(FileSystem, "read_from_buffer_or_disk")
         stub_file_content({ "local x = 1", "print(x)", "" })
-        diff_state = {}
+        diff_state = new_diff_state()
         vim.cmd("tabnew")
         test_tabpage = vim.api.nvim_get_current_tabpage()
     end)
 
     after_each(function()
-        read_stub:revert()
-        if test_tabpage and vim.api.nvim_tabpage_is_valid(test_tabpage) then
-            pcall(DiffSplitView.clear_split_diff, diff_state)
-            pcall(vim.api.nvim_tabpage_del, test_tabpage)
+        for _, owner_state in ipairs(owner_states) do
+            pcall(DiffSplitView.clear_split_diff, owner_state)
         end
-        for _, path in ipairs({
-            test_file_path,
-            test_file_path .. ".first",
-            test_file_path .. ".second",
-        }) do
-            local bufnr = vim.fn.bufnr(path)
-            if bufnr ~= -1 then
+        read_stub:revert()
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            if not base_tabs[tabpage] then
+                pcall(function()
+                    vim.api.nvim_set_current_tabpage(tabpage)
+                    vim.cmd("tabclose!")
+                end)
+            end
+        end
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            if not base_bufs[bufnr] and vim.api.nvim_buf_is_valid(bufnr) then
                 pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
             end
         end
+        local extra_bufs = 0
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            if not base_bufs[bufnr] then
+                extra_bufs = extra_bufs + 1
+            end
+        end
+        assert.equal(0, extra_bufs)
     end)
 
     --- @return number bufnr
@@ -374,7 +403,7 @@ describe("DiffSplitView", function()
 
         it("stores two split paths under one owner", function()
             --- @type agentic.ui.DiffState
-            local owner_state = {}
+            local owner_state = new_diff_state()
             local first_path = test_file_path .. ".first"
             local second_path = test_file_path .. ".second"
             local get_winid = function(bufnr)
@@ -471,9 +500,9 @@ describe("DiffSplitView", function()
 
         it("isolates same-path scratch buffers for two owners", function()
             --- @type agentic.ui.DiffState
-            local first_state = {}
+            local first_state = new_diff_state()
             --- @type agentic.ui.DiffState
-            local second_state = {}
+            local second_state = new_diff_state()
             local get_winid = function(bufnr)
                 local winid = vim.api.nvim_get_current_win()
                 vim.api.nvim_win_set_buf(winid, bufnr)
@@ -507,9 +536,9 @@ describe("DiffSplitView", function()
                 local bufnr = vim.fn.bufadd(test_file_path)
                 local original_modifiable = vim.bo[bufnr].modifiable
                 --- @type agentic.ui.DiffState
-                local first_state = {}
+                local first_state = new_diff_state()
                 --- @type agentic.ui.DiffState
-                local second_state = {}
+                local second_state = new_diff_state()
                 local function open_for(state)
                     return DiffSplitView.show_split_diff({
                         file_path = test_file_path,
@@ -546,7 +575,7 @@ describe("DiffSplitView", function()
             local foreign_win = vim.api.nvim_get_current_win()
             vim.api.nvim_win_set_buf(foreign_win, bufnr)
             --- @type agentic.ui.DiffState
-            local state = {}
+            local state = new_diff_state()
 
             DiffSplitView.show_split_diff({
                 file_path = test_file_path,
@@ -589,6 +618,34 @@ describe("DiffSplitView", function()
                 usable_stub:revert()
                 schedule_stub:revert()
                 assert.is_true(usable_called)
+                assert.equal(0, win_call_count)
+            end
+        )
+
+        it(
+            "skips scheduled navigation when the original window is repurposed",
+            function()
+                local scheduled
+                local schedule_stub = spy_module.stub(vim, "schedule")
+                schedule_stub:invokes(function(callback)
+                    scheduled = callback
+                end)
+                setup_and_show_split()
+                local split = DiffSplitView.find_split_state(diff_state)
+                assert.is_not_nil(split)
+                ---@cast split agentic.ui.DiffSplitView.State
+                local replacement_bufnr = vim.api.nvim_create_buf(false, true)
+                vim.api.nvim_win_set_buf(
+                    split.original_winid,
+                    replacement_bufnr
+                )
+                local win_call_stub = spy_module.stub(vim.api, "nvim_win_call")
+
+                scheduled()
+
+                local win_call_count = win_call_stub.call_count
+                win_call_stub:revert()
+                schedule_stub:revert()
                 assert.equal(0, win_call_count)
             end
         )

--- a/lua/agentic/ui/diff_split_view.test.lua
+++ b/lua/agentic/ui/diff_split_view.test.lua
@@ -4,10 +4,21 @@ local spy_module = require("tests.helpers.spy")
 describe("DiffSplitView", function()
     local DiffSplitView = require("agentic.ui.diff_split_view")
     local FileSystem = require("agentic.utils.file_system")
+    local BufHelpers = require("agentic.utils.buf_helpers")
+    local DiffPreview = require("agentic.ui.diff_preview")
 
     local test_file_path = "/tmp/test_diff_split_view_fake.lua"
     local test_tabpage
     local read_stub
+    --- @type agentic.ui.DiffState
+    local diff_state
+
+    --- @param opts agentic.ui.DiffPreview.ShowOpts
+    --- @return boolean success
+    local function show_split(opts)
+        opts.state = diff_state
+        return DiffSplitView.show_split_diff(opts)
+    end
 
     --- @param lines string[]|nil
     local function stub_file_content(lines)
@@ -17,6 +28,7 @@ describe("DiffSplitView", function()
     before_each(function()
         read_stub = spy_module.stub(FileSystem, "read_from_buffer_or_disk")
         stub_file_content({ "local x = 1", "print(x)", "" })
+        diff_state = {}
         vim.cmd("tabnew")
         test_tabpage = vim.api.nvim_get_current_tabpage()
     end)
@@ -24,8 +36,18 @@ describe("DiffSplitView", function()
     after_each(function()
         read_stub:revert()
         if test_tabpage and vim.api.nvim_tabpage_is_valid(test_tabpage) then
-            pcall(DiffSplitView.clear_split_diff, test_tabpage)
+            pcall(DiffSplitView.clear_split_diff, diff_state)
             pcall(vim.api.nvim_tabpage_del, test_tabpage)
+        end
+        for _, path in ipairs({
+            test_file_path,
+            test_file_path .. ".first",
+            test_file_path .. ".second",
+        }) do
+            local bufnr = vim.fn.bufnr(path)
+            if bufnr ~= -1 then
+                pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            end
         end
     end)
 
@@ -34,7 +56,7 @@ describe("DiffSplitView", function()
     local function setup_and_show_split()
         local bufnr = vim.fn.bufadd(test_file_path)
 
-        DiffSplitView.show_split_diff({
+        show_split({
             file_path = test_file_path,
             diff = { old = { "local x = 1" }, new = { "local x = 2" } },
             get_winid = function()
@@ -51,7 +73,7 @@ describe("DiffSplitView", function()
             function()
                 stub_file_content(nil)
 
-                local success = DiffSplitView.show_split_diff({
+                local success = show_split({
                     file_path = test_file_path,
                     diff = { old = {}, new = { "local y = 2" } },
                     get_winid = function()
@@ -68,7 +90,7 @@ describe("DiffSplitView", function()
             function()
                 stub_file_content(nil)
 
-                local success = DiffSplitView.show_split_diff({
+                local success = show_split({
                     file_path = test_file_path,
                     diff = { old = {}, new = { "" } },
                     get_winid = function()
@@ -87,7 +109,7 @@ describe("DiffSplitView", function()
                 local bufnr = vim.fn.bufadd(test_file_path)
                 vim.fn.bufload(bufnr)
 
-                local success = DiffSplitView.show_split_diff({
+                local success = show_split({
                     file_path = test_file_path,
                     diff = { old = {}, new = { "local y = 2" } },
                     get_winid = function()
@@ -97,7 +119,7 @@ describe("DiffSplitView", function()
 
                 assert.is_true(success)
 
-                local state = DiffSplitView.get_split_state(test_tabpage)
+                local state = DiffSplitView.find_split_state(diff_state)
                 assert.is_not_nil(state)
 
                 if state then
@@ -115,8 +137,8 @@ describe("DiffSplitView", function()
         it(
             "should create split view with correct state and buffer options",
             function()
-                local bufnr, tabpage = setup_and_show_split()
-                local state = DiffSplitView.get_split_state(tabpage)
+                local bufnr = setup_and_show_split()
+                local state = DiffSplitView.find_split_state(diff_state)
 
                 assert.is_not_nil(state)
                 if state then
@@ -136,7 +158,7 @@ describe("DiffSplitView", function()
         it("should reconstruct full file from partial diff", function()
             stub_file_content({ "local x = 1", "local y = 2", "print(x)", "" })
 
-            local success = DiffSplitView.show_split_diff({
+            local success = show_split({
                 file_path = test_file_path,
                 diff = {
                     old = { "local y = 2" },
@@ -149,7 +171,7 @@ describe("DiffSplitView", function()
 
             assert.is_true(success)
 
-            local state = DiffSplitView.get_split_state(test_tabpage)
+            local state = DiffSplitView.find_split_state(diff_state)
             assert.is_not_nil(state)
 
             if state then
@@ -171,7 +193,7 @@ describe("DiffSplitView", function()
                 "",
             })
 
-            local success = DiffSplitView.show_split_diff({
+            local success = show_split({
                 file_path = test_file_path,
                 diff = {
                     old = { "local y = 2", "local z = 3" },
@@ -184,7 +206,7 @@ describe("DiffSplitView", function()
 
             assert.is_true(success)
 
-            local state = DiffSplitView.get_split_state(test_tabpage)
+            local state = DiffSplitView.find_split_state(diff_state)
             assert.is_not_nil(state)
 
             if state then
@@ -206,7 +228,7 @@ describe("DiffSplitView", function()
                 return vim.api.nvim_get_current_win()
             end)
 
-            local success = DiffSplitView.show_split_diff({
+            local success = show_split({
                 file_path = test_file_path,
                 diff = {
                     old = { "nonexistent line content" },
@@ -216,13 +238,13 @@ describe("DiffSplitView", function()
             })
 
             assert.is_false(success)
-            assert.is_nil(DiffSplitView.get_split_state(test_tabpage))
+            assert.is_nil(DiffSplitView.find_split_state(diff_state))
             assert.spy(get_winid_spy).was.called(0)
             get_winid_spy:revert()
         end)
 
         it("should handle substring fallback for single-line diffs", function()
-            local success = DiffSplitView.show_split_diff({
+            local success = show_split({
                 file_path = test_file_path,
                 diff = {
                     old = { "x = 1" },
@@ -235,7 +257,7 @@ describe("DiffSplitView", function()
 
             assert.is_true(success)
 
-            local state = DiffSplitView.get_split_state(test_tabpage)
+            local state = DiffSplitView.find_split_state(diff_state)
             assert.is_not_nil(state)
 
             if state then
@@ -248,7 +270,7 @@ describe("DiffSplitView", function()
         it("should replace all matches when replace_all is true", function()
             stub_file_content({ "print(a)", "print(b)", "print(a)", "" })
 
-            local success = DiffSplitView.show_split_diff({
+            local success = show_split({
                 file_path = test_file_path,
                 diff = {
                     old = { "print(a)" },
@@ -262,7 +284,7 @@ describe("DiffSplitView", function()
 
             assert.is_true(success)
 
-            local state = DiffSplitView.get_split_state(test_tabpage)
+            local state = DiffSplitView.find_split_state(diff_state)
             assert.is_not_nil(state)
 
             if state then
@@ -277,7 +299,7 @@ describe("DiffSplitView", function()
             function()
                 stub_file_content({ "print(a)", "print(b)", "print(a)", "" })
 
-                local success = DiffSplitView.show_split_diff({
+                local success = show_split({
                     file_path = test_file_path,
                     diff = {
                         old = { "print(a)" },
@@ -290,7 +312,7 @@ describe("DiffSplitView", function()
 
                 assert.is_true(success)
 
-                local state = DiffSplitView.get_split_state(test_tabpage)
+                local state = DiffSplitView.find_split_state(diff_state)
                 assert.is_not_nil(state)
 
                 if state then
@@ -315,24 +337,24 @@ describe("DiffSplitView", function()
                 return vim.api.nvim_get_current_win()
             end
 
-            local first = DiffSplitView.show_split_diff({
+            local first = show_split({
                 file_path = test_file_path,
                 diff = { old = { "local x = 1" }, new = { "local x = 2" } },
                 get_winid = get_winid,
             })
             assert.is_true(first)
 
-            local state1 = DiffSplitView.get_split_state(test_tabpage)
+            local state1 = DiffSplitView.find_split_state(diff_state)
             assert.is_not_nil(state1)
 
-            local second = DiffSplitView.show_split_diff({
+            local second = show_split({
                 file_path = test_file_path,
                 diff = { old = { "local x = 1" }, new = { "local x = 3" } },
                 get_winid = get_winid,
             })
             assert.is_true(second)
 
-            local state2 = DiffSplitView.get_split_state(test_tabpage)
+            local state2 = DiffSplitView.find_split_state(diff_state)
             assert.is_not_nil(state2)
 
             if state2 then
@@ -345,20 +367,278 @@ describe("DiffSplitView", function()
                 assert.same({ "local x = 3", "print(x)", "" }, lines)
             end
 
-            DiffSplitView.clear_split_diff(test_tabpage)
-            assert.is_nil(DiffSplitView.get_split_state(test_tabpage))
+            DiffSplitView.clear_split_diff(diff_state)
+            assert.is_nil(DiffSplitView.find_split_state(diff_state))
             assert.equal(orig_modifiable, vim.bo[bufnr].modifiable)
+        end)
+
+        it("stores two split paths under one owner", function()
+            --- @type agentic.ui.DiffState
+            local owner_state = {}
+            local first_path = test_file_path .. ".first"
+            local second_path = test_file_path .. ".second"
+            local get_winid = function(bufnr)
+                local winid = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(winid, bufnr)
+                return winid
+            end
+
+            local first = DiffSplitView.show_split_diff({
+                file_path = first_path,
+                diff = { old = { "local x = 1" }, new = { "local x = 2" } },
+                state = owner_state,
+                get_winid = get_winid,
+            })
+            local second = DiffSplitView.show_split_diff({
+                file_path = second_path,
+                diff = { old = { "local x = 1" }, new = { "local x = 3" } },
+                state = owner_state,
+                get_winid = get_winid,
+            })
+
+            assert.is_true(first)
+            assert.is_true(second)
+            assert.is_not_nil(owner_state.split_state)
+            assert.is_not_nil(owner_state.split_state[first_path])
+            assert.is_not_nil(owner_state.split_state[second_path])
+        end)
+
+        it("selects the owned split containing the current buffer", function()
+            local current = vim.api.nvim_get_current_buf()
+            local other = vim.api.nvim_create_buf(false, true)
+            local state = {
+                split_state = {
+                    first = {
+                        original_bufnr = other,
+                        new_bufnr = other,
+                    },
+                    second = {
+                        original_bufnr = current,
+                        new_bufnr = current,
+                    },
+                },
+            }
+
+            local selected = DiffSplitView.find_split_state(state)
+            --- @cast selected -nil
+
+            assert.equal(current, selected.original_bufnr)
+            pcall(vim.api.nvim_buf_delete, other, { force = true })
+        end)
+
+        it("falls back to any split owned by the supplied state", function()
+            local state = {
+                split_state = {
+                    only = {
+                        original_bufnr = -1,
+                        new_bufnr = -2,
+                    },
+                },
+            }
+
+            assert.is_not_nil(DiffSplitView.find_split_state(state))
+        end)
+
+        it("returns nil when the supplied state owns no split", function()
+            assert.is_nil(DiffSplitView.find_split_state({}))
+        end)
+
+        it("clears only the split matching a requested buffer", function()
+            local first_path = test_file_path .. ".first"
+            local second_path = test_file_path .. ".second"
+            local get_winid = function(bufnr)
+                local winid = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(winid, bufnr)
+                return winid
+            end
+            show_split({
+                file_path = first_path,
+                diff = { old = { "local x = 1" }, new = { "local x = 2" } },
+                get_winid = get_winid,
+            })
+            show_split({
+                file_path = second_path,
+                diff = { old = { "local x = 1" }, new = { "local x = 3" } },
+                get_winid = get_winid,
+            })
+            local first = diff_state.split_state[first_path]
+
+            DiffPreview.clear_diff(first.original_bufnr, false, diff_state)
+
+            assert.is_nil(diff_state.split_state[first_path])
+            assert.is_not_nil(diff_state.split_state[second_path])
+        end)
+
+        it("isolates same-path scratch buffers for two owners", function()
+            --- @type agentic.ui.DiffState
+            local first_state = {}
+            --- @type agentic.ui.DiffState
+            local second_state = {}
+            local get_winid = function(bufnr)
+                local winid = vim.api.nvim_get_current_win()
+                vim.api.nvim_win_set_buf(winid, bufnr)
+                return winid
+            end
+            local opts = {
+                file_path = test_file_path,
+                diff = { old = { "local x = 1" }, new = { "local x = 2" } },
+                get_winid = get_winid,
+                state = first_state,
+            }
+
+            assert.is_true(DiffSplitView.show_split_diff(opts))
+            opts.state = second_state
+            assert.is_true(DiffSplitView.show_split_diff(opts))
+
+            local first = DiffSplitView.find_split_state(first_state)
+            local second = DiffSplitView.find_split_state(second_state)
+            assert.is_not_nil(first)
+            assert.is_not_nil(second)
+            ---@cast first agentic.ui.DiffSplitView.State
+            ---@cast second agentic.ui.DiffSplitView.State
+            assert.is_not.equal(first.new_bufnr, second.new_bufnr)
+            assert.is_true(vim.api.nvim_buf_is_valid(first.new_bufnr))
+            assert.is_true(vim.api.nvim_buf_is_valid(second.new_bufnr))
+        end)
+
+        it(
+            "restores the original buffer after the final owner clears",
+            function()
+                local bufnr = vim.fn.bufadd(test_file_path)
+                local original_modifiable = vim.bo[bufnr].modifiable
+                --- @type agentic.ui.DiffState
+                local first_state = {}
+                --- @type agentic.ui.DiffState
+                local second_state = {}
+                local function open_for(state)
+                    return DiffSplitView.show_split_diff({
+                        file_path = test_file_path,
+                        diff = {
+                            old = { "local x = 1" },
+                            new = { "local x = 2" },
+                        },
+                        state = state,
+                        get_winid = function(target)
+                            local winid = vim.api.nvim_get_current_win()
+                            vim.api.nvim_win_set_buf(winid, target)
+                            return winid
+                        end,
+                    })
+                end
+
+                assert.is_true(open_for(first_state))
+                assert.is_true(open_for(second_state))
+                assert.is_true(DiffSplitView.clear_split_diff(first_state))
+                assert.is_false(vim.bo[bufnr].modifiable)
+                assert.is_true(DiffSplitView.clear_split_diff(second_state))
+                assert.equal(original_modifiable, vim.bo[bufnr].modifiable)
+            end
+        )
+
+        it("restricts split lookup to the explicit tabpage", function()
+            local bufnr = vim.fn.bufadd(test_file_path)
+            vim.fn.bufload(bufnr)
+            local owner_tab = vim.api.nvim_get_current_tabpage()
+            local owner_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(owner_win, bufnr)
+
+            vim.cmd("tabnew")
+            local foreign_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(foreign_win, bufnr)
+            --- @type agentic.ui.DiffState
+            local state = {}
+
+            DiffSplitView.show_split_diff({
+                file_path = test_file_path,
+                diff = { old = { "local x = 1" }, new = { "local x = 2" } },
+                state = state,
+                tabpage = owner_tab,
+                get_winid = function()
+                    return foreign_win
+                end,
+            })
+
+            local split = DiffSplitView.find_split_state(state)
+            assert.is_not_nil(split)
+            ---@cast split agentic.ui.DiffSplitView.State
+            assert.equal(owner_win, split.original_winid)
+        end)
+
+        it(
+            "skips scheduled navigation when the target window is unusable",
+            function()
+                local scheduled
+                local schedule_stub = spy_module.stub(vim, "schedule")
+                schedule_stub:invokes(function(callback)
+                    scheduled = callback
+                end)
+                setup_and_show_split()
+                local split = DiffSplitView.find_split_state(diff_state)
+                assert.is_not_nil(split)
+                ---@cast split agentic.ui.DiffSplitView.State
+                local usable_stub = spy_module.stub(BufHelpers, "is_win_usable")
+                usable_stub:returns(false)
+                local win_call_stub = spy_module.stub(vim.api, "nvim_win_call")
+
+                scheduled()
+
+                local usable_called =
+                    usable_stub:called_with(split.original_winid)
+                local win_call_count = win_call_stub.call_count
+                win_call_stub:revert()
+                usable_stub:revert()
+                schedule_stub:revert()
+                assert.is_true(usable_called)
+                assert.equal(0, win_call_count)
+            end
+        )
+
+        it("does not close an unusable stale suggestion window", function()
+            setup_and_show_split()
+            local usable_stub = spy_module.stub(BufHelpers, "is_win_usable")
+            usable_stub:returns(false)
+            local close_stub = spy_module.stub(vim.api, "nvim_win_close")
+
+            show_split({
+                file_path = test_file_path,
+                diff = { old = { "local x = 1" }, new = { "local x = 3" } },
+                get_winid = function(bufnr)
+                    local winid = vim.api.nvim_get_current_win()
+                    vim.api.nvim_win_set_buf(winid, bufnr)
+                    return winid
+                end,
+            })
+
+            local usable_count = usable_stub.call_count
+            local close_count = close_stub.call_count
+            close_stub:revert()
+            usable_stub:revert()
+            assert.is_true(usable_count > 0)
+            assert.equal(0, close_count)
         end)
     end)
 
     describe("clear_split_diff", function()
+        it("reports whether it tore down a matching split", function()
+            setup_and_show_split()
+
+            assert.is_false(
+                DiffSplitView.clear_split_diff(diff_state, "/tmp/missing.lua")
+            )
+            assert.is_true(
+                DiffSplitView.clear_split_diff(diff_state, test_file_path)
+            )
+            assert.is_false(
+                DiffSplitView.clear_split_diff(diff_state, test_file_path)
+            )
+        end)
         it("should restore original buffer state and clear state", function()
             local bufnr = vim.fn.bufadd(test_file_path)
 
             local orig_modifiable = vim.bo[bufnr].modifiable
             local orig_modified = vim.bo[bufnr].modified
 
-            DiffSplitView.show_split_diff({
+            show_split({
                 file_path = test_file_path,
                 diff = { old = { "local x = 1" }, new = { "local x = 2" } },
                 get_winid = function()
@@ -366,19 +646,18 @@ describe("DiffSplitView", function()
                 end,
             })
 
-            local tabpage = vim.api.nvim_get_current_tabpage()
-            DiffSplitView.clear_split_diff(tabpage)
+            DiffSplitView.clear_split_diff(diff_state)
 
             assert.equal(orig_modifiable, vim.bo[bufnr].modifiable)
             assert.equal(orig_modified, vim.bo[bufnr].modified)
-            assert.is_nil(DiffSplitView.get_split_state(tabpage))
+            assert.is_nil(DiffSplitView.find_split_state(diff_state))
         end)
 
         it(
             "should handle cleanup when scratch window already closed",
             function()
-                local _, tabpage = setup_and_show_split()
-                local state = DiffSplitView.get_split_state(tabpage)
+                setup_and_show_split()
+                local state = DiffSplitView.find_split_state(diff_state)
 
                 assert.is_not_nil(state)
                 if state then
@@ -386,10 +665,30 @@ describe("DiffSplitView", function()
                 end
 
                 assert.has_no_errors(function()
-                    DiffSplitView.clear_split_diff(tabpage)
+                    DiffSplitView.clear_split_diff(diff_state)
                 end)
-                assert.is_nil(DiffSplitView.get_split_state(tabpage))
+                assert.is_nil(DiffSplitView.find_split_state(diff_state))
             end
         )
+
+        it("skips stale-valid handles whose tabpage is gone", function()
+            setup_and_show_split()
+            local usable_stub = spy_module.stub(BufHelpers, "is_win_usable")
+            usable_stub:returns(false)
+            local win_call_stub = spy_module.stub(vim.api, "nvim_win_call")
+            local close_stub = spy_module.stub(vim.api, "nvim_win_close")
+
+            DiffSplitView.clear_split_diff(diff_state)
+
+            local usable_count = usable_stub.call_count
+            local win_call_count = win_call_stub.call_count
+            local close_count = close_stub.call_count
+            close_stub:revert()
+            win_call_stub:revert()
+            usable_stub:revert()
+            assert.is_true(usable_count > 0)
+            assert.equal(0, win_call_count)
+            assert.equal(0, close_count)
+        end)
     end)
 end)

--- a/lua/agentic/ui/hunk_navigation.lua
+++ b/lua/agentic/ui/hunk_navigation.lua
@@ -17,6 +17,9 @@ local NS_DIFF = M.NS_DIFF
 --- @class agentic.ui.HunkNavigation.State
 --- @field saved_keymaps { next?: table, prev?: table } Saved keymaps for restoration
 --- @field anchors_cache integer[]|nil Cached hunk anchor positions (0-indexed line numbers)
+--- @field saved_keymaps_captured boolean
+--- @field owners { key: string, state: agentic.ui.DiffState|nil }[]
+--- @field owner_lookup table<string, boolean>
 
 --- Module-level state storage (per-buffer)
 --- @type table<number, agentic.ui.HunkNavigation.State>
@@ -30,6 +33,9 @@ local function get_state(bufnr)
         buffer_state[bufnr] = {
             saved_keymaps = {},
             anchors_cache = nil,
+            saved_keymaps_captured = false,
+            owners = {},
+            owner_lookup = {},
         }
     end
     return buffer_state[bufnr]
@@ -106,15 +112,16 @@ end
 --- Find next/previous hunk position relative to buffer's cursor position
 --- @param bufnr number
 --- @param direction "next"|"prev"
+--- @param preferred_winid integer|nil
 --- @return number|nil target_line 1-indexed line number
-local function find_hunk(bufnr, direction)
+local function find_hunk(bufnr, direction, preferred_winid)
     local anchors = M._get_hunk_anchors(bufnr)
     if #anchors == 0 then
         return nil
     end
 
-    local winid = vim.fn.bufwinid(bufnr)
-    if winid == -1 then
+    local winid = BufHelpers.find_visible_win(bufnr, preferred_winid)
+    if not winid then
         return nil
     end
 
@@ -183,44 +190,57 @@ end
 
 --- Navigate to hunk in specified direction
 --- @param bufnr number
+--- @param diff_state agentic.ui.DiffState|nil
+local function find_split_state_for_buf(bufnr, diff_state)
+    local split_states = diff_state and diff_state.split_state
+    if not split_states then
+        return nil
+    end
+    for _, state in pairs(split_states) do
+        if state.original_bufnr == bufnr or state.new_bufnr == bufnr then
+            return state
+        end
+    end
+    return nil
+end
+
 --- @param direction "next"|"prev"
-local function navigate_hunk(bufnr, direction)
-    local target_winid = vim.fn.bufwinid(bufnr)
-    if target_winid == -1 then
+--- @param diff_state agentic.ui.DiffState|nil
+local function navigate_hunk(bufnr, direction, diff_state)
+    local split_state = find_split_state_for_buf(bufnr, diff_state)
+    local painted_winid = diff_state
+        and (
+            diff_state.preview_winid
+            or split_state and split_state.original_winid
+        )
+    local target_winid = BufHelpers.find_visible_win(bufnr, painted_winid)
+    if painted_winid and target_winid ~= painted_winid then
+        return
+    end
+    if not target_winid then
         Logger.notify("Buffer not visible in any window", vim.log.levels.WARN)
         return
     end
 
-    if Config.diff_preview.layout == "split" then
-        local ok, tabpage = pcall(vim.api.nvim_win_get_tabpage, target_winid)
-        if not ok then
-            return
+    if Config.diff_preview.layout == "split" and split_state then
+        local diff_cmd = direction == "next" and "]c" or "[c"
+        local center_cmd = Config.diff_preview.center_on_navigate_hunks and "zz"
+            or ""
+
+        local nav_ok = pcall(vim.api.nvim_win_call, target_winid, function()
+            vim.cmd("normal! " .. diff_cmd .. center_cmd)
+        end)
+
+        if not nav_ok then
+            Logger.notify(
+                "No more hunks in this direction",
+                vim.log.levels.INFO
+            )
         end
-
-        local DiffSplitView = require("agentic.ui.diff_split_view")
-        local split_state = DiffSplitView.get_split_state(tabpage)
-
-        if split_state then
-            local diff_cmd = direction == "next" and "]c" or "[c"
-            local center_cmd = Config.diff_preview.center_on_navigate_hunks
-                    and "zz"
-                or ""
-
-            local nav_ok = pcall(vim.api.nvim_win_call, target_winid, function()
-                vim.cmd("normal! " .. diff_cmd .. center_cmd)
-            end)
-
-            if not nav_ok then
-                Logger.notify(
-                    "No more hunks in this direction",
-                    vim.log.levels.INFO
-                )
-            end
-            return
-        end
+        return
     end
 
-    local target_line = find_hunk(bufnr, direction)
+    local target_line = find_hunk(bufnr, direction, target_winid)
     if not target_line then
         Logger.notify("No hunks found", vim.log.levels.INFO)
         return
@@ -264,70 +284,115 @@ end
 
 --- Navigate to next hunk
 --- @param bufnr number
-function M.navigate_next(bufnr)
-    navigate_hunk(bufnr, "next")
+--- @param diff_state agentic.ui.DiffState|nil
+function M.navigate_next(bufnr, diff_state)
+    navigate_hunk(bufnr, "next", diff_state)
 end
 
 --- Navigate to previous hunk
 --- @param bufnr number
-function M.navigate_prev(bufnr)
-    navigate_hunk(bufnr, "prev")
+--- @param diff_state agentic.ui.DiffState|nil
+function M.navigate_prev(bufnr, diff_state)
+    navigate_hunk(bufnr, "prev", diff_state)
+end
+
+local LEGACY_OWNER = "legacy"
+
+--- @param diff_state agentic.ui.DiffState|nil
+--- @return string key
+local function owner_key(diff_state)
+    return diff_state and tostring(diff_state) or LEGACY_OWNER
+end
+
+--- @param bufnr number
+--- @param diff_state agentic.ui.DiffState|nil
+local function install_agentic_keymaps(bufnr, diff_state)
+    local keymaps = Config.keymaps.diff_preview
+    BufHelpers.keymap_set(bufnr, "n", keymaps.next_hunk, function()
+        M.navigate_next(bufnr, diff_state)
+    end, { desc = "Go to next hunk - " .. M.KEYMAP_DESC_SUFFIX })
+
+    BufHelpers.keymap_set(bufnr, "n", keymaps.prev_hunk, function()
+        M.navigate_prev(bufnr, diff_state)
+    end, { desc = "Go to previous hunk - " .. M.KEYMAP_DESC_SUFFIX })
 end
 
 --- Setup hunk navigation keymaps for buffer
 --- @param bufnr number
-function M.setup_keymaps(bufnr)
+--- @param diff_state agentic.ui.DiffState|nil
+function M.setup_keymaps(bufnr, diff_state)
     local keymaps = Config.keymaps.diff_preview
     local state = get_state(bufnr)
-    state.saved_keymaps.next = save_keymap(bufnr, keymaps.next_hunk)
-    state.saved_keymaps.prev = save_keymap(bufnr, keymaps.prev_hunk)
+    if not state.saved_keymaps_captured then
+        state.saved_keymaps.next = save_keymap(bufnr, keymaps.next_hunk)
+        state.saved_keymaps.prev = save_keymap(bufnr, keymaps.prev_hunk)
+        state.saved_keymaps_captured = true
+    end
 
-    BufHelpers.keymap_set(bufnr, "n", keymaps.next_hunk, function()
-        M.navigate_next(bufnr)
-    end, { desc = "Go to next hunk - " .. M.KEYMAP_DESC_SUFFIX })
-
-    BufHelpers.keymap_set(bufnr, "n", keymaps.prev_hunk, function()
-        M.navigate_prev(bufnr)
-    end, { desc = "Go to previous hunk - " .. M.KEYMAP_DESC_SUFFIX })
+    local key = owner_key(diff_state)
+    if state.owner_lookup[key] then
+        for index, owner in ipairs(state.owners) do
+            if owner.key == key then
+                table.remove(state.owners, index)
+                break
+            end
+        end
+    end
+    state.owners[#state.owners + 1] = { key = key, state = diff_state }
+    state.owner_lookup[key] = true
+    install_agentic_keymaps(bufnr, diff_state)
 end
+
+local RESTORED_KEYMAP_FLAGS = { "noremap", "silent", "expr", "nowait" }
 
 --- Restore saved keymaps for buffer
 --- @param bufnr number
-function M.restore_keymaps(bufnr)
-    local keymaps = Config.keymaps.diff_preview
-    pcall(vim.api.nvim_buf_del_keymap, bufnr, "n", keymaps.next_hunk)
-    pcall(vim.api.nvim_buf_del_keymap, bufnr, "n", keymaps.prev_hunk)
-
+--- @param diff_state agentic.ui.DiffState|nil
+function M.restore_keymaps(bufnr, diff_state)
     local state = buffer_state[bufnr]
-    if state and state.saved_keymaps then
-        for _, saved_map in pairs(state.saved_keymaps) do
-            if saved_map and saved_map.lhs then
-                -- No `buffer` key: `BufHelpers.keymap_set` sets the scope itself,
-                -- and on 0.12.1+ both keys together raise "Conflict: 'buf' not
-                -- allowed with 'buffer'", silently swallowed by the pcall below.
-                local opts = {}
-                if saved_map.noremap == 1 then
-                    opts.noremap = true
-                end
-                if saved_map.silent == 1 then
-                    opts.silent = true
-                end
-                if saved_map.expr == 1 then
-                    opts.expr = true
-                end
-                if saved_map.nowait == 1 then
-                    opts.nowait = true
-                end
+    if not state then
+        return
+    end
 
-                pcall(
-                    BufHelpers.keymap_set,
-                    bufnr,
-                    "n",
-                    saved_map.lhs,
-                    saved_map.callback or saved_map.rhs,
-                    opts
-                )
+    local key = owner_key(diff_state)
+    if not state.owner_lookup[key] then
+        return
+    end
+    state.owner_lookup[key] = nil
+    for index, owner in ipairs(state.owners) do
+        if owner.key == key then
+            table.remove(state.owners, index)
+            break
+        end
+    end
+
+    local keymaps = Config.keymaps.diff_preview
+    BufHelpers.keymap_del(bufnr, "n", keymaps.next_hunk)
+    BufHelpers.keymap_del(bufnr, "n", keymaps.prev_hunk)
+
+    local last_owner = state.owners[#state.owners]
+    if last_owner then
+        install_agentic_keymaps(bufnr, last_owner.state)
+        return
+    end
+
+    for _, saved_map in pairs(state.saved_keymaps) do
+        if saved_map and saved_map.lhs then
+            --- @type vim.keymap.set.Opts
+            local opts = {}
+            for _, flag in ipairs(RESTORED_KEYMAP_FLAGS) do
+                if saved_map[flag] == 1 then
+                    opts[flag] = true
+                end
             end
+            pcall(
+                BufHelpers.keymap_set,
+                bufnr,
+                "n",
+                saved_map.lhs,
+                saved_map.callback or saved_map.rhs,
+                opts
+            )
         end
     end
 

--- a/lua/agentic/ui/hunk_navigation.lua
+++ b/lua/agentic/ui/hunk_navigation.lua
@@ -208,13 +208,25 @@ end
 --- @param diff_state agentic.ui.DiffState|nil
 local function navigate_hunk(bufnr, direction, diff_state)
     local split_state = find_split_state_for_buf(bufnr, diff_state)
-    local painted_winid = diff_state
-        and (
-            diff_state.preview_winid
-            or split_state and split_state.original_winid
-        )
+    local painted_winid
+    if diff_state then
+        if split_state then
+            painted_winid = split_state.original_bufnr == bufnr
+                    and split_state.original_winid
+                or split_state.new_winid
+        elseif diff_state.preview_bufnr == bufnr then
+            painted_winid = diff_state.preview_winid
+        else
+            return
+        end
+
+        if not painted_winid then
+            return
+        end
+    end
+
     local target_winid = BufHelpers.find_visible_win(bufnr, painted_winid)
-    if painted_winid and target_winid ~= painted_winid then
+    if diff_state and target_winid ~= painted_winid then
         return
     end
     if not target_winid then

--- a/lua/agentic/ui/hunk_navigation.lua
+++ b/lua/agentic/ui/hunk_navigation.lua
@@ -343,7 +343,7 @@ function M.setup_keymaps(bufnr, diff_state)
     install_agentic_keymaps(bufnr, diff_state)
 end
 
-local RESTORED_KEYMAP_FLAGS = { "noremap", "silent", "expr", "nowait" }
+local RESTORED_KEYMAP_FLAGS = { "silent", "expr", "nowait" }
 
 --- Restore saved keymaps for buffer
 --- @param bufnr number
@@ -379,7 +379,7 @@ function M.restore_keymaps(bufnr, diff_state)
     for _, saved_map in pairs(state.saved_keymaps) do
         if saved_map and saved_map.lhs then
             --- @type vim.keymap.set.Opts
-            local opts = {}
+            local opts = { remap = saved_map.noremap == 0 }
             for _, flag in ipairs(RESTORED_KEYMAP_FLAGS) do
                 if saved_map[flag] == 1 then
                     opts[flag] = true

--- a/lua/agentic/ui/hunk_navigation.test.lua
+++ b/lua/agentic/ui/hunk_navigation.test.lua
@@ -1,6 +1,7 @@
 local assert = require("tests.helpers.assert")
 local spy_module = require("tests.helpers.spy")
 local BufHelpers = require("agentic.utils.buf_helpers")
+local AgenticConfig = require("agentic.config")
 local HunkNavigation = require("agentic.ui.hunk_navigation")
 local Theme = require("agentic.theme")
 
@@ -151,14 +152,36 @@ describe("hunk_navigation", function()
 
     describe("navigation", function()
         local winid
+        local base_tabs
+        local saved_layout
+        local win_call_stub
 
         before_each(function()
+            base_tabs = {}
+            for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+                base_tabs[tabpage] = true
+            end
+            saved_layout = AgenticConfig.diff_preview.layout
+            win_call_stub = nil
             vim.cmd("buffer " .. test_bufnr)
             winid = vim.api.nvim_get_current_win()
             HunkNavigation.setup_keymaps(test_bufnr)
         end)
 
         after_each(function()
+            if win_call_stub then
+                win_call_stub:revert()
+                win_call_stub = nil
+            end
+            AgenticConfig.diff_preview.layout = saved_layout
+            for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+                if not base_tabs[tabpage] then
+                    pcall(function()
+                        vim.api.nvim_set_current_tabpage(tabpage)
+                        vim.cmd("tabclose!")
+                    end)
+                end
+            end
             HunkNavigation.clear_state(test_bufnr)
         end)
 
@@ -206,13 +229,11 @@ describe("hunk_navigation", function()
 
         it("uses the painted window from the provided owner state", function()
             vim.cmd("tabnew")
-            local owner_tab = vim.api.nvim_get_current_tabpage()
             local owner_win = vim.api.nvim_get_current_win()
             vim.api.nvim_win_set_buf(owner_win, test_bufnr)
             vim.api.nvim_win_set_cursor(owner_win, { 1, 0 })
 
             vim.cmd("tabnew")
-            local foreign_tab = vim.api.nvim_get_current_tabpage()
             local foreign_win = vim.api.nvim_get_current_win()
             vim.api.nvim_win_set_buf(foreign_win, test_bufnr)
             vim.api.nvim_win_set_cursor(foreign_win, { 1, 0 })
@@ -225,13 +246,6 @@ describe("hunk_navigation", function()
 
             assert.equal(11, vim.api.nvim_win_get_cursor(owner_win)[1])
             assert.equal(1, vim.api.nvim_win_get_cursor(foreign_win)[1])
-
-            vim.api.nvim_set_current_tabpage(foreign_tab)
-            vim.cmd("tabclose!")
-            if vim.api.nvim_tabpage_is_valid(owner_tab) then
-                vim.api.nvim_set_current_tabpage(owner_tab)
-                vim.cmd("tabclose!")
-            end
         end)
 
         it(
@@ -246,6 +260,7 @@ describe("hunk_navigation", function()
         )
 
         it("prefers an owned split window over the inline preview", function()
+            AgenticConfig.diff_preview.layout = "split"
             local preview_bufnr = vim.api.nvim_create_buf(false, true)
             vim.api.nvim_buf_set_lines(
                 preview_bufnr,
@@ -259,7 +274,7 @@ describe("hunk_navigation", function()
                 false,
                 { split = "right", win = winid }
             )
-            local win_call_stub = spy_module.stub(vim.api, "nvim_win_call")
+            win_call_stub = spy_module.stub(vim.api, "nvim_win_call")
             add_hunk(test_bufnr, test_ns, 10)
 
             HunkNavigation.navigate_next(test_bufnr, {
@@ -278,10 +293,13 @@ describe("hunk_navigation", function()
 
             local called_winid = win_call_stub.calls[1]
                 and win_call_stub.calls[1][1]
+            local win_call_count = win_call_stub.call_count
             win_call_stub:revert()
+            win_call_stub = nil
             pcall(vim.api.nvim_win_close, preview_winid, true)
             pcall(vim.api.nvim_buf_delete, preview_bufnr, { force = true })
 
+            assert.equal(1, win_call_count)
             assert.equal(winid, called_winid)
         end)
 

--- a/lua/agentic/ui/hunk_navigation.test.lua
+++ b/lua/agentic/ui/hunk_navigation.test.lua
@@ -496,6 +496,25 @@ describe("hunk_navigation", function()
             assert.equal(1, restored.nowait)
         end)
 
+        it("restores a recursive mapping with its other flags", function()
+            BufHelpers.keymap_set(
+                test_bufnr,
+                "n",
+                "<leader>hn",
+                "v:count",
+                { remap = true, silent = true, expr = true, nowait = true }
+            )
+
+            HunkNavigation.setup_keymaps(test_bufnr, nil)
+            HunkNavigation.restore_keymaps(test_bufnr, nil)
+
+            local restored = get_keymap_in_buf(test_bufnr, "<leader>hn")
+            assert.equal(0, restored.noremap)
+            assert.equal(1, restored.silent)
+            assert.equal(1, restored.expr)
+            assert.equal(1, restored.nowait)
+        end)
+
         it(
             "keeps the newer owner callback when the older owner clears",
             function()

--- a/lua/agentic/ui/hunk_navigation.test.lua
+++ b/lua/agentic/ui/hunk_navigation.test.lua
@@ -1,4 +1,5 @@
 local assert = require("tests.helpers.assert")
+local spy_module = require("tests.helpers.spy")
 local BufHelpers = require("agentic.utils.buf_helpers")
 local HunkNavigation = require("agentic.ui.hunk_navigation")
 local Theme = require("agentic.theme")
@@ -203,6 +204,36 @@ describe("hunk_navigation", function()
             assert.equal(cursor[2], 0)
         end)
 
+        it("uses the painted window from the provided owner state", function()
+            vim.cmd("tabnew")
+            local owner_tab = vim.api.nvim_get_current_tabpage()
+            local owner_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(owner_win, test_bufnr)
+            vim.api.nvim_win_set_cursor(owner_win, { 1, 0 })
+
+            vim.cmd("tabnew")
+            local foreign_tab = vim.api.nvim_get_current_tabpage()
+            local foreign_win = vim.api.nvim_get_current_win()
+            vim.api.nvim_win_set_buf(foreign_win, test_bufnr)
+            vim.api.nvim_win_set_cursor(foreign_win, { 1, 0 })
+            add_hunk(test_bufnr, test_ns, 10)
+
+            HunkNavigation.navigate_next(test_bufnr, {
+                preview_bufnr = test_bufnr,
+                preview_winid = owner_win,
+            })
+
+            assert.equal(11, vim.api.nvim_win_get_cursor(owner_win)[1])
+            assert.equal(1, vim.api.nvim_win_get_cursor(foreign_win)[1])
+
+            vim.api.nvim_set_current_tabpage(foreign_tab)
+            vim.cmd("tabclose!")
+            if vim.api.nvim_tabpage_is_valid(owner_tab) then
+                vim.api.nvim_set_current_tabpage(owner_tab)
+                vim.cmd("tabclose!")
+            end
+        end)
+
         it(
             "navigates prev to closest hunk when cursor is between hunks",
             function()
@@ -405,6 +436,135 @@ describe("hunk_navigation", function()
                 assert.equal(after_next.rhs, original_rhs)
             end
             assert.equal(next(after_prev), nil)
+        end)
+
+        it("preserves the original keymap across repeated setup", function()
+            BufHelpers.keymap_set(
+                test_bufnr,
+                "n",
+                "<leader>hn",
+                ":echo 'original'<CR>"
+            )
+            local original = get_keymap_in_buf(test_bufnr, "<leader>hn").rhs
+
+            HunkNavigation.setup_keymaps(test_bufnr, nil)
+            HunkNavigation.setup_keymaps(test_bufnr, nil)
+            HunkNavigation.restore_keymaps(test_bufnr, nil)
+
+            assert.equal(
+                original,
+                get_keymap_in_buf(test_bufnr, "<leader>hn").rhs
+            )
+        end)
+
+        it("keeps one entry for repeated setup by the same owner", function()
+            BufHelpers.keymap_set(
+                test_bufnr,
+                "n",
+                "<leader>hn",
+                ":echo 'original'<CR>"
+            )
+            --- @type agentic.ui.DiffState
+            local state = {}
+
+            HunkNavigation.setup_keymaps(test_bufnr, state)
+            HunkNavigation.setup_keymaps(test_bufnr, state)
+            HunkNavigation.restore_keymaps(test_bufnr, state)
+
+            assert.equal(
+                ":echo 'original'<CR>",
+                get_keymap_in_buf(test_bufnr, "<leader>hn").rhs
+            )
+        end)
+
+        it("restores noremap silent expr and nowait", function()
+            BufHelpers.keymap_set(
+                test_bufnr,
+                "n",
+                "<leader>hn",
+                "v:count",
+                { noremap = true, silent = true, expr = true, nowait = true }
+            )
+
+            HunkNavigation.setup_keymaps(test_bufnr, nil)
+            HunkNavigation.restore_keymaps(test_bufnr, nil)
+
+            local restored = get_keymap_in_buf(test_bufnr, "<leader>hn")
+            assert.equal(1, restored.noremap)
+            assert.equal(1, restored.silent)
+            assert.equal(1, restored.expr)
+            assert.equal(1, restored.nowait)
+        end)
+
+        it(
+            "keeps the newer owner callback when the older owner clears",
+            function()
+                --- @type agentic.ui.DiffState
+                local older = {}
+                --- @type agentic.ui.DiffState
+                local newer = {}
+                local navigate_spy =
+                    spy_module.on(HunkNavigation, "navigate_next")
+
+                HunkNavigation.setup_keymaps(test_bufnr, older)
+                HunkNavigation.setup_keymaps(test_bufnr, newer)
+                HunkNavigation.restore_keymaps(test_bufnr, older)
+
+                local mapping = get_keymap_in_buf(test_bufnr, "<leader>hn")
+                assert.equal("function", type(mapping.callback))
+                mapping.callback()
+                assert.spy(navigate_spy).was.called_with(test_bufnr, newer)
+                navigate_spy:revert()
+            end
+        )
+
+        it(
+            "reinstalls the older owner callback when the newer owner clears",
+            function()
+                --- @type agentic.ui.DiffState
+                local older = {}
+                --- @type agentic.ui.DiffState
+                local newer = {}
+                local navigate_spy =
+                    spy_module.on(HunkNavigation, "navigate_next")
+
+                HunkNavigation.setup_keymaps(test_bufnr, older)
+                HunkNavigation.setup_keymaps(test_bufnr, newer)
+                HunkNavigation.restore_keymaps(test_bufnr, newer)
+
+                local mapping = get_keymap_in_buf(test_bufnr, "<leader>hn")
+                assert.equal("function", type(mapping.callback))
+                mapping.callback()
+                assert.spy(navigate_spy).was.called_with(test_bufnr, older)
+                navigate_spy:revert()
+            end
+        )
+
+        it("restores the user mapping after the final owner clears", function()
+            BufHelpers.keymap_set(
+                test_bufnr,
+                "n",
+                "<leader>hn",
+                ":echo 'user'<CR>"
+            )
+            --- @type agentic.ui.DiffState
+            local first = {}
+            --- @type agentic.ui.DiffState
+            local second = {}
+
+            HunkNavigation.setup_keymaps(test_bufnr, first)
+            HunkNavigation.setup_keymaps(test_bufnr, second)
+            HunkNavigation.restore_keymaps(test_bufnr, first)
+            assert.is_not.equal(
+                ":echo 'user'<CR>",
+                get_keymap_in_buf(test_bufnr, "<leader>hn").rhs
+            )
+            HunkNavigation.restore_keymaps(test_bufnr, second)
+
+            assert.equal(
+                ":echo 'user'<CR>",
+                get_keymap_in_buf(test_bufnr, "<leader>hn").rhs
+            )
         end)
 
         it("clears state after restore", function()

--- a/lua/agentic/ui/hunk_navigation.test.lua
+++ b/lua/agentic/ui/hunk_navigation.test.lua
@@ -235,6 +235,57 @@ describe("hunk_navigation", function()
         end)
 
         it(
+            "does not navigate a buffer unowned by the provided state",
+            function()
+                add_hunk(test_bufnr, test_ns, 10)
+
+                HunkNavigation.navigate_next(test_bufnr, {})
+
+                assert.equal(1, vim.api.nvim_win_get_cursor(winid)[1])
+            end
+        )
+
+        it("prefers an owned split window over the inline preview", function()
+            local preview_bufnr = vim.api.nvim_create_buf(false, true)
+            vim.api.nvim_buf_set_lines(
+                preview_bufnr,
+                0,
+                -1,
+                false,
+                { "preview" }
+            )
+            local preview_winid = vim.api.nvim_open_win(
+                preview_bufnr,
+                false,
+                { split = "right", win = winid }
+            )
+            local win_call_stub = spy_module.stub(vim.api, "nvim_win_call")
+            add_hunk(test_bufnr, test_ns, 10)
+
+            HunkNavigation.navigate_next(test_bufnr, {
+                preview_bufnr = preview_bufnr,
+                preview_winid = preview_winid,
+                split_state = {
+                    ["/tmp/owned-split.lua"] = {
+                        original_bufnr = test_bufnr,
+                        original_winid = winid,
+                        new_bufnr = preview_bufnr,
+                        new_winid = preview_winid,
+                        file_path = "/tmp/owned-split.lua",
+                    },
+                },
+            })
+
+            local called_winid = win_call_stub.calls[1]
+                and win_call_stub.calls[1][1]
+            win_call_stub:revert()
+            pcall(vim.api.nvim_win_close, preview_winid, true)
+            pcall(vim.api.nvim_buf_delete, preview_bufnr, { force = true })
+
+            assert.equal(winid, called_winid)
+        end)
+
+        it(
             "navigates prev to closest hunk when cursor is between hunks",
             function()
                 add_hunk(test_bufnr, test_ns, 1)

--- a/lua/agentic/ui/widget_layout.lua
+++ b/lua/agentic/ui/widget_layout.lua
@@ -181,6 +181,7 @@ local function get_or_create_window(
         if ok and cached_tabpage == tab_page_id then
             return cached_winid
         end
+        win_nrs[panel_name] = nil
         pcall(vim.api.nvim_win_close, cached_winid, true)
     end
 
@@ -223,8 +224,8 @@ local function open_or_resize_dynamic_window(
         local ok, win_tabpage = pcall(vim.api.nvim_win_get_tabpage, winid)
         reusable = ok and win_tabpage == tab_page_id
         if not reusable then
-            pcall(vim.api.nvim_win_close, winid, true)
             win_nrs[window_name] = nil
+            pcall(vim.api.nvim_win_close, winid, true)
         end
     end
 

--- a/lua/agentic/ui/widget_layout.lua
+++ b/lua/agentic/ui/widget_layout.lua
@@ -164,17 +164,24 @@ end
 --- @param bufnr integer
 --- @param open_opts vim.api.keyset.win_config
 --- @param win_opts table<string, any>
+--- @param tab_page_id integer
 --- @return integer
 local function get_or_create_window(
     win_nrs,
     panel_name,
     bufnr,
     open_opts,
-    win_opts
+    win_opts,
+    tab_page_id
 )
     local cached_winid = win_nrs[panel_name]
-    if cached_winid and vim.api.nvim_win_is_valid(cached_winid) then
-        return cached_winid
+    if cached_winid and BufHelpers.is_win_usable(cached_winid) then
+        local ok, cached_tabpage =
+            pcall(vim.api.nvim_win_get_tabpage, cached_winid)
+        if ok and cached_tabpage == tab_page_id then
+            return cached_winid
+        end
+        pcall(vim.api.nvim_win_close, cached_winid, true)
     end
 
     local new_winid =
@@ -190,26 +197,38 @@ end
 --- @param open_win_opts vim.api.keyset.win_config
 --- @param max_height integer
 --- @param position agentic.UserConfig.Windows.Position
+--- @param tab_page_id integer
 local function open_or_resize_dynamic_window(
     buf_nrs,
     win_nrs,
     window_name,
     open_win_opts,
     max_height,
-    position
+    position,
+    tab_page_id
 )
     local bufnr = buf_nrs[window_name]
     local winid = win_nrs[window_name]
 
     if BufHelpers.is_buffer_empty(bufnr) then
-        if winid and vim.api.nvim_win_is_valid(winid) then
+        if winid and BufHelpers.is_win_usable(winid) then
             pcall(vim.api.nvim_win_close, winid, true)
         end
         win_nrs[window_name] = nil
         return
     end
 
-    if not winid or not vim.api.nvim_win_is_valid(winid) then
+    local reusable = false
+    if winid and BufHelpers.is_win_usable(winid) then
+        local ok, win_tabpage = pcall(vim.api.nvim_win_get_tabpage, winid)
+        reusable = ok and win_tabpage == tab_page_id
+        if not reusable then
+            pcall(vim.api.nvim_win_close, winid, true)
+            win_nrs[window_name] = nil
+        end
+    end
+
+    if not reusable then
         -- Open at min height first so we can measure wrapped rows against the
         -- real window width, then resize. ADR 0001 uses the same pattern for
         -- screen-row math (fold sizing). Buffer-line count understates wraps.
@@ -218,6 +237,7 @@ local function open_or_resize_dynamic_window(
         win_nrs[window_name] = winid
     end
 
+    ---@cast winid integer
     local height = calculate_dynamic_height(winid, bufnr, max_height, position)
     vim.api.nvim_win_set_config(winid, { height = height })
 
@@ -255,7 +275,7 @@ local function show_layout(params, position)
         winhighlight = CHAT_GUTTER_WINHIGHLIGHT,
         winfixheight = is_bottom,
         winfixwidth = not is_bottom,
-    })
+    }, params.tab_page_id)
 
     Fold.setup_window(win_nrs.chat, buf_nrs.chat)
 
@@ -274,14 +294,19 @@ local function show_layout(params, position)
         input_opts.height = Config.windows.input.height
     end
 
-    get_or_create_window(win_nrs, "input", buf_nrs.input, input_opts, {
-        winfixheight = not is_bottom,
-    })
+    get_or_create_window(
+        win_nrs,
+        "input",
+        buf_nrs.input,
+        input_opts,
+        { winfixheight = not is_bottom },
+        params.tab_page_id
+    )
 
     open_or_resize_dynamic_window(buf_nrs, win_nrs, "code", {
         win = is_bottom and win_nrs.input or win_nrs.chat,
         split = "below",
-    }, Config.windows.code.max_height, position)
+    }, Config.windows.code.max_height, position, params.tab_page_id)
 
     local ref_win = is_bottom and (win_nrs.code or win_nrs.input)
         or win_nrs.input
@@ -289,7 +314,7 @@ local function show_layout(params, position)
     open_or_resize_dynamic_window(buf_nrs, win_nrs, "files", {
         win = ref_win,
         split = is_bottom and "below" or "above",
-    }, Config.windows.files.max_height, position)
+    }, Config.windows.files.max_height, position, params.tab_page_id)
 
     ref_win = is_bottom and (win_nrs.files or win_nrs.code or win_nrs.input)
         or win_nrs.input
@@ -297,7 +322,7 @@ local function show_layout(params, position)
     open_or_resize_dynamic_window(buf_nrs, win_nrs, "diagnostics", {
         win = ref_win,
         split = is_bottom and "below" or "above",
-    }, Config.windows.diagnostics.max_height, position)
+    }, Config.windows.diagnostics.max_height, position, params.tab_page_id)
 
     if Config.windows.todos.display then
         ref_win = is_bottom
@@ -307,13 +332,17 @@ local function show_layout(params, position)
         open_or_resize_dynamic_window(buf_nrs, win_nrs, "todos", {
             win = ref_win,
             split = "below",
-        }, Config.windows.todos.max_height, position)
+        }, Config.windows.todos.max_height, position, params.tab_page_id)
     end
 
     if should_focus then
         vim.schedule(function()
             local winid = win_nrs.input
-            if winid and vim.api.nvim_win_is_valid(winid) then
+            if
+                vim.api.nvim_get_current_tabpage() == params.tab_page_id
+                and winid
+                and BufHelpers.is_win_usable(winid)
+            then
                 vim.api.nvim_set_current_win(winid)
                 BufHelpers.start_insert_on_last_char()
             end
@@ -399,16 +428,8 @@ end
 function WidgetLayout.close(win_nrs)
     for name, winid in pairs(win_nrs) do
         win_nrs[name] = nil
-        if vim.api.nvim_win_is_valid(winid) then
-            -- Guard: verify the window's tabpage is still valid.
-            -- On Neovim v0.11.5 Linux, tabclose can leave window
-            -- handles in a partially-freed state where
-            -- nvim_win_is_valid() returns true but nvim_win_close()
-            -- segfaults. Checking the tabpage avoids this.
-            local tab_ok, win_tab = pcall(vim.api.nvim_win_get_tabpage, winid)
-            if tab_ok and vim.api.nvim_tabpage_is_valid(win_tab) then
-                pcall(vim.api.nvim_win_close, winid, true)
-            end
+        if BufHelpers.is_win_usable(winid) then
+            pcall(vim.api.nvim_win_close, winid, true)
         end
     end
 end
@@ -426,12 +447,12 @@ function WidgetLayout.close_optional_window(win_nrs, window_name, position)
     if
         position == "bottom"
         and chat_winid
-        and vim.api.nvim_win_is_valid(chat_winid)
+        and BufHelpers.is_win_usable(chat_winid)
     then
         chat_height = vim.api.nvim_win_get_height(chat_winid)
     end
 
-    if winid and vim.api.nvim_win_is_valid(winid) then
+    if winid and BufHelpers.is_win_usable(winid) then
         pcall(vim.api.nvim_win_close, winid, true)
     end
     win_nrs[window_name] = nil

--- a/lua/agentic/ui/widget_layout.test.lua
+++ b/lua/agentic/ui/widget_layout.test.lua
@@ -4,6 +4,7 @@ local WidgetLayout = require("agentic.ui.widget_layout")
 local Config = require("agentic.config")
 local Logger = require("agentic.utils.logger")
 local ToolBlockBorder = require("agentic.ui.tool_block_border")
+local BufHelpers = require("agentic.utils.buf_helpers")
 
 describe("WidgetLayout", function()
     local notify_stub
@@ -552,5 +553,101 @@ describe("WidgetLayout", function()
                 end
             )
         end)
+    end)
+end)
+
+describe("WidgetLayout deferred window guards", function()
+    local schedule_stub
+    local scheduled
+    local base_tabs
+
+    --- @return agentic.ui.ChatWidget.BufNrs
+    local function make_buffers()
+        return {
+            chat = vim.api.nvim_create_buf(false, true),
+            input = vim.api.nvim_create_buf(false, true),
+            code = vim.api.nvim_create_buf(false, true),
+            files = vim.api.nvim_create_buf(false, true),
+            diagnostics = vim.api.nvim_create_buf(false, true),
+            todos = vim.api.nvim_create_buf(false, true),
+        }
+    end
+
+    before_each(function()
+        base_tabs = {}
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            base_tabs[tabpage] = true
+        end
+        scheduled = nil
+        schedule_stub = spy.stub(vim, "schedule")
+        schedule_stub:invokes(function(callback)
+            scheduled = callback
+        end)
+    end)
+
+    after_each(function()
+        schedule_stub:revert()
+        for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
+            if not base_tabs[tabpage] then
+                pcall(function()
+                    vim.api.nvim_set_current_tabpage(tabpage)
+                    vim.cmd("tabclose!")
+                end)
+            end
+        end
+    end)
+
+    it("replaces a cached handle owned by another tabpage", function()
+        vim.cmd("tabnew")
+        local foreign_win = vim.api.nvim_get_current_win()
+        vim.cmd("tabnew")
+        local owner_tab = vim.api.nvim_get_current_tabpage()
+        local win_nrs = { chat = foreign_win }
+
+        WidgetLayout.open({
+            tab_page_id = owner_tab,
+            buf_nrs = make_buffers(),
+            win_nrs = win_nrs,
+            position = "right",
+            focus_prompt = false,
+        })
+
+        assert.is_not.equal(foreign_win, win_nrs.chat)
+        assert.equal(owner_tab, vim.api.nvim_win_get_tabpage(win_nrs.chat))
+    end)
+
+    it("does not focus input after the current tab changes", function()
+        vim.cmd("tabnew")
+        local owner_tab = vim.api.nvim_get_current_tabpage()
+        local win_nrs = {}
+        WidgetLayout.open({
+            tab_page_id = owner_tab,
+            buf_nrs = make_buffers(),
+            win_nrs = win_nrs,
+            position = "right",
+            focus_prompt = true,
+        })
+        assert.equal("function", type(scheduled))
+
+        vim.cmd("tabnew")
+        local foreign_tab = vim.api.nvim_get_current_tabpage()
+        scheduled()
+
+        assert.equal(foreign_tab, vim.api.nvim_get_current_tabpage())
+    end)
+
+    it("gates close through window usability", function()
+        vim.cmd("tabnew")
+        local winid = vim.api.nvim_get_current_win()
+        local usable_stub = spy.stub(BufHelpers, "is_win_usable")
+        usable_stub:returns(false)
+        local close_stub = spy.stub(vim.api, "nvim_win_close")
+
+        WidgetLayout.close({ chat = winid })
+
+        assert.spy(usable_stub).was.called_with(winid)
+        assert.spy(close_stub).was.called(0)
+        usable_stub:revert()
+        close_stub:revert()
     end)
 end)

--- a/lua/agentic/ui/widget_layout.test.lua
+++ b/lua/agentic/ui/widget_layout.test.lua
@@ -560,6 +560,7 @@ describe("WidgetLayout deferred window guards", function()
     local schedule_stub
     local scheduled
     local base_tabs
+    local base_bufs
 
     --- @return agentic.ui.ChatWidget.BufNrs
     local function make_buffers()
@@ -578,6 +579,10 @@ describe("WidgetLayout deferred window guards", function()
         for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
             base_tabs[tabpage] = true
         end
+        base_bufs = {}
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            base_bufs[bufnr] = true
+        end
         scheduled = nil
         schedule_stub = spy.stub(vim, "schedule")
         schedule_stub:invokes(function(callback)
@@ -595,6 +600,18 @@ describe("WidgetLayout deferred window guards", function()
                 end)
             end
         end
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            if not base_bufs[bufnr] and vim.api.nvim_buf_is_valid(bufnr) then
+                pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+            end
+        end
+        local extra_bufs = 0
+        for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+            if not base_bufs[bufnr] then
+                extra_bufs = extra_bufs + 1
+            end
+        end
+        assert.equal(0, extra_bufs)
     end)
 
     it("replaces a cached handle owned by another tabpage", function()
@@ -634,6 +651,28 @@ describe("WidgetLayout deferred window guards", function()
         scheduled()
 
         assert.equal(foreign_tab, vim.api.nvim_get_current_tabpage())
+    end)
+
+    it("does not focus input after the owner tab closes", function()
+        vim.cmd("tabnew")
+        local owner_tab = vim.api.nvim_get_current_tabpage()
+        local win_nrs = {}
+        WidgetLayout.open({
+            tab_page_id = owner_tab,
+            buf_nrs = make_buffers(),
+            win_nrs = win_nrs,
+            position = "right",
+            focus_prompt = true,
+        })
+        assert.equal("function", type(scheduled))
+
+        vim.cmd("tabclose!")
+        local safe_tab = vim.api.nvim_get_current_tabpage()
+        local safe_win = vim.api.nvim_get_current_win()
+        scheduled()
+
+        assert.equal(safe_tab, vim.api.nvim_get_current_tabpage())
+        assert.equal(safe_win, vim.api.nvim_get_current_win())
     end)
 
     it("gates close through window usability", function()

--- a/lua/agentic/ui/widget_layout.test.lua
+++ b/lua/agentic/ui/widget_layout.test.lua
@@ -561,6 +561,8 @@ describe("WidgetLayout deferred window guards", function()
     local scheduled
     local base_tabs
     local base_bufs
+    local usable_stub
+    local close_stub
 
     --- @return agentic.ui.ChatWidget.BufNrs
     local function make_buffers()
@@ -580,6 +582,8 @@ describe("WidgetLayout deferred window guards", function()
             base_tabs[tabpage] = true
         end
         base_bufs = {}
+        usable_stub = nil
+        close_stub = nil
         for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
             base_bufs[bufnr] = true
         end
@@ -591,6 +595,14 @@ describe("WidgetLayout deferred window guards", function()
     end)
 
     after_each(function()
+        if close_stub then
+            close_stub:revert()
+            close_stub = nil
+        end
+        if usable_stub then
+            usable_stub:revert()
+            usable_stub = nil
+        end
         schedule_stub:revert()
         for _, tabpage in ipairs(vim.api.nvim_list_tabpages()) do
             if not base_tabs[tabpage] then
@@ -678,15 +690,19 @@ describe("WidgetLayout deferred window guards", function()
     it("gates close through window usability", function()
         vim.cmd("tabnew")
         local winid = vim.api.nvim_get_current_win()
-        local usable_stub = spy.stub(BufHelpers, "is_win_usable")
+        usable_stub = spy.stub(BufHelpers, "is_win_usable")
         usable_stub:returns(false)
-        local close_stub = spy.stub(vim.api, "nvim_win_close")
+        close_stub = spy.stub(vim.api, "nvim_win_close")
 
         WidgetLayout.close({ chat = winid })
 
-        assert.spy(usable_stub).was.called_with(winid)
-        assert.spy(close_stub).was.called(0)
-        usable_stub:revert()
+        local usable_called = usable_stub:called_with(winid)
+        local close_count = close_stub.call_count
         close_stub:revert()
+        close_stub = nil
+        usable_stub:revert()
+        usable_stub = nil
+        assert.is_true(usable_called)
+        assert.equal(0, close_count)
     end)
 end)


### PR DESCRIPTION
- Isolate diff state per coordinator
- Preserve concurrent preview ownership
- Restore user mappings after cleanup
- Guard deferred window focus
- Verify with `make validate`
