### PR TITLE
fix(session): send the bootstrap create on the restore-first path

### DIFF
--- a/lua/agentic/session_manager.lua
+++ b/lua/agentic/session_manager.lua
@@ -790,11 +790,17 @@ end
 --- The first `session/new`, one tick after construction. Guarded HERE and not in
 --- `new_session`, which stays usable as the chat input's `/new`.
 function SessionManager:_bootstrap_session()
-    if self._destroyed or self._is_restoring_session then
+    if self._destroyed then
         return
     end
 
-    self:new_session()
+    -- Still sent when a restore claimed this manager first: `session/load` does
+    -- not re-send modes/models, so this response is their only source.
+    -- `restore_mode` keeps it out of `_cancel_session`, which would clear
+    -- `_is_restoring_session` and leave two requests racing for `session_id`.
+    -- The staleness guard in the response callback adopts the options and
+    -- cancels the session this opened.
+    self:new_session({ restore_mode = self._is_restoring_session })
 end
 
 --- @param opts {restore_mode?: boolean, on_created?: fun(), timestamp?: string|integer}|nil

--- a/lua/agentic/session_restore_race.test.lua
+++ b/lua/agentic/session_restore_race.test.lua
@@ -307,33 +307,55 @@ describe("race: stale create_session after load_acp_session", function()
 
     -- The ordering `SessionRestore` produces: the manager is built for the
     -- restore, so its bootstrap `session/new` is already queued for the next tick
-    -- when `load_acp_session` runs in this one. An unguarded bootstrap reaches
-    -- `_cancel_session`, which clears `_is_restoring_session` and thereby disarms
-    -- the Race A guard, leaving two requests competing for `session_id`.
-    it("load before the bootstrap sends no competing create", function()
-        local create_cb_ref = {}
-        local load_cb_ref = {}
-        local session = make_session(create_cb_ref, load_cb_ref)
+    -- when `load_acp_session` runs in this one. The create still goes out --
+    -- `session/load` does not re-send modes/models, so its response is their
+    -- only source -- but in `restore_mode`, so it never reaches
+    -- `_cancel_session`, which would clear `_is_restoring_session` and disarm
+    -- the Race A guard.
+    it(
+        "load before the bootstrap adopts the create's config options",
+        function()
+            local create_cb_ref = {}
+            local load_cb_ref = {}
+            local session = make_session(create_cb_ref, load_cb_ref)
 
-        -- The constructor's queued bootstrap, through the same `vim.schedule`
-        -- queue the real one uses: enqueued first, run last.
-        vim.schedule(function()
-            session:_bootstrap_session()
-        end)
+            -- The constructor's queued bootstrap, through the same
+            -- `vim.schedule` queue the real one uses: enqueued first, run last.
+            vim.schedule(function()
+                session:_bootstrap_session()
+            end)
 
-        session:load_acp_session("restored-id", "title", nil)
-        drain()
+            session:load_acp_session("restored-id", "title", nil)
+            drain()
 
-        -- Nothing in flight to answer out of order, and the guard is still armed.
-        assert.is_nil(create_cb_ref.cb)
-        assert.is_true(session._is_restoring_session)
+            -- The create is in flight, and the restore guard survived it.
+            assert.is_not_nil(create_cb_ref.cb)
+            assert.is_true(session._is_restoring_session)
 
-        load_cb_ref.cb(nil)
-        drain()
+            load_cb_ref.cb(nil)
+            drain()
 
-        assert.equal("restored-id", session.session_id)
-        assert.equal(0, #session._cancelled)
-    end)
+            assert.equal("restored-id", session.session_id)
+
+            -- The stale create answers last: the staleness guard adopts its
+            -- options and cancels the session it opened, leaving the restored
+            -- id untouched.
+            local config_options =
+                { { category = "mode", currentValue = "plan" } }
+            create_cb_ref.cb(
+                { sessionId = "new-id", configOptions = config_options },
+                nil
+            )
+            drain()
+
+            assert.equal("restored-id", session.session_id)
+            assert.equal(
+                config_options,
+                session.config_options._config_options_set
+            )
+            assert.is_true(vim.tbl_contains(session._cancelled, "new-id"))
+        end
+    )
 
     -- The staleness guard runs BEFORE the `if err or not response` branch, so the
     -- restored session_id survives. Moved below that branch, the error path would


### PR DESCRIPTION
Fixes #310.

## Problem

`session/load` does not re-send modes/models — the throwaway `session/new` fired alongside a restore is their only source, which is what #280 fixed for #277.

Since `10f9bab` (#298) the bootstrap early-returns while `_is_restoring_session` is set:

```lua
function SessionManager:_bootstrap_session()
    if self._destroyed or self._is_restoring_session then
        return
    end
    self:new_session()
end
```

On the ordering `SessionRestore` produces — manager built, `load_acp_session` called synchronously, bootstrap running a tick later — that means **no create is sent at all**. `config_options` stays empty, so `_show_mode_selector` warns "This provider does not support mode switching", `get_mode_id()` returns nil and the header shows no mode, and the model / thought-level pickers are empty too.

## Fix

Send the create in `restore_mode` rather than skipping it. `restore_mode` already existed for exactly this and was unreferenced after #298.

It keeps the create out of `_cancel_session`, so it cannot clear `_is_restoring_session` and disarm the Race A guard — which is what #298 was protecting against. The staleness guard at `session_manager.lua:844-865` then adopts the response's config options and cancels the session it opened.

## Tests

`session_restore_race.test.lua`'s "load before the bootstrap sends no competing create" asserted the behaviour that causes the bug, so it is updated: the create *is* expected now, and the test additionally asserts the restored `session_id` survives, the stale one is cancelled, and the config options are adopted. It fails without the source change and passes with it.

The other 15 cases in that file pass unchanged, so the race guarantees from #298 are intact. Full suite is green apart from `file_picker.test.lua | real commands`, which fails identically on unmodified `main` here (missing `deps/` fixture).

`stylua --check` passes.