### PR TITLE
test(acp): cover fast-event response delivery

### DIFF
--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -275,46 +275,92 @@ describe("ACPClient", function()
                 local ACPClient = require("agentic.acp.acp_client")
                 local client = ACPClient:new({ command = "test-agent" }, function() end)
 
-                _G.p5_fast_delivery = {}
+                _G.p5_fast_delivery = { messages = {}, callbacks = {} }
 
                 local original_on_message = client.transport.callbacks.on_message
                 client.transport.callbacks.on_message = function(message)
-                    _G.p5_fast_delivery.on_message_fast = vim.in_fast_event()
+                    local delivered = {
+                        fast = vim.in_fast_event(),
+                    }
                     local ok, err = pcall(original_on_message, message)
-                    _G.p5_fast_delivery.on_message_ok = ok
-                    _G.p5_fast_delivery.on_message_err = err
+                    delivered.ok = ok
+                    delivered.err = err
+                    _G.p5_fast_delivery.messages[#_G.p5_fast_delivery.messages + 1] = delivered
                 end
 
-                client:create_session({
+                local handlers = {
                     on_session_update = function() end,
                     on_request_permission = function() end,
                     on_error = function() end,
                     on_tool_call = function() end,
                     on_tool_call_update = function() end,
-                }, function(result, err)
-                    _G.p5_fast_delivery.callback_fast = vim.in_fast_event()
-                    _G.p5_fast_delivery.result = result
-                    _G.p5_fast_delivery.callback_err = err
-                end)
+                }
 
-                client.transport:deliver({
+                local function create_request(index)
+                    client:create_session(handlers, function(result, err)
+                        _G.p5_fast_delivery.callbacks[index] = {
+                            fast = vim.in_fast_event(),
+                            result = result,
+                            err = err,
+                        }
+                    end)
+                    return client.id_counter
+                end
+
+                local first_id = create_request(1)
+                local second_id = create_request(2)
+
+                local first_timer = client.transport:deliver({
                     jsonrpc = "2.0",
-                    id = client.id_counter,
-                    error = { code = -32000, message = "fast delivery failed" },
+                    id = first_id,
+                    error = { code = -32000, message = "first fast delivery failed" },
                 }, "fast_event")
+                local second_timer = client.transport:deliver({
+                    jsonrpc = "2.0",
+                    id = second_id,
+                    error = { code = -32001, message = "second fast delivery failed" },
+                }, "fast_event")
+
+                _G.p5_fast_timers = { first_timer, second_timer }
+                _G.p5_fast_delivery.distinct_timers = first_timer ~= second_timer
             ]])
 
             vim.uv.sleep(50)
             child.api.nvim_eval("1")
+            child.lua([[
+                _G.p5_fast_delivery.first_timer_closed =
+                    _G.p5_fast_timers[1]:is_closing()
+                _G.p5_fast_delivery.second_timer_closed =
+                    _G.p5_fast_timers[2]:is_closing()
+            ]])
 
             local result = child.lua_get("_G.p5_fast_delivery")
-            assert.is_true(result.on_message_fast)
-            assert.is_true(result.callback_fast)
-            assert.is_true(result.on_message_ok)
-            assert.is_nil(result.on_message_err)
-            assert.is_nil(result.result)
-            assert.equal(-32000, result.callback_err.code)
-            assert.equal("fast delivery failed", result.callback_err.message)
+            assert.is_true(result.distinct_timers)
+            assert.is_true(result.first_timer_closed)
+            assert.is_true(result.second_timer_closed)
+            assert.equal(2, #result.messages)
+            assert.equal(2, #result.callbacks)
+
+            for _, delivered in ipairs(result.messages) do
+                assert.is_true(delivered.fast)
+                assert.is_true(delivered.ok)
+                assert.is_nil(delivered.err)
+            end
+
+            assert.is_true(result.callbacks[1].fast)
+            assert.is_nil(result.callbacks[1].result)
+            assert.equal(-32000, result.callbacks[1].err.code)
+            assert.equal(
+                "first fast delivery failed",
+                result.callbacks[1].err.message
+            )
+            assert.is_true(result.callbacks[2].fast)
+            assert.is_nil(result.callbacks[2].result)
+            assert.equal(-32001, result.callbacks[2].err.code)
+            assert.equal(
+                "second fast delivery failed",
+                result.callbacks[2].err.message
+            )
         end)
     end)
 

--- a/lua/agentic/acp/acp_client.test.lua
+++ b/lua/agentic/acp/acp_client.test.lua
@@ -1,4 +1,5 @@
 local assert = require("tests.helpers.assert")
+local Child = require("tests.helpers.child")
 local spy = require("tests.helpers.spy")
 
 describe("ACPClient", function()
@@ -218,6 +219,102 @@ describe("ACPClient", function()
 
             local encoded = vim.json.encode(captured_initialize_params)
             assert.is_not_nil(encoded:find('"boolean":{}', 1, true))
+        end)
+    end)
+
+    describe("mock response delivery", function()
+        local child = Child.new()
+
+        before_each(function()
+            child.setup()
+        end)
+
+        after_each(function()
+            child.stop()
+        end)
+
+        it("delivers responses synchronously by default", function()
+            child.lua([[
+                local ACPClient = require("agentic.acp.acp_client")
+                local client = ACPClient:new({ command = "test-agent" }, function() end)
+                local callback_called = false
+
+                _G.p5_direct_delivery = {}
+
+                client:create_session({
+                    on_session_update = function() end,
+                    on_request_permission = function() end,
+                    on_error = function() end,
+                    on_tool_call = function() end,
+                    on_tool_call_update = function() end,
+                }, function(result, err)
+                    callback_called = true
+                    _G.p5_direct_delivery.callback_fast = vim.in_fast_event()
+                    _G.p5_direct_delivery.result = result
+                    _G.p5_direct_delivery.err = err
+                end)
+
+                client.transport:deliver({
+                    jsonrpc = "2.0",
+                    id = client.id_counter,
+                    result = { sessionId = "direct-session" },
+                })
+
+                _G.p5_direct_delivery.completed_before_return = callback_called
+            ]])
+
+            local result = child.lua_get("_G.p5_direct_delivery")
+            assert.is_true(result.completed_before_return)
+            assert.is_false(result.callback_fast)
+            assert.equal("direct-session", result.result.sessionId)
+            assert.is_nil(result.err)
+        end)
+
+        it("delivers ACP errors from a libuv fast event", function()
+            child.lua([[
+                local ACPClient = require("agentic.acp.acp_client")
+                local client = ACPClient:new({ command = "test-agent" }, function() end)
+
+                _G.p5_fast_delivery = {}
+
+                local original_on_message = client.transport.callbacks.on_message
+                client.transport.callbacks.on_message = function(message)
+                    _G.p5_fast_delivery.on_message_fast = vim.in_fast_event()
+                    local ok, err = pcall(original_on_message, message)
+                    _G.p5_fast_delivery.on_message_ok = ok
+                    _G.p5_fast_delivery.on_message_err = err
+                end
+
+                client:create_session({
+                    on_session_update = function() end,
+                    on_request_permission = function() end,
+                    on_error = function() end,
+                    on_tool_call = function() end,
+                    on_tool_call_update = function() end,
+                }, function(result, err)
+                    _G.p5_fast_delivery.callback_fast = vim.in_fast_event()
+                    _G.p5_fast_delivery.result = result
+                    _G.p5_fast_delivery.callback_err = err
+                end)
+
+                client.transport:deliver({
+                    jsonrpc = "2.0",
+                    id = client.id_counter,
+                    error = { code = -32000, message = "fast delivery failed" },
+                }, "fast_event")
+            ]])
+
+            vim.uv.sleep(50)
+            child.api.nvim_eval("1")
+
+            local result = child.lua_get("_G.p5_fast_delivery")
+            assert.is_true(result.on_message_fast)
+            assert.is_true(result.callback_fast)
+            assert.is_true(result.on_message_ok)
+            assert.is_nil(result.on_message_err)
+            assert.is_nil(result.result)
+            assert.equal(-32000, result.callback_err.code)
+            assert.equal("fast delivery failed", result.callback_err.message)
         end)
     end)
 

--- a/tests/mocks/acp_transport_mock.lua
+++ b/tests/mocks/acp_transport_mock.lua
@@ -43,6 +43,7 @@ function M.create_stdio_transport(config, callbacks)
 
     --- @param message agentic.acp.ResponseRaw
     --- @param mode tests.mocks.ACPTransportDeliveryMode|nil
+    --- @return uv.uv_timer_t|nil timer
     function transport:deliver(message, mode)
         if mode == "fast_event" then
             local timer = assert(vim.uv.new_timer())
@@ -50,6 +51,7 @@ function M.create_stdio_transport(config, callbacks)
                 timer:close()
                 self._callbacks.on_message(message)
             end)
