### PR TITLE
docs(adr): remove commit SHA references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,8 @@ not a trigger.
 
 `grill-with-docs` skill ships a minimal ADR template. Path + 4-digit numbering
 match this repo; the template does NOT. Use `docs/adr/README.md` verbatim. Keep
-the `Rejected / superseded alternatives` table and `Changelog`.
+the `Rejected / superseded alternatives` table and `Changelog`. Changelog rows
+contain only the date and change summary.
 
 `CONTEXT.md`: glossary only, no implementation. Populate incrementally as
 overloaded terms surface. Not a spec, scratchpad, or design doc.

--- a/docs/adr/0001-tool-call-folding.md
+++ b/docs/adr/0001-tool-call-folding.md
@@ -2,7 +2,6 @@
 
 - Status: accepted
 - Last updated: 2026-07-29
-- Commits: dc33d56, 28cb6ff
 - Related: PR #197, PR #210, discussion #212
 
 ## Context
@@ -97,7 +96,7 @@ anchor pads as provider output, so it counts toward `Fold.should_fold`.
 
 | Option                                                                             | Reason rejected                                                                                               |
 | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `foldmethod=expr` (initial impl, dc33d56)                                          | Lazy cache + `zb` race produced viewport flicker on every body that crossed the threshold.                    |
+| `foldmethod=expr` (initial implementation)                                         | Lazy cache + `zb` race produced viewport flicker on every body that crossed the threshold.                    |
 | `foldexpr` + `zX` to force recompute                                               | Only synchronous recompute. O(N) per transition; resets `foldlevel=0` and closes user-opened folds elsewhere. |
 | `vim.fn.foldlevel(L)` / `foldclosed(L)`                                            | Passive cache reads. Do not trigger eval. Verified empirically.                                               |
 | Self-reassign `foldexpr` to invalidate cache (`vim.wo.foldexpr = vim.wo.foldexpr`) | Invalidates cached entries only; new uncached lines stay unfolded.                                            |
@@ -120,14 +119,14 @@ Our case (live transitions on growing blocks) is the harder variant.
 
 ## Changelog
 
-| Date       | Commit  | Change                                         |
-| ---------- | ------- | ---------------------------------------------- |
-| 2026-04-18 | dc33d56 | Initial: foldexpr + threshold + foldtext.      |
-| 2026-04-29 | 28cb6ff | Manual folds + anchor pads + sync scroll.      |
-| 2026-04-29 | 28cb6ff | Hidden chat float preserves fold state.        |
-| 2026-05-03 | -       | Screen-row folding; sync dimensions/wrap.      |
-| 2026-05-15 | -       | Long-title body counts inside body fold range. |
-| 2026-07-29 |         | Document configured-versus-visible widths.     |
+| Date       | Change                                         |
+| ---------- | ---------------------------------------------- |
+| 2026-04-18 | Initial: foldexpr + threshold + foldtext.      |
+| 2026-04-29 | Manual folds + anchor pads + sync scroll.      |
+| 2026-04-29 | Hidden chat float preserves fold state.        |
+| 2026-05-03 | Screen-row folding; sync dimensions/wrap.      |
+| 2026-05-15 | Long-title body counts inside body fold range. |
+| 2026-07-29 | Document configured-versus-visible widths.     |
 
 ## Sources
 

--- a/docs/adr/0002-tool-call-borders.md
+++ b/docs/adr/0002-tool-call-borders.md
@@ -2,7 +2,6 @@
 
 - Status: accepted
 - Last updated: 2026-04-30
-- Commits: 8ff45f2, d3cd47a, 1f3cde6
 - Related: PR #215, issue #196, issue #211, neovim/neovim#35341
 
 ## Context
@@ -41,8 +40,8 @@ lives in `glyph_for_line`, range lookup in `block_range_at_row`
 
 | Option                                                                 | Reason rejected                                                                                                                                                                                  |
 | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `virt_text_pos = "overlay"` (8ff45f2)                                  | Required hardcoded buffer padding for the glyph to overlay onto.                                                                                                                                 |
