### PR TITLE
fix(session): report unavailable session commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,8 +111,12 @@ Two consequences bite every runtime change:
 
 ### Resolving a session
 
-Three entry points on `SessionRegistry`. Only one creates:
+Four entry points on `SessionRegistry`. Only one creates:
 
+- `get(session_key)` — exact registered session for a known key, else `nil`.
+  Never creates and changes neither placement nor recency. Regressions:
+  `lua/agentic/session_registry.test.lua::"returns the registered session without changing recency or placement"`
+  and `::"returns nil for an unknown key without creating a session"`.
 - `visible_here()` — session visible in the current tabpage, else `nil`.
 - `current()` — `visible_here()`, falling back to the registered most-recent
   session. Never creates. **This is the default choice.**
@@ -123,14 +127,17 @@ Three entry points on `SessionRegistry`. Only one creates:
 
 ```mermaid
 flowchart TD
-    Q{"May this entry point<br/>CREATE a session?"}
+    K{"Do you have a known<br/>session key?"}
+    K -->|"yes"| G["get(session_key)<br/>exact registered session"]
+    K -->|"no"| Q{"May this entry point<br/>CREATE a session?"}
     Q -->|"yes"| ROC["resolve_or_create()<br/>may spawn provider work"]
     Q -->|"no"| T{"Must it be in the<br/>CURRENT tabpage?"}
 
     T -->|"yes — placement matters"| VH["visible_here()"]
     T -->|"no"| C["current()<br/>DEFAULT CHOICE"]
 
-    VH --> N["nil-check: all three<br/>can return nil"]
+    G --> N["nil-check: all four<br/>can return nil"]
+    VH --> N
     C --> N
     ROC --> N
 ```
@@ -142,10 +149,11 @@ Worked examples:
 - `Agentic.destroy_session`, `SessionNavigation.next`,
   `SessionNavigation.previous` — `current`; they act on a session, not a
   placement.
-- Clipboard paste closure — resolves through `WidgetRegistry` from the buffer
-  under the cursor. Runs on every `vim.paste` and must not create anything.
+- Clipboard paste closure — resolves a widget through `WidgetRegistry`, then
+  uses `get(session_key)`. Runs on every `vim.paste` and must not create
+  anything.
 
-All three return `SessionManager|nil`, `resolve_or_create` included:
+All four return `SessionManager|nil`, `resolve_or_create` included:
 `SessionRegistry.create` returns `nil` when
 `ACPHealth.check_configured_provider()` fails, so an unconfigured user gets `nil`
 from the creating entry point too. Nil-check every bare return.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,8 @@ Worked examples:
   placement.
 - Clipboard paste closure — resolves a widget through `WidgetRegistry`, then
   uses `get(session_key)`. Runs on every `vim.paste` and must not create
-  anything.
+  anything. Regression:
+  `lua/agentic/agentic.test.lua::"does not create a session from clipboard callbacks"`.
 
 All four return `SessionManager|nil`, `resolve_or_create` included:
 `SessionRegistry.create` returns `nil` when

--- a/doc/agentic.txt
+++ b/doc/agentic.txt
@@ -446,8 +446,9 @@ small integer assigned at creation and stable for its whole life.
   - Use |agentic.destroy_session()| to end a session directly.
 
 |agentic.destroy_session()| takes a `session` field naming the key to
-destroy. Without it, it destroys the session visible in the current
-tab, falling back to the most recently opened one.
+destroy. An unknown key reports that no matching session exists.
+Without a key, it destroys the session visible in the current tab,
+falling back to the most recently opened one.
 >lua
   -- Destroy session 2 without opening it
   require("agentic").destroy_session({ session = 2 })
@@ -550,6 +551,8 @@ agentic.new_session({opts})
                                              *agentic.destroy_session()*
 agentic.destroy_session({opts})
   Destroy a session and its widget. Hiding keeps it running.
+  An unknown explicit session key reports that no matching session
+  exists and leaves all sessions unchanged.
 
   Parameters: ~
     {opts}  (table|nil)  Optional fields:
@@ -561,7 +564,8 @@ agentic.destroy_session({opts})
 agentic.select_session()
   Show a picker listing every live session and open the chosen one
   in the current tab. Entries are labelled with the session title,
-  and the session visible in the current tab is marked.
+  and the session visible in the current tab is marked. When no
+  sessions exist, report that state without opening the picker.
 
                                                 *agentic.next_session()*
 agentic.next_session()

