### PR TITLE
docs: correct session hook and widget edit contracts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -227,7 +227,8 @@ carries the **Session key**. Six hooks today:
 - `on_create_session_response` — fires after `session/new` returns.
 - `on_prompt_submit` — fires when user submits a prompt.
 - `on_response_complete` — fires when the agent finishes a turn.
-- `on_session_update` — fires for every live `session/update` notification.
+- `on_session_update` — fires for live non-tool-call `session/update`
+  notifications.
   Skipped during session restore.
 - `on_file_edit` — fires when a file-mutating **Tool Call** completes (kinds:
   `edit`, `create`, `write`, `delete`, `move`). Skipped during session restore.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -227,7 +227,8 @@ carries the **Session key**. Six hooks today:
 - `on_create_session_response` — fires after `session/new` returns.
 - `on_prompt_submit` — fires when user submits a prompt.
 - `on_response_complete` — fires when the agent finishes a turn.
-- `on_session_update` — fires for every `session/update` notification.
+- `on_session_update` — fires for every live `session/update` notification.
+  Skipped during session restore.
 - `on_file_edit` — fires when a file-mutating **Tool Call** completes (kinds:
   `edit`, `create`, `write`, `delete`, `move`). Skipped during session restore.
 - `on_request_permission` — fires for each pending **Permission Request**.

--- a/README.md
+++ b/README.md
@@ -1083,6 +1083,7 @@ return {
 
       -- Called when the session is updated.
       -- Fires for background sessions too, so key everything off session_key.
+      -- Skipped during session restore.
       on_session_update = function(data)
         -- data.session_id: string - The ACP session ID
         -- data.session_key: integer - Stable session identity

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -825,9 +825,10 @@ Identify a session by `data.session_key`, not by `data.tab_page_id`.
 `session_key` is the session's key (see |agentic-sessions|) and never
 changes. `tab_page_id` only says which tab the session shows in right
 now, and is `nil` for a session running in the background -- hidden, or
-in a closed tab. `on_session_update` and `on_response_complete` fire
-for background sessions, so guard `tab_page_id` before passing it to
-any `nvim_tabpage_*` function; those raise on `nil`.
+in a closed tab. `on_session_update` fires for background sessions.
+Skipped during session restore. `on_response_complete` also fires for
+background sessions. Guard `tab_page_id` before passing it to any
+`nvim_tabpage_*` function; those raise on `nil`.
 >lua
   -- Token usage per session, keyed by session_key. A plain Lua table,
   -- because a session may be running in no tab at all.

--- a/lua/agentic/ui/AGENTS.md
+++ b/lua/agentic/ui/AGENTS.md
@@ -210,12 +210,14 @@ tests.
 - Reopening the hidden chat float without closing the previous one
   - Overwrites the stored winid and leaks the prior window.
 - `:edit` on a widget buffer
-  - Buffer keeps its ID but gains a name and `buftype != "nofile"`.
-    `BufferGuard` detects this on `BufEnter` and swaps a fresh scratch buffer
-    into the widget window, redirecting the named buffer out. The replacement
-    buffer takes over the panel's `buf_nrs` entry and is re-registered, so the
-    single shared augroup can still resolve the window's owner on the next
-    event. Re-grep `BufferGuard` for the exact entry point before refactoring.
+  - Normal `:edit` allocates a separate foreign buffer. The widget buffer keeps
+    its identity and `nofile` type. `BufferGuard.on_buf_enter` takes the
+    `cur_buf ~= expected` path, restores the widget buffer in its window, and
+    `redirect_foreign` moves the foreign buffer to a non-widget window in the
+    same tabpage and focuses that destination.
+  - The named non-`nofile` in-place replacement branch in
+    `BufferGuard.on_buf_enter` still exists, but normal widget operations do not
+    reach it.
 - Writing header state back after reading it
   - `WindowDecoration`'s header-state getter hands back the owning widget's own
     `ChatWidget.headers` table, so an in-place mutation is already visible to the


### PR DESCRIPTION
- Document restore-suppressed session updates
- Correct widget edit redirect guidance
- Verify vimdoc formatting and help tags
