### PR TITLE
test: cover session safety boundaries

### DIFF
--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -852,14 +852,25 @@ describe("ACPClient", function()
             local client = create_ready_client()
             local sent = capture_sent()
             local queue = queue_schedules()
+            --- @type { event: string, tool_call_id: string }[]
+            local events = {}
 
             --- @type agentic.acp.ClientHandlers
             local handlers = {
                 on_session_update = function() end,
                 on_error = function() end,
                 on_tool_call = function() end,
-                on_tool_call_update = function() end,
-                on_request_permission = function(_request, callback)
+                on_tool_call_update = function(message)
+                    events[#events + 1] = {
+                        event = "update",
+                        tool_call_id = message.tool_call_id,
+                    }
+                end,
+                on_request_permission = function(request, callback)
+                    events[#events + 1] = {
+                        event = "request",
+                        tool_call_id = request.toolCall.toolCallId,
+                    }
                     callback("allow_once")
                 end,
             }
@@ -870,6 +881,10 @@ describe("ACPClient", function()
 
             drain(queue)
 
+            assert.same({
+                { event = "update", tool_call_id = "tc-1" },
+                { event = "request", tool_call_id = "tc-1" },
+            }, events)
             assert.equal(1, #sent)
             assert.same({
                 outcome = { outcome = "selected", optionId = "allow_once" },

--- a/lua/agentic/agentic.test.lua
+++ b/lua/agentic/agentic.test.lua
@@ -835,13 +835,20 @@ describe("agentic: switch_provider", function()
         session.is_generating = true
 
         -- Avoids a real RPC call
-        track_stub(session.agent, "stop_generation")
-        track_stub(session.permission_manager, "clear")
+        local stop_generation_stub =
+            track_stub(session.agent, "stop_generation")
+        local permission_clear_stub =
+            track_stub(session.permission_manager, "clear")
         local anim_stop_spy = track_stub(session.status_animation, "stop")
 
         Agentic.stop_generation()
 
         -- Both immediate, not deferred to the callback
+        assert.spy(stop_generation_stub).was.called(1)
+        assert
+            .spy(stop_generation_stub).was
+            .called_with(session.agent, "test-session-id")
+        assert.spy(permission_clear_stub).was.called(1)
         assert.is_false(session.is_generating)
         assert.spy(anim_stop_spy).was.called(1)
     end)

--- a/tests/integration/test_add_file_or_selection_to_session.lua
+++ b/tests/integration/test_add_file_or_selection_to_session.lua
@@ -43,6 +43,12 @@ describe("Add file or selection to session", function()
         child.lua([[ require("agentic").toggle() ]])
         child.flush()
 
+        local code_winid = child.lua([[
+            local session = require("agentic.session_registry").current()
+            assert(session, "expected an existing session")
+            return session.widget.win_nrs.code
+        ]])
+
         local selections = child.lua([[
             local session = require("agentic.session_registry").current()
             assert(session, "expected an existing session")
@@ -56,5 +62,6 @@ describe("Add file or selection to session", function()
         assert.same(expected_lines, selections[1].lines)
         assert.equal(28, selections[1].start_line)
         assert.equal(29, selections[1].end_line)
+        assert.is_true(child.api.nvim_win_is_valid(code_winid))
     end)
 end)


### PR DESCRIPTION
- Guard session cleanup regressions
- Pin permission rendering order
- Require visible selection code panel
- Assertion-only current behavior coverage
- Verified with `make validate`