+            return timer
         else
             self._callbacks.on_message(message)
         end

--- a/tests/mocks/acp_transport_mock.lua
+++ b/tests/mocks/acp_transport_mock.lua
@@ -1,4 +1,8 @@
 --- Mock implementation of agentic.acp.ACPTransportModule for testing
+--- @alias tests.mocks.ACPTransportDeliveryMode
+--- | "direct"
+--- | "fast_event"
+
 --- @class agentic.acp.ACPTransportModuleMock
 local M = {}
 
@@ -7,7 +11,7 @@ local M = {}
 --- @param callbacks agentic.acp.TransportCallbacks
 --- @return agentic.acp.ACPTransportInstance
 function M.create_stdio_transport(config, callbacks)
-    --- @type agentic.acp.ACPTransportInstance
+    --- @class tests.mocks.ACPTransportInstance : agentic.acp.ACPTransportInstance
     local transport = {
         stdin = nil,
         stdout = nil,
@@ -35,6 +39,20 @@ function M.create_stdio_transport(config, callbacks)
     function transport:stop()
         self._stopped = true
         self._callbacks.on_state_change("disconnected")
+    end
+
+    --- @param message agentic.acp.ResponseRaw
+    --- @param mode tests.mocks.ACPTransportDeliveryMode|nil
+    function transport:deliver(message, mode)
+        if mode == "fast_event" then
+            local timer = assert(vim.uv.new_timer())
+            timer:start(0, 0, function()
+                timer:close()
+                self._callbacks.on_message(message)
+            end)
+        else
+            self._callbacks.on_message(message)
+        end
     end
 
     return transport


### PR DESCRIPTION
- Change only ACP test infrastructure
- Preserve synchronous response delivery by default
- Add opt-in fast-event delivery mode
- Cover real ACP client callbacks
- Verify per-delivery timer closure
- Add no production code changes
- Validate with `make validate`