-| `virt_text_pos = "inline"` (d3cd47a)                                   | Renders only on the first screen line of a buffer line. Soft-wrap continuations have no border.                                                                                                  |
+| `virt_text_pos = "overlay"`                                            | Required hardcoded buffer padding for the glyph to overlay onto.                                                                                                                                 |
+| `virt_text_pos = "inline"`                                             | Renders only on the first screen line of a buffer line. Soft-wrap continuations have no border.                                                                                                  |
 | `virt_text_repeat_linebreak`                                           | `inline` not supported. With `overlay` + `win_col`: needs buffer padding + `breakindent`; same glyph repeats so header lines show `╭─` on continuations. Upstream wontfix (neovim/neovim#35341). |
 | Sign column                                                            | No soft-wrap repeat. Conflicts with gitsigns/diagnostics. Per-line sign bookkeeping.                                                                                                             |
 | `statuscolumn` + `signcolumn=yes:1` + `winhighlight=SignColumn:Normal` | Intermediate attempt to seam gutter bg. Extra width on some setups. Redundant under `style=minimal`.                                                                                             |
@@ -51,8 +50,8 @@ lives in `glyph_for_line`, range lookup in `block_range_at_row`
 
 ## Changelog
 
-| Date       | Commit  | Change                                                       |
-| ---------- | ------- | ------------------------------------------------------------ |
-| 2025-11-13 | 8ff45f2 | Initial: per-line virt_text extmarks, `overlay`.             |
-| 2025-11-13 | d3cd47a | Switch to `inline` to drop hardcoded buffer padding.         |
-| 2026-04-30 | 1f3cde6 | Replace per-line extmarks with `'statuscolumn'` + range ext. |
+| Date       | Change                                                       |
+| ---------- | ------------------------------------------------------------ |
+| 2025-11-13 | Initial: per-line virt_text extmarks, `overlay`.             |
+| 2025-11-13 | Switch to `inline` to drop hardcoded buffer padding.         |
+| 2026-04-30 | Replace per-line extmarks with `'statuscolumn'` + range ext. |

--- a/docs/adr/0003-inline-permission-buttons.md
+++ b/docs/adr/0003-inline-permission-buttons.md
@@ -5,7 +5,6 @@
 
 - Status: accepted
 - Last updated: 2026-05-27
-- Commits: -
 - Related: -
 
 ## Context
@@ -21,8 +20,8 @@ Inline buttons on row N exhibited two failures and one product gap:
 2. **Layout overflow on long labels.** Multiple long labels on a single row
    spilled into a second visual row; one button could end up orphaned on its
    own wrapped line, disconnected from the status word.
-3. **Static label map hides provider intent.** The fixed `Allow` / `Allow
-   Always` / `Reject` / `Reject Always` labels discarded provider-supplied
+3. **Static label map hides provider intent.** The fixed `Allow` / `Allow Always`
+   / `Reject` / `Reject Always` labels discarded provider-supplied
    text (e.g. Claude Code's `"Yes, and bypass permissions"`) and produced
    identical text regardless of which provider sent the request.
 
@@ -210,12 +209,12 @@ special-case needed. ADR 0001's contract is unchanged.
 
 ## Changelog
 
-| Date       | Commit  | Change                                                                                                                                                                                         |
-| ---------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-05-13 | initial | Initial implementation per `docs/superpowers/inline-permission-buttons.md`. Concurrent map, head-tracking focus, row N text.                                                                   |
-| 2026-05-13 | -       | Two-level focus added: `h` / `l` / `<CR>` for buttons; digits kept; static label map; bg-only highlights, brackets removed.                                                                    |
-| 2026-05-13 | -       | Row-gated `expr=true` keymaps; cursor positions on first button column.                                                                                                                        |
-| 2026-05-13 | -       | `<C-n>` / `<C-p>` replace `]p` / `[p`; `Config.keymaps.permission.cycle_next` / `cycle_prev` made configurable.                                                                                |
-| 2026-05-13 | -       | Digits `1`..`4` ungated (fire from anywhere in the chat buffer); only motion / submit keys (`h`/`l`/`<Left>`/`<Right>`/`<CR>`) remain row-gated.                                               |
-| 2026-05-14 | -       | Auto-scroll suppresses follow mode on `NS_STATUS` permission-button rows; no `PermissionManager` focus-row callback.                                                                           |
-| 2026-05-27 | -       | Stacked one-per-row buttons supersede inline row N rendering. Provider `option.name` used verbatim. Eight cycle keys (h/j/k/l + arrows). Block focus lands on button row 1. NBSP join removed. |
+| Date       | Change                                                                                                                                                                                         |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-13 | Initial implementation per `docs/superpowers/inline-permission-buttons.md`. Concurrent map, head-tracking focus, row N text.                                                                   |
+| 2026-05-13 | Two-level focus added: `h` / `l` / `<CR>` for buttons; digits kept; static label map; bg-only highlights, brackets removed.                                                                    |
+| 2026-05-13 | Row-gated `expr=true` keymaps; cursor positions on first button column.                                                                                                                        |
+| 2026-05-13 | `<C-n>` / `<C-p>` replace `]p` / `[p`; `Config.keymaps.permission.cycle_next` / `cycle_prev` made configurable.                                                                                |
+| 2026-05-13 | Digits `1`..`4` ungated (fire from anywhere in the chat buffer); only motion / submit keys (`h`/`l`/`<Left>`/`<Right>`/`<CR>`) remain row-gated.                                               |
+| 2026-05-14 | Auto-scroll suppresses follow mode on `NS_STATUS` permission-button rows; no `PermissionManager` focus-row callback.                                                                           |
+| 2026-05-27 | Stacked one-per-row buttons supersede inline row N rendering. Provider `option.name` used verbatim. Eight cycle keys (h/j/k/l + arrows). Block focus lands on button row 1. NBSP join removed. |

--- a/docs/adr/0004-shared-agent-instance-per-provider.md
+++ b/docs/adr/0004-shared-agent-instance-per-provider.md
@@ -2,7 +2,6 @@
 
 - Status: accepted
 - Last updated: 2026-07-25
-- Commits:
 - Related:
 
 > The decision below still holds. Its **per-tab framing is superseded by ADR
@@ -55,7 +54,7 @@ The **SessionRegistry** owns **SessionManager** instances, keyed by session key
 
 ## Changelog
 
-| Date       | Commit | Change                                                                 |
-| ---------- | ------ | ---------------------------------------------------------------------- |
-| 2026-05-16 |        | Initial decision recorded.                                             |
-| 2026-07-25 |        | Per-tab framing superseded by ADR 0008; subprocess decision unchanged. |
+| Date       | Change                                                                 |
+| ---------- | ---------------------------------------------------------------------- |
+| 2026-05-16 | Initial decision recorded.                                             |
+| 2026-07-25 | Per-tab framing superseded by ADR 0008; subprocess decision unchanged. |

--- a/docs/adr/0005-generic-acp-client-no-adapters.md
+++ b/docs/adr/0005-generic-acp-client-no-adapters.md
@@ -2,7 +2,6 @@
 
 - Status: accepted
 - Last updated: 2026-05-16
-- Commits: 65981da, fa66ff1
 - Related: PR #162, PR #14
 
 ## Context
@@ -39,15 +38,15 @@ deviates from ACP in ways not yet handled by `ACPClient`.
 
 ## Rejected / superseded alternatives
 
-| Option                                                         | Reason rejected                                                                                                                |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Per-provider adapter modules (original design, fa66ff1)        | Duplicated translation code across providers; new providers required new files even when ACP-conformant. Replaced in 65981da.  |
-| Strategy/hook-point pattern with per-provider strategy objects | Same duplication tax with extra indirection; no observable benefit over inline quirks for the small number of deviations seen. |
+| Option                                                         | Reason rejected                                                                                                                                 |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Per-provider adapter modules (original design)                 | Duplicated translation code across providers; new providers required new files even when ACP-conformant. Replaced by the generic client design. |
+| Strategy/hook-point pattern with per-provider strategy objects | Same duplication tax with extra indirection; no observable benefit over inline quirks for the small number of deviations seen.                  |
 
 ## Changelog
 
-| Date       | Commit  | Change                                                               |
-| ---------- | ------- | -------------------------------------------------------------------- |
-| 2026-05-16 |         | Initial decision recorded (post-hoc).                                |
-| 2026-03-20 | 65981da | Removed per-provider adapter modules; inlined quirks in `ACPClient`. |
-| 2025-12-19 | fa66ff1 | (Superseded) Introduced dedicated per-provider adapter modules.      |
+| Date       | Change                                                               |
+| ---------- | -------------------------------------------------------------------- |
+| 2026-05-16 | Initial decision recorded (post-hoc).                                |
+| 2026-03-20 | Removed per-provider adapter modules; inlined quirks in `ACPClient`. |
+| 2025-12-19 | (Superseded) Introduced dedicated per-provider adapter modules.      |

--- a/docs/adr/0006-acp-subprocess-process-group.md
+++ b/docs/adr/0006-acp-subprocess-process-group.md
@@ -2,7 +2,6 @@
 
 - Status: accepted
 - Last updated: 2026-05-18
-- Commits:
 - Related:
 
 ## Context
@@ -28,7 +27,7 @@ detached flag maps to `DETACHED_PROCESS` there and process groups behave
 differently.
 
 Regression test:
-``lua/agentic/acp/acp_transport.test.lua::"kills descendant processes when wrapper does not forward signals"``.
+`lua/agentic/acp/acp_transport.test.lua::"kills descendant processes when wrapper does not forward signals"`.
 
 ## Consequences
 
@@ -44,18 +43,18 @@ Regression test:
 
 ## Rejected / superseded alternatives
 
-| Option | Reason rejected |
-| --- | --- |
-| Keep `detached = false`, kill direct PID only | Original behaviour. Leaks codex-acp native grandchildren on every quit. |
-| Walk descendants with `pgrep -P` on stop | Works without spawn-flag changes and keeps crash-case cleanup via parent pgrp, but adds per-shutdown fork+exec and a race window where new grandchildren spawned during the walk are missed. |
-| File upstream fix in `codex-acp.js` to forward sigs | Right long-term, but does not help users until they upgrade. Pursue in parallel. |
-| `PR_SET_PDEATHSIG` so children die with nvim | Linux-only, not exposed by libuv, would require an FFI shim. Not worth it for the hard-kill edge case. |
+| Option                                              | Reason rejected                                                                                                                                                                              |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Keep `detached = false`, kill direct PID only       | Original behaviour. Leaks codex-acp native grandchildren on every quit.                                                                                                                      |
+| Walk descendants with `pgrep -P` on stop            | Works without spawn-flag changes and keeps crash-case cleanup via parent pgrp, but adds per-shutdown fork+exec and a race window where new grandchildren spawned during the walk are missed. |
+| File upstream fix in `codex-acp.js` to forward sigs | Right long-term, but does not help users until they upgrade. Pursue in parallel.                                                                                                             |
+| `PR_SET_PDEATHSIG` so children die with nvim        | Linux-only, not exposed by libuv, would require an FFI shim. Not worth it for the hard-kill edge case.                                                                                       |
 
 ## Changelog
 
-| Date       | Commit | Change                                                                                  |
-| ---------- | ------ | --------------------------------------------------------------------------------------- |
-| 2026-05-18 |        | Initial decision: detached spawn + group kill so non-signal-forwarding wrappers reap cleanly. |
+| Date       | Change                                                                                        |
+| ---------- | --------------------------------------------------------------------------------------------- |
+| 2026-05-18 | Initial decision: detached spawn + group kill so non-signal-forwarding wrappers reap cleanly. |
 
 ## Sources
 

--- a/docs/adr/0007-native-clipboard-image-backend.md
+++ b/docs/adr/0007-native-clipboard-image-backend.md
@@ -2,7 +2,6 @@
 
 - Status: accepted
 - Last updated: 2026-05-28
-- Commits: 7473096, 364185d
 - Related: -
 
 ## Context
@@ -72,10 +71,10 @@ a remote filesystem for SSH sessions.
 
 ## Changelog
 
-| Date       | Commit  | Change                                 |
-| ---------- | ------- | -------------------------------------- |
-| 2026-05-28 | 7473096 | Initial native clipboard backend.      |
-| 2026-05-28 | 364185d | Refine WSL and SSH clipboard handling. |
+| Date       | Change                                 |
+| ---------- | -------------------------------------- |
+| 2026-05-28 | Initial native clipboard backend.      |
+| 2026-05-28 | Refine WSL and SSH clipboard handling. |
 
 ## Sources
 

--- a/docs/adr/0008-session-keyed-ownership.md
+++ b/docs/adr/0008-session-keyed-ownership.md
@@ -2,7 +2,6 @@
 
 - Status: accepted
 - Last updated: 2026-07-30
-- Commits:
 - Related: PR #283, PR #261, issue #282
 
 ## Context
@@ -155,10 +154,10 @@ prompt to label `select_session` rows.
 
 ## Changelog
 
-| Date       | Commit | Change                                                                                       |
-| ---------- | ------ | -------------------------------------------------------------------------------------------- |
-| 2026-07-25 |        | Initial decision: ownership keyed by session, placement derived from the widget.             |
-| 2026-07-30 |        | Clarified that the buffer-name key suffix is published per header render, not retroactively. |
+| Date       | Change                                                                                       |
+| ---------- | -------------------------------------------------------------------------------------------- |
+| 2026-07-25 | Initial decision: ownership keyed by session, placement derived from the widget.             |
+| 2026-07-30 | Clarified that the buffer-name key suffix is published per header render, not retroactively. |
 
 ## Sources
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,7 +49,7 @@ Do NOT create a new ADR. Update the existing one:
 1. Rewrite the "Current decision" section to the new truth.
 2. Move the previous decision into "Rejected / superseded alternatives" with the
    reason it was dropped.
-3. Add a row to the "Changelog" with date + commit + one-line summary.
+3. Add a row to the "Changelog" with the date and a one-line summary.
 
 Append-only history lives in the changelog and the rejected section. The top of
 the file always reflects what the code does today.
@@ -61,7 +61,6 @@ the file always reflects what the code does today.
 
 - Status: accepted
 - Last updated: YYYY-MM-DD
-- Commits: comma-separated 7-char short SHAs
 - Related: comma-separated refs in `<kind> #N` form. Allowed kinds: `PR`,
   `issue`, `discussion`. Cross-repo: `owner/repo#N` (no kind prefix). Example:
   `Related: PR #215, issue #196, issue #211, neovim/neovim#35341`.
@@ -90,9 +89,9 @@ What this costs us. Things that fail loud if violated.
 
 ## Changelog
 
-| Date       | Commit | Change                         |
-| ---------- | ------ | ------------------------------ |
-| YYYY-MM-DD | <sha>  | Initial decision: <one-liner>. |
+| Date       | Change                         |
+| ---------- | ------------------------------ |
+| YYYY-MM-DD | Initial decision: <one-liner>. |
 
 ## Sources (optional)
 
@@ -122,5 +121,3 @@ Tracked issue/PR refs (own repo or cross-repo, e.g. `neovim/neovim#35341`) go in
   `Current decision` to today's truth, move the prior text into
   `Rejected / superseded alternatives`, and add a changelog row. Do NOT silently
   leave a stale `Current decision` — agents read it as authoritative.
-- SHAs are 7-char short SHAs. Fill them in after the squash-merge SHA is known;
-  do NOT use `(uncommitted)` placeholders in landed commits.


### PR DESCRIPTION
- Remove ADR commit SHA requirements
- Drop historical SHA metadata and columns
- Keep changelogs date and change only
- Verify Markdown with `prettier --check`
