### PR TITLE
feat(acp): implement client-side terminal reverse-RPC (opt-in per provider)

### DIFF
--- a/lua/agentic/acp/acp_client.lua
+++ b/lua/agentic/acp/acp_client.lua
@@ -1,6 +1,7 @@
 local Logger = require("agentic.utils.logger")
 local JsonFormat = require("agentic.utils.json_format")
 local transport_module = require("agentic.acp.acp_transport")
+local TerminalManager = require("agentic.acp.terminal_manager")
 
 local KNOWN_ACP_KINDS = {
     read = true,
@@ -32,6 +33,7 @@ local KNOWN_ACP_KINDS = {
 --- @field transport? agentic.acp.ACPTransportInstance
 --- @field ready_listeners { on_ready: fun(client: agentic.acp.ACPClient), on_failure: fun(err: agentic.acp.ACPError)|nil }[]
 --- @field subscribers table<string, agentic.acp.ClientHandlers>
+--- @field terminals agentic.acp.TerminalManager
 
 --- @class agentic.acp.ACPClient : agentic.acp.ACPClientData
 --- @field _on_ready fun(client: agentic.acp.ACPClient)
@@ -57,6 +59,7 @@ function ACPClient:new(config, on_ready)
     local instance = {
         provider_config = config,
         subscribers = {},
+        terminals = TerminalManager:new(),
         id_counter = 0,
         protocol_version = 1,
         client_info = {
@@ -68,7 +71,11 @@ function ACPClient:new(config, on_ready)
                 readTextFile = false,
                 writeTextFile = false,
             },
-            terminal = false,
+            -- Off by default so every provider keeps its prior local shell
+            -- execution. Opt-in per provider (`terminal = true`) only for
+            -- agents that delegate shell to the client via the `terminal/*`
+            -- reverse-RPC methods (e.g. Kimi Code). See the terminal handler.
+            terminal = config.terminal == true,
             session = {
                 configOptions = {
                     boolean = vim.empty_dict(),
@@ -230,6 +237,7 @@ function ACPClient:_set_state(state)
     if state == "disconnected" or state == "error" then
         self:_drain_pending_callbacks(state)
         self:_drain_ready_listeners(state)
+        self.terminals:release_all()
     elseif state == "ready" then
         self:_drain_ready_listeners(nil)
     end
@@ -347,6 +355,20 @@ function ACPClient:__send_result(id, result)
     self.transport:send(data)
 end
 
+--- @protected
+--- @param id number
+--- @param code number
+--- @param message string
+function ACPClient:__send_error(id, code, message)
+    local payload = {
+        jsonrpc = "2.0",
+        id = id,
+        error = self:__create_error(code, message),
+    }
+
+    self.transport:send(vim.json.encode(payload))
+end
+
 --- @param message agentic.acp.ResponseRaw
 function ACPClient:_handle_message(message)
     -- Chunks are not logged: they would flood the log file.
@@ -399,9 +421,106 @@ function ACPClient:_handle_notification(message_id, method, params)
         Logger.debug(
             string.format("Received '%s' notification, ignoring it", method)
         )
+    elseif vim.startswith(method, "terminal/") then
+        self:__handle_terminal_request(message_id, method, params)
     else
         Logger.notify("Unknown notification method: " .. method)
     end
+end
+
+--- Client side of ACP terminal support: agents that delegate shell execution
+--- (e.g. Kimi Code in ACP mode) send these as reverse-RPC requests. Each is a
+--- JSON-RPC request owed exactly one result/error on `message_id`.
+--- @protected
+--- @param message_id number
+--- @param method string
+--- @param params table
+function ACPClient:__handle_terminal_request(message_id, method, params)
+    if type(params) ~= "table" then
+        self:__send_error(
+            message_id,
+            self.ERROR_CODES.INVALID_REQUEST,
+            method .. " requires params"
+        )
+        return
+    end
+
+    -- Spawning and killing processes touches vim APIs that are unsafe in the
+    -- libuv read callback this runs from; hop onto the main loop first.
+    vim.schedule(function()
+        local terminals = self.terminals
+
+        if method == "terminal/create" then
+            local id, err = terminals:create(params)
+            if id then
+                self:__send_result(message_id, { terminalId = id })
+            else
+                self:__send_error(
+                    message_id,
+                    self.ERROR_CODES.INVALID_REQUEST,
+                    err or "failed to create terminal"
+                )
+            end
+            return
+        end
+
+        local terminal_id = params.terminalId
+        if type(terminal_id) ~= "string" then
+            self:__send_error(
+                message_id,
+                self.ERROR_CODES.INVALID_REQUEST,
+                method .. " requires a 'terminalId'"
+            )
+            return
+        end
+
+        local function unknown()
+            self:__send_error(
+                message_id,
+                self.ERROR_CODES.INVALID_REQUEST,
+                "Unknown terminalId: " .. terminal_id
+            )
+        end
+
+        -- terminal/kill and terminal/release both return an empty result on
+        -- success or the same "unknown terminal" error otherwise.
+        local function ok_or_unknown(known)
+            if known then
+                self:__send_result(message_id, vim.empty_dict())
+            else
+                unknown()
+            end
+        end
+
+        if method == "terminal/output" then
+            local output = terminals:get_output(terminal_id)
+            if output then
+                self:__send_result(message_id, output)
+            else
+                unknown()
+            end
+        elseif method == "terminal/wait_for_exit" then
+            local known = terminals:wait_for_exit(terminal_id, function(status)
+                self:__send_result(message_id, {
+                    exitCode = status.exitCode,
+                    signal = status.signal,
+                })
+            end)
+            if not known then
+                unknown()
+            end
+        elseif method == "terminal/kill" then
+            ok_or_unknown(terminals:kill(terminal_id))
+        elseif method == "terminal/release" then
+            ok_or_unknown(terminals:release(terminal_id))
+        else
+            self:__send_error(
+                message_id,
+                self.ERROR_CODES.INVALID_REQUEST,
+                "Unknown terminal method: " .. method
+            )
+        end
+    end)
 end
 
 --- @protected
@@ -944,6 +1063,9 @@ function ACPClient:cancel_session(session_id)
 
     -- Dropped first, so no further messages reach the old subscriber.
     self.subscribers[session_id] = nil
+
+    -- Destroying the session must not orphan its running shell commands.
+    self.terminals:release_session(session_id)
 
     self:_send_notification("session/cancel", {
         sessionId = session_id,

--- a/lua/agentic/acp/acp_client_types.lua
+++ b/lua/agentic/acp/acp_client_types.lua
@@ -392,3 +392,4 @@
 --- @field default_mode? string Default mode ID to set on session creation
 --- @field initial_model? string Default model ID to set on session creation. When also setting default_thought_level, the thought level is applied AFTER the model change response (because effort/thought_level options can be model-dependent, e.g. Claude rebuilds them on model switch).
 --- @field default_thought_level? string Default thought_level / effort value to set on session creation. Validated against the model's options. If `initial_model` is also set, applied after the model change completes.
+--- @field terminal? boolean Advertise ACP terminal capability so the agent delegates shell execution to the client via `terminal/*` reverse-RPC. Only enable for agents that do not run shell commands locally (e.g. Kimi Code). Defaults to false, matching every provider's prior behavior.

--- a/lua/agentic/acp/terminal_manager.lua
+++ b/lua/agentic/acp/terminal_manager.lua
@@ -1,0 +1,263 @@
+local Logger = require("agentic.utils.logger")
+
+--- Implements the client side of ACP terminal support
+--- (https://agentclientprotocol.com/protocol/terminals.md).
+---
+--- Agents that delegate shell execution to the client (e.g. Kimi Code in ACP
+--- mode) issue `terminal/create` and friends as reverse-RPC requests. Each
+--- terminal is a background process spawned with `vim.system`; output is
+--- accumulated as it streams so `terminal/output` can be answered at any time,
+--- and `terminal/wait_for_exit` requests are parked until the process exits.
+
+--- @class agentic.acp.TerminalExitStatus
+--- @field exitCode number|vim.NIL
+--- @field signal string|vim.NIL
+
+--- @class agentic.acp.TerminalRecord
+--- @field session_id? string Owning session, so it can be torn down on cancel
+--- @field output_chunks string[] Streamed output, joined lazily in get_output
+--- @field output_bytes number Retained byte count, capped to outputByteLimit
+--- @field truncated boolean True once the byte limit dropped earlier output
+--- @field exit_status? agentic.acp.TerminalExitStatus nil until the process exits
+--- @field handle? vim.SystemObj
+--- @field waiters fun(status: agentic.acp.TerminalExitStatus)[] wait_for_exit callbacks
+
+--- @class agentic.acp.TerminalManager
+--- @field terminals table<string, agentic.acp.TerminalRecord>
+--- @field id_counter number
+local TerminalManager = {}
+TerminalManager.__index = TerminalManager
+
+--- @return agentic.acp.TerminalManager
+function TerminalManager:new()
+    return setmetatable({
+        terminals = {},
+        id_counter = 0,
+    }, self)
+end
+
+--- @param signal number|nil libuv signal number from vim.system on_exit
+--- @return string|vim.NIL
+local function normalize_signal(signal)
+    if type(signal) == "number" and signal ~= 0 then
+        return tostring(signal)
+    end
+    return vim.NIL
+end
+
+--- Signal a running process. The record is left intact so its output and exit
+--- status stay readable until `terminal/release`.
+--- @param terminal agentic.acp.TerminalRecord
+local function kill_if_running(terminal)
+    if terminal.handle and not terminal.exit_status then
+        pcall(function()
+            terminal.handle:kill(15)
+        end)
+    end
+end
+
+--- Answer and clear every parked wait_for_exit request. Snapshot-then-clear so
+--- a callback that re-enters cannot see a half-drained list.
+--- @param terminal agentic.acp.TerminalRecord
+--- @param status agentic.acp.TerminalExitStatus
+local function resolve_waiters(terminal, status)
+    local waiters = terminal.waiters
+    terminal.waiters = {}
+    for _, waiter in ipairs(waiters) do
+        pcall(waiter, status)
+    end
+end
+
+--- Spawn a background process for a `terminal/create` request.
+--- @param params { command?: string, args?: string[], env?: agentic.acp.EnvVariable[], cwd?: string, outputByteLimit?: number, sessionId?: string }
+--- @return string|nil terminal_id nil when the command is missing or spawn fails
+--- @return string|nil err
+function TerminalManager:create(params)
+    if type(params) ~= "table" or type(params.command) ~= "string" then
+        return nil, "terminal/create requires a 'command' string"
+    end
+
+    self.id_counter = self.id_counter + 1
+    local id = "term_" .. self.id_counter
+
+    local cmd = { params.command }
+    if type(params.args) == "table" then
+        for _, arg in ipairs(params.args) do
+            cmd[#cmd + 1] = arg
+        end
+    end
+
+    --- @type table<string, string>|nil
+    local env
+    if type(params.env) == "table" then
+        env = {}
+        for _, entry in ipairs(params.env) do
+            if type(entry) == "table" and type(entry.name) == "string" then
+                env[entry.name] = entry.value
+            end
+        end
+    end
+
+    local limit = params.outputByteLimit
+
+    --- @type agentic.acp.TerminalRecord
+    local terminal = {
+        session_id = params.sessionId,
+        output_chunks = {},
+        output_bytes = 0,
+        truncated = false,
+        waiters = {},
+    }
+
+    local function append(data)
+        if type(data) ~= "string" or data == "" then
+            return
+        end
+
+        terminal.output_chunks[#terminal.output_chunks + 1] = data
+        terminal.output_bytes = terminal.output_bytes + #data
+
+        -- Only pay the join+trim once the cap is exceeded; the uncapped case
+        -- stays O(#data) per chunk instead of copying the whole buffer.
+        if limit and terminal.output_bytes > limit then
+            local joined = table.concat(terminal.output_chunks)
+            joined = string.sub(joined, #joined - limit + 1)
+            terminal.output_chunks = { joined }
+            terminal.output_bytes = #joined
+            terminal.truncated = true
+        end
+    end
+
+    local ok, handle = pcall(vim.system, cmd, {
+        cwd = params.cwd,
+        env = env,
+        text = true,
+        stdout = function(_, data)
+            append(data)
+        end,
+        stderr = function(_, data)
+            append(data)
+        end,
+    }, function(out)
+        --- on_exit runs in a libuv fast-event context; defer state changes and
+        --- waiter callbacks (which write JSON-RPC results) onto the main loop.
+        vim.schedule(function()
+            terminal.exit_status = {
+                exitCode = type(out.code) == "number" and out.code or vim.NIL,
+                signal = normalize_signal(out.signal),
+            }
+            resolve_waiters(terminal, terminal.exit_status)
+        end)
+    end)
+
+    if not ok or not handle then
+        local err = ok and "failed to spawn process" or tostring(handle)
+        Logger.debug(
+            "terminal/create failed for '" .. params.command .. "': " .. err
+        )
+        return nil, err
+    end
+
+    terminal.handle = handle
+    self.terminals[id] = terminal
+
+    return id, nil
+end
+
+--- Answer a `terminal/output` request.
+--- @param terminal_id string
+--- @return { output: string, truncated: boolean, exitStatus?: agentic.acp.TerminalExitStatus }|nil
+function TerminalManager:get_output(terminal_id)
+    local terminal = self.terminals[terminal_id]
+    if not terminal then
+        return nil
+    end
+
+    local result = {
+        output = table.concat(terminal.output_chunks),
+        truncated = terminal.truncated,
+    }
+
+    if terminal.exit_status then
+        result.exitStatus = terminal.exit_status
+    end
+
+    return result
+end
+
+--- Answer a `terminal/wait_for_exit` request, either immediately (already
+--- exited) or once the process exits.
+--- @param terminal_id string
+--- @param callback fun(status: agentic.acp.TerminalExitStatus)
+--- @return boolean known false when the terminal id is unknown
+function TerminalManager:wait_for_exit(terminal_id, callback)
+    local terminal = self.terminals[terminal_id]
+    if not terminal then
+        return false
+    end
+
+    if terminal.exit_status then
+        callback(terminal.exit_status)
+    else
+        terminal.waiters[#terminal.waiters + 1] = callback
+    end
+
+    return true
+end
+
+--- Handle a `terminal/kill` request. The terminal stays alive so its output
+--- and exit status remain readable until `terminal/release`.
+--- @param terminal_id string
+--- @return boolean known false when the terminal id is unknown
+function TerminalManager:kill(terminal_id)
+    local terminal = self.terminals[terminal_id]
+    if not terminal then
+        return false
+    end
+
+    kill_if_running(terminal)
+    return true
+end
+
+--- Handle a `terminal/release` request: kill the process if still running,
+--- resolve any pending waiters, and drop the terminal record.
+--- @param terminal_id string
+--- @return boolean known false when the terminal id is unknown
+function TerminalManager:release(terminal_id)
+    local terminal = self.terminals[terminal_id]
+    if not terminal then
+        return false
+    end
+
+    kill_if_running(terminal)
+    self.terminals[terminal_id] = nil
+
+    -- Never strand a parked wait_for_exit request on the shared subprocess.
+    resolve_waiters(
+        terminal,
+        terminal.exit_status or { exitCode = vim.NIL, signal = vim.NIL }
+    )
+
+    return true
+end
+
+--- Release every terminal spawned for a session. Mirrors how subscribers are
+--- dropped on `cancel_session`, so cancelling a prompt does not orphan its
+--- running shell commands.
+--- @param session_id string
+function TerminalManager:release_session(session_id)
+    for id, terminal in pairs(self.terminals) do
+        if terminal.session_id == session_id then
+            self:release(id)
+        end
+    end
+end
+
+--- Kill and drop every terminal. Called when the client disconnects.
+function TerminalManager:release_all()
+    for id in pairs(self.terminals) do
+        self:release(id)
+    end
+end
+
+return TerminalManager

--- a/lua/agentic/acp/terminal_manager.test.lua
+++ b/lua/agentic/acp/terminal_manager.test.lua
@@ -1,0 +1,130 @@
+local TerminalManager = require("agentic.acp.terminal_manager")
+local assert = require("tests.helpers.assert")
+
+--- Wait until `predicate` returns truthy or the timeout elapses, pumping the
+--- event loop so vim.system callbacks and their scheduled work can run.
+--- @param predicate fun(): any
+local function wait_for(predicate)
+    vim.wait(2000, predicate, 10)
+end
+
+describe("terminal manager", function()
+    it("rejects a create request without a command", function()
+        local manager = TerminalManager:new()
+
+        local id, err = manager:create({})
+
+        assert.is_nil(id)
+        assert.is_not_nil(err)
+    end)
+
+    it("runs a command and captures its output and exit status", function()
+        local manager = TerminalManager:new()
+
+        local id = manager:create({
+            command = "printf",
+            args = { "hello" },
+        })
+
+        assert.is_not_nil(id)
+
+        wait_for(function()
+            local output = manager:get_output(id)
+            return output and output.exitStatus ~= nil
+        end)
+
+        local output = manager:get_output(id)
+        assert.equal(output.output, "hello")
+        assert.is_false(output.truncated)
+        assert.equal(output.exitStatus.exitCode, 0)
+    end)
+
+    it("resolves wait_for_exit once the process exits", function()
+        local manager = TerminalManager:new()
+
+        local id = manager:create({ command = "true" })
+        assert.is_not_nil(id)
+
+        local status
+        local known = manager:wait_for_exit(id, function(s)
+            status = s
+        end)
+
+        assert.is_true(known)
+
+        wait_for(function()
+            return status ~= nil
+        end)
+
+        assert.is_not_nil(status)
+        assert.equal(status.exitCode, 0)
+    end)
+
+    it("reports a non-zero exit code", function()
+        local manager = TerminalManager:new()
+
+        local id = manager:create({ command = "false" })
+
+        wait_for(function()
+            local output = manager:get_output(id)
+            return output and output.exitStatus ~= nil
+        end)
+
+        assert.equal(manager:get_output(id).exitStatus.exitCode, 1)
+    end)
+
+    it("caps output to outputByteLimit and flags truncation", function()
+        local manager = TerminalManager:new()
+
+        local id = manager:create({
+            command = "printf",
+            args = { "abcdefghij" },
+            outputByteLimit = 4,
+        })
+
+        wait_for(function()
+            local output = manager:get_output(id)
+            return output and output.exitStatus ~= nil
+        end)
+
+        local output = manager:get_output(id)
+        assert.equal(output.output, "ghij")
+        assert.is_true(output.truncated)
+    end)
+
+    it("returns nil/false for an unknown terminal id", function()
+        local manager = TerminalManager:new()
+
+        assert.is_nil(manager:get_output("term_missing"))
+        assert.is_false(manager:kill("term_missing"))
+        assert.is_false(manager:release("term_missing"))
+        assert.is_false(
+            manager:wait_for_exit("term_missing", function() end)
+        )
+    end)
+
+    it("release_session drops only that session's terminals", function()
+        local manager = TerminalManager:new()
+
+        local a = manager:create({ command = "true", sessionId = "s1" })
+        local b = manager:create({ command = "true", sessionId = "s2" })
+
+        manager:release_session("s1")
+
+        assert.is_nil(manager:get_output(a))
+        assert.is_not_nil(manager:get_output(b))
+    end)
+
+    it("drops the terminal record on release", function()
+        local manager = TerminalManager:new()
+
+        local id = manager:create({ command = "true" })
+        wait_for(function()
+            local output = manager:get_output(id)
+            return output and output.exitStatus ~= nil
+        end)
+
+        assert.is_true(manager:release(id))
+        assert.is_nil(manager:get_output(id))
+    end)
+end)


### PR DESCRIPTION
## Problem

Some ACP agents do **not** execute shell commands locally. Instead they delegate execution to the ACP *client* via the terminal reverse-RPC methods (`terminal/create`, `terminal/output`, `terminal/wait_for_exit`, `terminal/kill`, `terminal/release`). [Kimi Code](https://www.kimi.com/code/docs/en/kimi-code-cli/reference/kimi-acp.html) in ACP mode (`kimi acp`) is one such agent.

agentic.nvim advertised `terminal = false` in the `initialize` handshake and had no handlers for the `terminal/*` methods. With those agents, file reads worked but **every shell/Bash tool call failed immediately** with:

```
ACP terminal capability is unavailable
```

The agent has nowhere to run the command, because the client declined the capability and the agent doesn't fall back to local execution.

See the ACP spec for the terminal protocol: https://agentclientprotocol.com/protocol/terminals

## What this PR adds

- **`lua/agentic/acp/terminal_manager.lua`** — a `TerminalManager` implementing the client side of ACP terminal support:
  - `terminal/create` spawns a background process with `vim.system` (honoring `command`, `args`, `env`, `cwd`, `outputByteLimit`) and returns a `terminalId`.
  - Output is streamed and accumulated in a chunk buffer (joined lazily, byte-capped to `outputByteLimit` with a `truncated` flag).
  - `terminal/output`, `terminal/wait_for_exit`, `terminal/kill`, `terminal/release` implement the rest of the lifecycle. `wait_for_exit` parks the request until the process exits.
  - Terminals are keyed by `sessionId`, so `cancel_session` releases that session's processes (via `release_session`) instead of orphaning them; `release_all` runs on client disconnect/error.
- **`lua/agentic/acp/acp_client.lua`** — dispatches `terminal/*` reverse-RPC requests from `_handle_notification` to the new handler, adds a `__send_error` JSON-RPC error helper, releases terminals on teardown, and advertises the capability from provider config.
- **`lua/agentic/acp/acp_client_types.lua`** — adds the optional `terminal` field to `ACPProviderConfig`.
- **`lua/agentic/acp/terminal_manager.test.lua`** — unit coverage (create/output/exit status, `wait_for_exit`, non-zero exit, byte-limit truncation, unknown-id handling, per-session release, release).

## Opt-in, per provider (no change for existing providers)

The capability is **off by default**. It is enabled per provider with `terminal = true`, so every existing provider keeps advertising `terminal = false` and its current local-execution behavior is unchanged.

```lua
{
  "carlos-algms/agentic.nvim",
  opts = {
    acp_providers = {
      -- Custom provider that delegates shell to the client:
      ["kimi-acp"] = {
        name = "Kimi ACP",
        command = vim.fn.expand("~/.kimi-code/bin/kimi"),
        args = { "acp" },
        terminal = true, -- opt in to client-side terminal execution
      },

      -- Or flip it on for a built-in provider (other fields are inherited):
      -- ["claude-agent-acp"] = { terminal = true },
    },
  },
}
```

| Provider config | Advertised capability | Shell execution |
| --- | --- | --- |
| `terminal = true` | `terminal: true` | delegated to the client via `terminal/*` |
| omitted / `false` (default) | `terminal: false` | provider's own local execution (unchanged) |

## Testing

- New `terminal_manager` unit tests pass.
- Full suite is green (`make test`, 0 fails).

## Known limitation / follow-up

`__build_tool_call_message` only renders tool-call content of type `content` and `diff`; it does not yet render embedded `type: "terminal"` content. Commands run and their output is returned to the agent correctly, but if an agent embeds a live terminal in the tool call (rather than echoing the output back as regular `content`), that terminal is not shown inline in the chat UI yet. Rendering live terminal content would be a good follow-up.