--- a/lua/agentic/agentic.test.lua
+++ b/lua/agentic/agentic.test.lua
@@ -859,11 +859,30 @@ describe("agentic: switch_provider", function()
 
     it("delegates explicit session destruction to the registry", function()
         local Agentic = require("agentic")
+        local live_session = {}
+        local get_stub = track_stub(SessionRegistry, "get")
+        get_stub:returns(live_session)
         local destroy_stub = track_stub(SessionRegistry, "destroy")
 
         Agentic.destroy_session({ session = 7 })
 
+        assert.spy(get_stub).was.called_with(7)
         assert.spy(destroy_stub).was.called_with(7)
+        assert.spy(logger_notify_stub).was.called(0)
+    end)
+
+    it("reports an unknown explicit session without destroying it", function()
+        local Agentic = require("agentic")
+        local get_stub = track_stub(SessionRegistry, "get")
+        get_stub:returns(nil)
+        local destroy_stub = track_stub(SessionRegistry, "destroy")
+
+        Agentic.destroy_session({ session = 9999 })
+
+        assert.spy(get_stub).was.called_with(9999)
+        assert.spy(logger_notify_stub).was.called(1)
+        assert.truthy(tostring(logger_notify_stub.calls[1][1]):find("9999"))
+        assert.spy(destroy_stub).was.called(0)
     end)
 
     it("delegates default session destruction to the registry", function()

--- a/lua/agentic/agentic.test.lua
+++ b/lua/agentic/agentic.test.lua
@@ -867,6 +867,7 @@ describe("agentic: switch_provider", function()
         Agentic.destroy_session({ session = 7 })
 
         assert.spy(get_stub).was.called_with(7)
+        assert.spy(destroy_stub).was.called(1)
         assert.spy(destroy_stub).was.called_with(7)
         assert.spy(logger_notify_stub).was.called(0)
     end)

--- a/lua/agentic/agentic.test.lua
+++ b/lua/agentic/agentic.test.lua
@@ -952,4 +952,48 @@ describe("agentic: switch_provider", function()
         local lines = vim.api.nvim_buf_get_lines(input_bufnr, 0, -1, false)
         assert.equal("my prompt text", lines[1])
     end)
+
+    it("does not create a session from clipboard callbacks", function()
+        local Agentic = require("agentic")
+        local original_image_paste_enabled = Config.image_paste.enabled
+        local original_clipboard = package.loaded["agentic.ui.clipboard"]
+        local original_widget_registry =
+            package.loaded["agentic.ui.widget_registry"]
+        local clipboard_opts
+
+        package.loaded["agentic.ui.clipboard"] = {
+            setup = function(opts)
+                clipboard_opts = opts
+            end,
+        }
+        package.loaded["agentic.ui.widget_registry"] = {
+            get = function()
+                return { session_key = 9999 }
+            end,
+        }
+        Config.image_paste.enabled = true
+
+        local get_stub = track_stub(SessionRegistry, "get")
+        get_stub:returns(nil)
+        local create_stub = track_stub(SessionRegistry, "create")
+        local resolve_stub = track_stub(SessionRegistry, "resolve_or_create")
+        local new_signal_stub = track_stub(vim.uv, "new_signal")
+        new_signal_stub:returns(nil)
+
+        Agentic.setup({})
+
+        local is_in_widget = clipboard_opts.is_cursor_in_widget()
+        local pasted = clipboard_opts.on_paste("image.png")
+
+        Config.image_paste.enabled = original_image_paste_enabled
+        package.loaded["agentic.ui.clipboard"] = original_clipboard
+        package.loaded["agentic.ui.widget_registry"] = original_widget_registry
+
+        assert.is_false(is_in_widget)
+        assert.is_false(pasted)
+        assert.spy(get_stub).was.called(2)
+        assert.spy(get_stub).was.called_with(9999)
+        assert.spy(create_stub).was.called(0)
+        assert.spy(resolve_stub).was.called(0)
+    end)
 end)

--- a/lua/agentic/init.lua
+++ b/lua/agentic/init.lua
@@ -177,6 +177,11 @@ function Agentic.destroy_session(opts)
     local target = opts and opts.session
 
     if target then
+        if not SessionRegistry.get(target) then
+            Logger.notify("Session not found: " .. target)
+            return
+        end
+
         SessionRegistry.destroy(target)
         return
     end
@@ -308,7 +313,7 @@ function Agentic.setup(opts)
             local widget = WidgetRegistry.get(vim.api.nvim_get_current_buf())
             local session_key = widget and widget.session_key
 
-            return session_key and SessionRegistry.sessions[session_key] or nil
+            return session_key and SessionRegistry.get(session_key) or nil
         end
 
         local Clipboard = require("agentic.ui.clipboard")

--- a/lua/agentic/session_navigation.lua
+++ b/lua/agentic/session_navigation.lua
@@ -1,4 +1,5 @@
 local SessionRegistry = require("agentic.session_registry")
+local Logger = require("agentic.utils.logger")
 
 --- @param step 1|-1
 local function cycle(step)
@@ -38,6 +39,12 @@ local SessionNavigation = {}
 --- Shows a picker over every live session and opens the chosen one.
 function SessionNavigation.select()
     local sessions = SessionRegistry.list()
+
+    if #sessions == 0 then
+        Logger.notify("No sessions available")
+        return
+    end
+
     local current_tab = vim.api.nvim_get_current_tabpage()
 
     vim.ui.select(sessions, {

--- a/lua/agentic/session_navigation.test.lua
+++ b/lua/agentic/session_navigation.test.lua
@@ -1,10 +1,12 @@
 local assert = require("tests.helpers.assert")
 local spy = require("tests.helpers.spy")
+local Logger = require("agentic.utils.logger")
 
 describe("agentic.SessionNavigation", function()
     local SessionNavigation
     local sessions
     local current_session
+    local logger_notify_stub
     local registry_mock
     local ui_select_stub
 
@@ -32,6 +34,7 @@ describe("agentic.SessionNavigation", function()
     before_each(function()
         sessions = {}
         current_session = nil
+        logger_notify_stub = spy.stub(Logger, "notify")
         registry_mock = {
             list = spy.new(function()
                 return sessions
@@ -49,9 +52,18 @@ describe("agentic.SessionNavigation", function()
     end)
 
     after_each(function()
+        logger_notify_stub:revert()
         ui_select_stub:revert()
         package.loaded["agentic.session_registry"] = original_registry
         package.loaded["agentic.session_navigation"] = original_navigation
+    end)
+
+    it("reports when no sessions are available", function()
+        SessionNavigation.select()
+
+        assert.spy(logger_notify_stub).was.called(1)
+        assert.spy(logger_notify_stub).was.called_with("No sessions available")
+        assert.spy(ui_select_stub).was.called(0)
     end)
 
     it("lists live sessions and opens the selected one", function()

--- a/lua/agentic/session_registry.lua
+++ b/lua/agentic/session_registry.lua
@@ -103,6 +103,12 @@ function SessionRegistry.visible_here()
     return nil
 end
 
+--- @param session_key integer
+--- @return agentic.SessionManager|nil
+function SessionRegistry.get(session_key)
+    return SessionRegistry.sessions[session_key]
+end
+
 --- The live session already holding an ACP session ID on this provider, if any.
 --- @param acp_session_id string
 --- @param agent agentic.acp.ACPClient

--- a/lua/agentic/session_registry.test.lua
+++ b/lua/agentic/session_registry.test.lua
@@ -192,6 +192,43 @@ describe("agentic.SessionRegistry", function()
         end
     end)
 
+    describe("get", function()
+        it(
+            "returns the registered session without changing recency or placement",
+            function()
+                local current_tab = vim.api.nvim_get_current_tabpage()
+                local target = create_mock_session(current_tab)
+                local most_recent = create_mock_session()
+                local previous_most_recent = create_mock_session()
+                target.session_key = 7
+                SessionRegistry.sessions[7] = target
+                SessionRegistry._most_recent = most_recent
+                SessionRegistry._previous_most_recent = previous_most_recent
+                local visible_tab = target.widget:get_visible_tab_id()
+
+                local resolved = SessionRegistry.get(7)
+
+                assert.equal(target, resolved)
+                assert.equal(most_recent, SessionRegistry._most_recent)
+                assert.equal(
+                    previous_most_recent,
+                    SessionRegistry._previous_most_recent
+                )
+                assert.equal(visible_tab, target.widget:get_visible_tab_id())
+            end
+        )
+
+        it(
+            "returns nil for an unknown key without creating a session",
+            function()
+                create_session_stub = spy.stub(SessionRegistry, "create")
+
+                assert.is_nil(SessionRegistry.get(9999))
+                assert.spy(create_session_stub).was.called(0)
+            end
+        )
+    end)
+
     describe("create", function()
         it("assigns incrementing session keys", function()
             local first = SessionRegistry.create()

--- a/lua/agentic/session_registry.test.lua
+++ b/lua/agentic/session_registry.test.lua
@@ -208,7 +208,7 @@ describe("agentic.SessionRegistry", function()
 
                 local resolved = SessionRegistry.get(7)
 
-                assert.equal(target, resolved)
+                assert.is_true(resolved == target)
                 assert.equal(most_recent, SessionRegistry._most_recent)
                 assert.equal(
                     previous_most_recent,

--- a/lua/agentic/session_registry.test.lua
+++ b/lua/agentic/session_registry.test.lua
@@ -204,7 +204,6 @@ describe("agentic.SessionRegistry", function()
                 SessionRegistry.sessions[7] = target
                 SessionRegistry._most_recent = most_recent
                 SessionRegistry._previous_most_recent = previous_most_recent
-                local visible_tab = target.widget:get_visible_tab_id()
 
                 local resolved = SessionRegistry.get(7)
 
@@ -214,7 +213,7 @@ describe("agentic.SessionRegistry", function()
                     previous_most_recent,
                     SessionRegistry._previous_most_recent
                 )
-                assert.equal(visible_tab, target.widget:get_visible_tab_id())
+                assert.same({}, widget_events)
             end
         )
 


### PR DESCRIPTION
- Add non-creating keyed lookup
- Notify missing explicit destroy targets
- Skip empty session picker
- Validate with `make validate`
